### PR TITLE
Refactor to split BPF / Stun / Socket behavior

### DIFF
--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -39,7 +39,7 @@ func (c *PublishController) Execute(ctx context.Context, peerId entity.PeerId) {
 		return
 	}
 
-	host, port, err := c.resolver.Resolve(uint16(peer.ListenPort()))
+	host, port, err := c.resolver.Resolve(ctx, uint16(peer.ListenPort()))
 	if err != nil {
 		log.Panic(err)
 	}

--- a/internal/ctrl/stun.go
+++ b/internal/ctrl/stun.go
@@ -1,5 +1,7 @@
 package ctrl
 
+import "context"
+
 type StunResolver interface {
-	Resolve(port uint16) (string, int, error)
+	Resolve(ctx context.Context, port uint16) (string, int, error)
 }

--- a/internal/session/stun.go
+++ b/internal/session/stun.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"log"
-	"net"
-	"time"
 
 	"github.com/pion/stun"
 	"golang.org/x/net/bpf"
@@ -21,30 +19,6 @@ const BindingPacketHeaderSize = 8
 var (
 	StunTimeout = 5
 )
-
-func (s *Session) Bind(port uint16, addr *net.UDPAddr) (*stun.Message, error) {
-	buf, err := createStunBindingPacket(port, uint16(addr.Port))
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := s.conn.WriteTo(buf, nil, addr); err != nil {
-		log.Panic(err)
-		return nil, err
-	}
-
-	// wait for respone
-	select {
-	case m, ok := <-s.messageChan:
-		if !ok {
-			return nil, ErrResponseMessage
-		}
-		return m, nil
-	case <-time.After(time.Duration(StunTimeout) * time.Second):
-		log.Printf("time out")
-		return nil, ErrTimeout
-	}
-}
 
 func createStunBindingPacket(srcPort, dstPort uint16) ([]byte, error) {
 	msg, err := stun.Build(stun.TransactionID, stun.BindingRequest)


### PR DESCRIPTION
* The `Session` handles the packet channel
* The `Session` stopped if the parent context closed
* The `Session` perform `Bind` which send a STUN binding packet and wait for address and port replied