### PR TITLE
Add peer repository

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -39,8 +39,8 @@ func Run(ctx context.Context, privateKey [32]byte, publish *ctrl.PublishControll
 			for _, peer := range peers {
 				serializer := NewCryptoSerializer(privateKey, peer.PublicKey())
 
-				publish.Execute(daemonCtx, serializer, peer)
-				establish.Execute(daemonCtx, serializer, peer)
+				publish.Execute(daemonCtx, serializer, peer.Id())
+				establish.Execute(daemonCtx, serializer, peer.Id())
 			}
 		}
 	}

--- a/internal/ctrl/establish.go
+++ b/internal/ctrl/establish.go
@@ -13,17 +13,25 @@ import (
 
 type EstablishController struct {
 	wgCtrl *wgctrl.Client
+	peers  PeerRepository
 	store  plugin.Store
 }
 
-func NewEstablishController(ctrl *wgctrl.Client, store plugin.Store) *EstablishController {
+func NewEstablishController(ctrl *wgctrl.Client, peers PeerRepository, store plugin.Store) *EstablishController {
 	return &EstablishController{
 		wgCtrl: ctrl,
+		peers:  peers,
 		store:  store,
 	}
 }
 
-func (c *EstablishController) Execute(ctx context.Context, serializer Deserializer, peer *entity.Peer) {
+func (c *EstablishController) Execute(ctx context.Context, serializer Deserializer, peerId entity.PeerId) {
+	peer, err := c.peers.Find(ctx, peerId)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
 	endpointData, err := c.store.Get(ctx, peer.RemoteId())
 	if err != nil {
 		log.Panic(err)

--- a/internal/ctrl/repository.go
+++ b/internal/ctrl/repository.go
@@ -1,0 +1,12 @@
+package ctrl
+
+import (
+	"context"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+)
+
+type PeerRepository interface {
+	Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error)
+	Save(ctx context.Context, peer *entity.Peer)
+}

--- a/internal/entity/peer.go
+++ b/internal/entity/peer.go
@@ -1,5 +1,11 @@
 package entity
 
+import "errors"
+
+var (
+	ErrPeerNotFound = errors.New("peer not found")
+)
+
 type Peer struct {
 	id         PeerId
 	deviceName string
@@ -16,7 +22,11 @@ func NewPeer(id PeerId, deviceName string, listenPort int, publicKey [32]byte) *
 	}
 }
 
-func (p *Peer) Id() string {
+func (p *Peer) Id() PeerId {
+	return p.id
+}
+
+func (p *Peer) LocalId() string {
 	return p.id.EndpointKey()
 }
 

--- a/internal/repo/peers.go
+++ b/internal/repo/peers.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+)
+
+type Peers struct {
+	mutex    sync.RWMutex
+	entities map[entity.PeerId]*entity.Peer
+}
+
+func NewPeers() *Peers {
+	return &Peers{
+		entities: make(map[entity.PeerId]*entity.Peer),
+	}
+}
+
+func (r *Peers) Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	peer, ok := r.entities[id]
+	if !ok {
+		return nil, entity.ErrPeerNotFound
+	}
+
+	return peer, nil
+}
+
+func (r *Peers) Save(ctx context.Context, peer *entity.Peer) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.entities[peer.Id()] = peer
+}

--- a/internal/repo/peers_test.go
+++ b/internal/repo/peers_test.go
@@ -1,0 +1,52 @@
+package repo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+	"github.com/tjjh89017/stunmesh-go/internal/repo"
+)
+
+func Test_PeerRepository_Find(t *testing.T) {
+	peerId := entity.NewPeerId([]byte{}, []byte{})
+
+	peer := entity.NewPeer(
+		peerId,
+		"wg0",
+		8080,
+		[32]byte{},
+	)
+
+	peers := repo.NewPeers()
+	peers.Save(context.TODO(), peer)
+
+	tests := []struct {
+		name    string
+		peerId  entity.PeerId
+		wantErr bool
+	}{
+		{
+			name:    "find peer",
+			peerId:  peerId,
+			wantErr: false,
+		},
+		{
+			name:    "find non-existent peer",
+			peerId:  entity.NewPeerId([]byte{1}, []byte{1}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := peers.Find(context.TODO(), tt.peerId)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PeerRepository.Find() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/config"
 	"github.com/tjjh89017/stunmesh-go/internal/ctrl"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
+	"github.com/tjjh89017/stunmesh-go/internal/repo"
 	"github.com/tjjh89017/stunmesh-go/internal/store"
 	"golang.zx2c4.com/wireguard/wgctrl"
 )
@@ -41,10 +42,11 @@ func main() {
 	}
 
 	store := store.NewCloudflareStore(cfApi, config.Cloudflare.ZoneName)
-	publishCtrl := ctrl.NewPublishController(wg, store)
-	establishCtrl := ctrl.NewEstablishController(wg, store)
+	peers := repo.NewPeers()
+	publishCtrl := ctrl.NewPublishController(peers, store)
+	establishCtrl := ctrl.NewEstablishController(wg, peers, store)
 
-	peers := make([]*entity.Peer, len(device.Peers))
+	legacyPeers := make([]*entity.Peer, len(device.Peers))
 
 	for _, p := range device.Peers {
 		peer := entity.NewPeer(
@@ -54,8 +56,11 @@ func main() {
 			p.PublicKey,
 		)
 
-		peers = append(peers, peer)
+		peers.Save(ctx, peer)
+
+		// NOTE: After Device and Peer repository is ready, the legacyPeers can be removed.
+		legacyPeers = append(legacyPeers, peer)
 	}
 
-	Run(ctx, localPrivateKey, publishCtrl, establishCtrl, peers)
+	Run(ctx, localPrivateKey, publishCtrl, establishCtrl, legacyPeers)
 }


### PR DESCRIPTION
> [!WARNING]
> Due to `CryptoSerializer` and `DeviceRepository` is not ready, there are 2 peer container

* Add `ctrl.PeerRepository` which is implemented by `repo.Peers`
* Save all peers in `PeerRepository` when started
* Use `PeerRepository` to get `*entity.Peer` in the controller