### PR TITLE
Add device entity

### DIFF
--- a/internal/ctrl/repository.go
+++ b/internal/ctrl/repository.go
@@ -6,6 +6,11 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 )
 
+type DeviceRepository interface {
+	Find(ctx context.Context, name entity.DeviceId) (*entity.Device, error)
+	Save(ctx context.Context, device *entity.Device)
+}
+
 type PeerRepository interface {
 	Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error)
 	Save(ctx context.Context, peer *entity.Peer)

--- a/internal/entity/device.go
+++ b/internal/entity/device.go
@@ -1,0 +1,31 @@
+package entity
+
+import "errors"
+
+var (
+	ErrDeviceNotFound = errors.New("device not found")
+)
+
+type DeviceId string
+
+type Device struct {
+	name       DeviceId
+	privateKey []byte
+}
+
+func NewDevice(name DeviceId, privateKey []byte) *Device {
+	return &Device{
+		name:       name,
+		privateKey: privateKey,
+	}
+}
+
+func (d *Device) Name() DeviceId {
+	return d.name
+}
+
+func (d *Device) PrivateKey() [32]byte {
+	var key [32]byte
+	copy(key[:], d.privateKey)
+	return key
+}

--- a/internal/repo/devices.go
+++ b/internal/repo/devices.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+)
+
+type Devices struct {
+	mutex sync.RWMutex
+	items map[entity.DeviceId]*entity.Device
+}
+
+func NewDevices() *Devices {
+	return &Devices{
+		items: make(map[entity.DeviceId]*entity.Device),
+	}
+}
+
+func (r *Devices) Find(ctx context.Context, name entity.DeviceId) (*entity.Device, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	device, ok := r.items[name]
+	if !ok {
+		return nil, entity.ErrDeviceNotFound
+	}
+
+	return device, nil
+}
+
+func (r *Devices) Save(ctx context.Context, device *entity.Device) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.items[device.Name()] = device
+}

--- a/internal/repo/devices_test.go
+++ b/internal/repo/devices_test.go
@@ -1,0 +1,46 @@
+package repo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+	"github.com/tjjh89017/stunmesh-go/internal/repo"
+)
+
+func Test_DeviceFind(t *testing.T) {
+	deviceName := entity.DeviceId("wg0")
+	device := entity.NewDevice(deviceName, []byte{})
+
+	devices := repo.NewDevices()
+	devices.Save(context.TODO(), device)
+
+	tests := []struct {
+		name       string
+		deviceName entity.DeviceId
+		wantErr    bool
+	}{
+		{
+			name:       "find device",
+			deviceName: deviceName,
+			wantErr:    false,
+		},
+		{
+			name:       "find non-existent device",
+			deviceName: entity.DeviceId("wg1"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := devices.Find(context.TODO(), tt.deviceName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeviceRepository.Find() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [!WARNING]
> This is working in progress for refactoring

* Add `entity.Device`
* Add `repo.Devices`

To make the daemon not depend on the device's private key and peers, we need the device and peer repository to create the `CryptoSerializer` to calculate encrypted values.