### PR TITLE
Add Queue to schedule update

### DIFF
--- a/internal/ctrl/queue.go
+++ b/internal/ctrl/queue.go
@@ -1,0 +1,7 @@
+package ctrl
+
+import "github.com/tjjh89017/stunmesh-go/internal/entity"
+
+type RefreshQueue interface {
+	Enqueue(entity entity.PeerId)
+}

--- a/internal/ctrl/refresh.go
+++ b/internal/ctrl/refresh.go
@@ -1,0 +1,30 @@
+package ctrl
+
+import (
+	"context"
+	"log"
+)
+
+type RefreshController struct {
+	peers PeerRepository
+	queue RefreshQueue
+}
+
+func NewRefreshController(peers PeerRepository, queue RefreshQueue) *RefreshController {
+	return &RefreshController{
+		peers: peers,
+		queue: queue,
+	}
+}
+
+func (c *RefreshController) Execute(ctx context.Context) {
+	peers, err := c.peers.List(ctx)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	for _, peer := range peers {
+		c.queue.Enqueue(peer.Id())
+	}
+}

--- a/internal/ctrl/repository.go
+++ b/internal/ctrl/repository.go
@@ -12,6 +12,7 @@ type DeviceRepository interface {
 }
 
 type PeerRepository interface {
+	List(ctx context.Context) ([]*entity.Peer, error)
 	Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error)
 	Save(ctx context.Context, peer *entity.Peer)
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,23 @@
+package queue
+
+type Queue[T any] struct {
+	stack chan T
+}
+
+func New[T any]() *Queue[T] {
+	return &Queue[T]{
+		stack: make(chan T),
+	}
+}
+
+func (q *Queue[T]) Enqueue(entity T) {
+	q.stack <- entity
+}
+
+func (q *Queue[T]) Dequeue() <-chan T {
+	return q.stack
+}
+
+func (q *Queue[T]) Close() {
+	close(q.stack)
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,29 @@
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/tjjh89017/stunmesh-go/internal/queue"
+)
+
+func Test_Queue_Dequeue(t *testing.T) {
+	t.Parallel()
+
+	q := queue.New[int]()
+	go func() {
+		for i := 0; i < 3; i++ {
+			q.Enqueue(i)
+		}
+	}()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case v := <-q.Dequeue():
+			if v != i {
+				t.Errorf("Expected %d, got %d", i, v)
+			}
+		default:
+			continue
+		}
+	}
+}

--- a/internal/repo/peers.go
+++ b/internal/repo/peers.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"sync"
 
+	"github.com/tjjh89017/stunmesh-go/internal/ctrl"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 )
+
+var _ ctrl.PeerRepository = &Peers{}
 
 type Peers struct {
 	mutex    sync.RWMutex
@@ -16,6 +19,18 @@ func NewPeers() *Peers {
 	return &Peers{
 		entities: make(map[entity.PeerId]*entity.Peer),
 	}
+}
+
+func (r *Peers) List(ctx context.Context) ([]*entity.Peer, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	peers := make([]*entity.Peer, 0, len(r.entities))
+	for _, peer := range r.entities {
+		peers = append(peers, peer)
+	}
+
+	return peers, nil
 }
 
 func (r *Peers) Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error) {


### PR DESCRIPTION
* Add `queue.Queue`
* Create a shared queue for `publish` and `establish`
* Remove `peers` dependency from `daemon.go`