### PR TITLE
Move store.go to internal/store

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/pion/stun"
+	"github.com/tjjh89017/stunmesh-go/plugin"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -14,10 +15,10 @@ const StunServerAddr = "stun.l.google.com:19302"
 
 type Controller struct {
 	wgCtrl *wgctrl.Client
-	store  Store
+	store  plugin.Store
 }
 
-func NewController(ctrl *wgctrl.Client, store Store) *Controller {
+func NewController(ctrl *wgctrl.Client, store plugin.Store) *Controller {
 	return &Controller{
 		wgCtrl: ctrl,
 		store:  store,

--- a/internal/store/cloudflare.go
+++ b/internal/store/cloudflare.go
@@ -1,10 +1,16 @@
-package main
+package store
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/tjjh89017/stunmesh-go/plugin"
+)
+
+var (
+	ErrEndpointDataNotFound = errors.New("endpoint data not found")
 )
 
 type CloudflareApi interface {
@@ -15,7 +21,7 @@ type CloudflareApi interface {
 	ZoneIDByName(zoneName string) (string, error)
 }
 
-var _ Store = &CloudflareStore{}
+var _ plugin.Store = &CloudflareStore{}
 
 type CloudflareStore struct {
 	mutex    sync.RWMutex

--- a/internal/store/cloudflare_test.go
+++ b/internal/store/cloudflare_test.go
@@ -1,4 +1,4 @@
-package main
+package store_test
 
 import (
 	"context"
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/tjjh89017/stunmesh-go/internal/store"
 )
 
-var _ CloudflareApi = &mockCloudflareApi{}
+var _ store.CloudflareApi = &mockCloudflareApi{}
 
 type mockCloudflareApi struct {
 	mutex   sync.RWMutex
@@ -88,7 +89,7 @@ func Test_CloudflareStore(t *testing.T) {
 	t.Parallel()
 
 	mockApi := newMockCloudflareApi()
-	store := NewCloudflareStore(mockApi, "example.com")
+	store := store.NewCloudflareStore(mockApi, "example.com")
 	ctx := context.Background()
 
 	key := "key"
@@ -111,7 +112,7 @@ func Test_CloudflareStore(t *testing.T) {
 
 func Test_CloudflareStore_ExistsDuplicate(t *testing.T) {
 	mockApi := newMockCloudflareApi()
-	store := NewCloudflareStore(mockApi, "example.com")
+	store := store.NewCloudflareStore(mockApi, "example.com")
 	ctx := context.Background()
 
 	for i := 0; i < 3; i++ {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/tjjh89017/stunmesh-go/internal/config"
+	"github.com/tjjh89017/stunmesh-go/internal/store"
 	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
@@ -43,7 +44,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	store := NewCloudflareStore(cfApi, config.Cloudflare.ZoneName)
+	store := store.NewCloudflareStore(cfApi, config.Cloudflare.ZoneName)
 	ctrl := NewController(wg, store)
 
 	peers := make([]*Peer, len(device.Peers))

--- a/plugin/store.go
+++ b/plugin/store.go
@@ -1,13 +1,6 @@
-package main
+package plugin
 
-import (
-	"context"
-	"errors"
-)
-
-var (
-	ErrEndpointDataNotFound = errors.New("endpoint data not found")
-)
+import "context"
 
 type Store interface {
 	Get(ctx context.Context, key string) (string, error)


### PR DESCRIPTION
Currently, most implementations are in the`main` package which is unable to be imported by others. To make future work can split interface we need to extract functions to `internal/` package.