### PR TITLE
Fix go version parse incorrect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: {{ env.GOVERSION }}
+          go-version: ${{ env.GOVERSION }}
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: {{ env.GOVERSION }}
+          go-version: ${{ env.GOVERSION }}
       - name: Build
         run: go build -v ./...
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GOVERSION: 1.20
+  GOVERSION: "1.20"
 
 jobs:
   lint:


### PR DESCRIPTION
The `1.20` is parsed as `1.2` the correct value is `"1.20"` that parsed as `1.20`