### PR TITLE
go: use go stable version in dockerfile and action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.22"
+  GO_VERSION: "stable"
   CGO_ENABLED: "0"
   APP: "stunmesh"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: "1.22"
+  GO_VERSION: "stable"
   CGO_ENABLED: "0"
   APP: "stunmesh"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:latest AS builder
 
 WORKDIR /work
 COPY . .


### PR DESCRIPTION
go.mod will keep the go version for the program.
we can use newer go compiler to compile