### PR TITLE
Skip updating the same DNS record to cloudflare

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.63.4
+          version: latest
 
   test:
     name: Test

--- a/internal/store/cloudflare.go
+++ b/internal/store/cloudflare.go
@@ -89,6 +89,11 @@ func (s *CloudflareStore) Set(ctx context.Context, key string, value string) err
 		}
 	}
 
+	// skip update the same record
+	if value == records[0].Content {
+		return nil
+	}
+
 	_, err = s.api.UpdateDNSRecord(ctx, zoneId, cloudflare.UpdateDNSRecordParams{
 		ID:      records[0].ID,
 		Content: value,

--- a/internal/store/cloudflare.go
+++ b/internal/store/cloudflare.go
@@ -91,6 +91,7 @@ func (s *CloudflareStore) Set(ctx context.Context, key string, value string) err
 
 	// skip update the same record
 	if value == records[0].Content {
+		logger.Info().Str("key", key).Str("value", value).Msg("the same record exists, skip the update.")
 		return nil
 	}
 

--- a/internal/store/cloudflare_test.go
+++ b/internal/store/cloudflare_test.go
@@ -180,3 +180,38 @@ func Test_CloudflareStore_ExistsDuplicate(t *testing.T) {
 		t.Fatalf("expected value %s, got %s", value, gotValue)
 	}
 }
+
+func Test_CloudflareStore_SetTheSameRecord(t *testing.T) {
+	ctx, mockApi := setup(t)
+
+	// mock expect for Set() operation
+	mockApi.EXPECT().ListDNSRecords(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(listDNSRecords).Times(2)
+	mockApi.EXPECT().CreateDNSRecord(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(createDNSRecord)
+
+	// mock expect for Get() operation
+	mockApi.EXPECT().ListDNSRecords(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(listDNSRecords)
+
+	store := store.NewCloudflareStore(mockApi, "example.com")
+
+	const key = "key"
+	const value = "value"
+
+	err := store.Set(ctx, key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err2 := store.Set(ctx, key, value)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	gotValue, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotValue != value {
+		t.Fatalf("expected value %s, got %s", value, gotValue)
+	}
+}


### PR DESCRIPTION
Implement #78.  

Check if the DNS record with the same value listed from the cloudflare store.  
Skip updating it if the value is the same.