### PR TITLE
support ipv6

### DIFF
--- a/internal/ctrl/bootstrap_test.go
+++ b/internal/ctrl/bootstrap_test.go
@@ -44,6 +44,7 @@ func TestBootstrap_WithError(t *testing.T) {
 	bootstrap := ctrl.NewBootstrapController(
 		mockWgClient,
 		cfg,
+		deviceConfig,
 		mockDevices,
 		mockPeers,
 		&logger,
@@ -133,6 +134,7 @@ func TestBootstrap_WithMultipleInterfaces(t *testing.T) {
 	bootstrap := ctrl.NewBootstrapController(
 		mockWgClient,
 		cfg,
+		deviceConfig,
 		mockDevices,
 		mockPeers,
 		&logger,

--- a/internal/ctrl/endpoint.go
+++ b/internal/ctrl/endpoint.go
@@ -2,15 +2,26 @@ package ctrl
 
 import "context"
 
+// EndpointData represents the encrypted endpoint information stored for peers
+// This structure is serialized to JSON and stored via plugins
+type EndpointData struct {
+	// IPv4 contains the encrypted IPv4 endpoint (format: "ip:port")
+	// Empty string means IPv4 endpoint is not available
+	IPv4 string `json:"ipv4,omitempty"`
+
+	// IPv6 contains the encrypted IPv6 endpoint (format: "ip:port")
+	// Empty string means IPv6 endpoint is not available
+	IPv6 string `json:"ipv6,omitempty"`
+}
+
 type EndpointEncryptRequest struct {
 	PeerPublicKey [32]byte
 	PrivateKey    [32]byte
-	Host          string
-	Port          int
+	Content       string // JSON content to encrypt
 }
 
 type EndpointEncryptResponse struct {
-	Data string
+	Data string // Encrypted base64/hex string
 }
 
 type EndpointEncryptor interface {
@@ -20,12 +31,11 @@ type EndpointEncryptor interface {
 type EndpointDecryptRequest struct {
 	PeerPublicKey [32]byte
 	PrivateKey    [32]byte
-	Data          string
+	Data          string // Encrypted base64/hex string
 }
 
 type EndpointDecryptResponse struct {
-	Host string
-	Port int
+	Content string // Decrypted JSON content
 }
 
 type EndpointDecryptor interface {

--- a/internal/ctrl/refresh_test.go
+++ b/internal/ctrl/refresh_test.go
@@ -25,6 +25,7 @@ func TestRefresh_Execute(t *testing.T) {
 			"wg0",
 			[32]byte{},
 			"exec",
+			"ipv4",
 			entity.PeerPingConfig{Enabled: false},
 		),
 	}

--- a/internal/ctrl/stun.go
+++ b/internal/ctrl/stun.go
@@ -3,5 +3,5 @@ package ctrl
 import "context"
 
 type StunResolver interface {
-	Resolve(ctx context.Context, deviceName string, port uint16) (string, int, error)
+	Resolve(ctx context.Context, deviceName string, port uint16, protocol string) (string, int, error)
 }

--- a/internal/entity/device.go
+++ b/internal/entity/device.go
@@ -12,13 +12,15 @@ type Device struct {
 	name       DeviceId
 	listenPort int
 	privateKey []byte
+	protocol   string
 }
 
-func NewDevice(name DeviceId, listenPort int, privateKey []byte) *Device {
+func NewDevice(name DeviceId, listenPort int, privateKey []byte, protocol string) *Device {
 	return &Device{
 		name:       name,
 		listenPort: listenPort,
 		privateKey: privateKey,
+		protocol:   protocol,
 	}
 }
 
@@ -34,4 +36,8 @@ func (d *Device) PrivateKey() [32]byte {
 
 func (d *Device) ListenPort() int {
 	return d.listenPort
+}
+
+func (d *Device) Protocol() string {
+	return d.protocol
 }

--- a/internal/entity/peer.go
+++ b/internal/entity/peer.go
@@ -21,15 +21,17 @@ type Peer struct {
 	deviceName string
 	publicKey  [32]byte
 	plugin     string
+	protocol   string
 	pingConfig PeerPingConfig
 }
 
-func NewPeer(id PeerId, deviceName string, publicKey [32]byte, plugin string, pingConfig PeerPingConfig) *Peer {
+func NewPeer(id PeerId, deviceName string, publicKey [32]byte, plugin string, protocol string, pingConfig PeerPingConfig) *Peer {
 	return &Peer{
 		id:         id,
 		deviceName: deviceName,
 		publicKey:  publicKey,
 		plugin:     plugin,
+		protocol:   protocol,
 		pingConfig: pingConfig,
 	}
 }
@@ -56,6 +58,10 @@ func (p *Peer) PublicKey() [32]byte {
 
 func (p *Peer) Plugin() string {
 	return p.plugin
+}
+
+func (p *Peer) Protocol() string {
+	return p.protocol
 }
 
 func (p *Peer) PingConfig() PeerPingConfig {

--- a/internal/repo/devices_test.go
+++ b/internal/repo/devices_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_DeviceFind(t *testing.T) {
 	deviceName := entity.DeviceId("wg0")
-	device := entity.NewDevice(deviceName, 6379, []byte{})
+	device := entity.NewDevice(deviceName, 6379, []byte{}, "ipv4")
 
 	devices := repo.NewDevices()
 	devices.Save(context.TODO(), device)
@@ -57,15 +57,15 @@ func Test_DeviceList(t *testing.T) {
 		{
 			name: "single device",
 			devices: []*entity.Device{
-				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}),
+				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4"),
 			},
 		},
 		{
 			name: "multiple devices",
 			devices: []*entity.Device{
-				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}),
-				entity.NewDevice(entity.DeviceId("wg1"), 6380, []byte{}),
-				entity.NewDevice(entity.DeviceId("wg2"), 6381, []byte{}),
+				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4"),
+				entity.NewDevice(entity.DeviceId("wg1"), 6380, []byte{}, "ipv4"),
+				entity.NewDevice(entity.DeviceId("wg2"), 6381, []byte{}, "ipv4"),
 			},
 		},
 	}

--- a/internal/repo/peers_test.go
+++ b/internal/repo/peers_test.go
@@ -23,6 +23,7 @@ func Test_PeerRepository_Find(t *testing.T) {
 		"wg0",
 		[32]byte{},
 		"cloudflare",
+		"ipv4",
 		entity.PeerPingConfig{Enabled: false},
 	)
 
@@ -81,6 +82,7 @@ func Test_PeerRepository_List(t *testing.T) {
 					"wg0",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 			},
@@ -93,6 +95,7 @@ func Test_PeerRepository_List(t *testing.T) {
 					"wg0",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 				entity.NewPeer(
@@ -100,6 +103,7 @@ func Test_PeerRepository_List(t *testing.T) {
 					"wg1",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 			},
@@ -158,6 +162,7 @@ func Test_PeerListByDevice(t *testing.T) {
 					"wg0",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 			},
@@ -172,6 +177,7 @@ func Test_PeerListByDevice(t *testing.T) {
 					"wg0",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 				entity.NewPeer(
@@ -179,6 +185,7 @@ func Test_PeerListByDevice(t *testing.T) {
 					"wg1",
 					[32]byte{},
 					"exec",
+					"ipv4",
 					entity.PeerPingConfig{Enabled: false},
 				),
 			},

--- a/internal/stun/helper.go
+++ b/internal/stun/helper.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	ErrResponseMessage = errors.New("error reading from response message channel")
-	ErrTimeout         = errors.New("timed out waiting for response")
+	ErrResponseMessage  = errors.New("error reading from response message channel")
+	ErrTimeout          = errors.New("timed out waiting for response")
+	ErrInvalidEndpoint  = errors.New("STUN returned invalid endpoint (port is 0 or host is empty)")
 )
 
 const BindingPacketHeaderSize = 8

--- a/internal/stun/resolver.go
+++ b/internal/stun/resolver.go
@@ -9,25 +9,32 @@ import (
 )
 
 type Resolver struct {
-	config *config.Config
-	logger zerolog.Logger
-	mu     sync.Mutex
+	config       *config.Config
+	deviceConfig *config.DeviceConfig
+	logger       zerolog.Logger
+	mu           sync.Mutex
 }
 
-func NewResolver(config *config.Config, logger *zerolog.Logger) *Resolver {
+func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logger *zerolog.Logger) *Resolver {
 	return &Resolver{
-		config: config,
-		logger: logger.With().Str("component", "stun").Logger(),
+		config:       config,
+		deviceConfig: deviceConfig,
+		logger:       logger.With().Str("component", "stun").Logger(),
 	}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16) (_ string, _ int, err error) {
+// Resolve performs STUN discovery for the specified device and protocol
+// protocol must be "ipv4" or "ipv6" (not "dualstack")
+// Returns error if STUN discovery fails or returns invalid endpoint (port=0 or empty host)
+func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, protocol string) (_ string, _ int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	stunCtx := r.logger.WithContext(ctx)
 
-	stun, err := New(stunCtx, deviceName, port)
+	r.logger.Debug().Str("device", deviceName).Str("protocol", protocol).Msg("resolving with protocol")
+
+	stun, err := New(stunCtx, deviceName, port, protocol)
 	if err != nil {
 		return "", 0, err
 	}
@@ -37,5 +44,20 @@ func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16) 
 		err = stun.Stop()
 	}()
 
-	return stun.Connect(stunCtx, r.config.Stun.Address)
+	host, discoveredPort, err := stun.Connect(stunCtx, r.config.Stun.Address)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Validate the discovered endpoint
+	if discoveredPort == 0 || host == "" {
+		r.logger.Warn().
+			Str("host", host).
+			Int("port", discoveredPort).
+			Str("protocol", protocol).
+			Msg("STUN returned invalid endpoint")
+		return "", 0, ErrInvalidEndpoint
+	}
+
+	return host, discoveredPort, nil
 }

--- a/wire.go
+++ b/wire.go
@@ -26,6 +26,7 @@ func setup() (*daemon.Daemon, error) {
 		wire.Bind(new(repo.WireGuardClient), new(*wgctrl.Client)),
 		wire.Bind(new(entity.ConfigPeerProvider), new(*config.DeviceConfig)),
 		wire.Bind(new(entity.DevicePeerChecker), new(*repo.Peers)),
+		wire.Bind(new(ctrl.DeviceConfigProvider), new(*config.DeviceConfig)),
 		providePluginManager,
 		provideRefreshQueue,
 		ctrl.NewPingMonitorController,

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -33,19 +33,19 @@ func setup() (*daemon.Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
+	deviceConfig := config.NewDeviceConfig(configConfig)
 	devices := repo.NewDevices()
 	peers := repo.NewPeers(client)
 	zerologLogger := logger.NewLogger(configConfig)
-	deviceConfig := config.NewDeviceConfig(configConfig)
 	filterPeerService := entity.NewFilterPeerService(peers, deviceConfig)
-	bootstrapController := ctrl.NewBootstrapController(client, configConfig, devices, peers, zerologLogger, filterPeerService)
+	bootstrapController := ctrl.NewBootstrapController(client, configConfig, deviceConfig, devices, peers, zerologLogger, filterPeerService)
 	manager, err := providePluginManager(configConfig)
 	if err != nil {
 		return nil, err
 	}
-	resolver := stun.NewResolver(configConfig, zerologLogger)
+	resolver := stun.NewResolver(configConfig, deviceConfig, zerologLogger)
 	endpoint := crypto.NewEndpoint()
-	publishController := ctrl.NewPublishController(devices, peers, manager, resolver, endpoint, zerologLogger)
+	publishController := ctrl.NewPublishController(devices, peers, manager, resolver, endpoint, deviceConfig, zerologLogger)
 	establishController := ctrl.NewEstablishController(client, devices, peers, manager, endpoint, zerologLogger)
 	refreshController := ctrl.NewRefreshController(peers, queue, zerologLogger)
 	pingMonitorController := ctrl.NewPingMonitorController(configConfig, devices, peers, publishController, establishController, refreshController, zerologLogger)


### PR DESCRIPTION
stun: ipv6: add IPv6 and dualstack support with protocol configuration
Implements comprehensive IPv6 support for STUN discovery and WireGuard endpoint management,
including dualstack mode and per-interface/per-peer protocol preferences.

- **Interface-level protocol** (`interfaces.<name>.protocol`):
  - `ipv4`: IPv4-only STUN discovery (default)
  - `ipv6`: IPv6-only STUN discovery
  - `dualstack`: Perform both IPv4 and IPv6 STUN discovery

- **Peer-level protocol** (`interfaces.<name>.peers.<peer>.protocol`):
  - `ipv4`: Use IPv4 endpoint only (default)
  - `ipv6`: Use IPv6 endpoint only
  - `prefer_ipv4`: Prefer IPv4, fallback to IPv6
  - `prefer_ipv6`: Prefer IPv6, fallback to IPv4

- Added IPv6 STUN discovery support for Linux platform:
  - Raw IPv6 sockets (`ip6:17`) with proper address handling
  - Platform-specific BPF filter offsets (IPv4 vs IPv6 kernel behavior)
  - IPv6 UDP checksum calculation via `SetChecksum(true, 6)` (RFC 8200)
  - Conversion of `net.UDPAddr` to `net.IPAddr` for raw socket operations

- `PublishController.discoverEndpoints()`: Protocol-aware STUN discovery
- `EstablishController.selectEndpoint()`: Protocol-based endpoint selection with fallback logic
- Endpoint validation: Reject invalid endpoints (port=0 or empty host) at resolver level
- Added logging for discovered IPv4/IPv6 endpoints

**Stored Content Format Change**: The format of encrypted data stored by plugins has changed from a
 plain endpoint string to a JSON structure.

- **Before**: Encrypted single endpoint string
  Content: "1.2.3.4:5678"
  Stored: hex(encrypt("1.2.3.4:5678"))

- **After**: Encrypted JSON with separate IPv4/IPv6 fields
  Content: {"ipv4": "1.2.3.4:5678", "ipv6": "[2001:db8::1]:5678"}
  Stored: hex(encrypt('{"ipv4":"1.2.3.4:5678","ipv6":"[2001:db8::1]:5678"}'))

**Impact**:
- Existing stored endpoints cannot be decrypted and parsed by the new version
- All peers will fail to establish connections until endpoints are republished
- Plugin storage (Cloudflare DNS, Redis, etc.) contains incompatible data

**Migration Path**:
1. Upgrade stunmesh-go binary
2. Wait for next publish cycle (automatic), or manually trigger republish
3. New format will overwrite old data in plugin storage

**Rationale**: JSON format enables storing both IPv4 and IPv6 endpoints simultaneously, supporting
dualstack configurations and per-peer protocol preferences.

- **BPF Filter Timing**: IPv4 BPF sees full packet (IP+UDP+payload), IPv6 BPF sees only UDP+payload
- **Application Layer**: Both protocols receive UDP header (8 bytes) + STUN payload after kernel
stripping
- **Checksum**: IPv6 UDP checksum mandatory, handled by kernel before packet transmission

- `Device`: Added `protocol` field for interface-level configuration
- `Peer`: Added `protocol` field for peer-level endpoint preference
- Updated constructors: `entity.NewDevice()` and `entity.NewPeer()`

- `internal/crypto/endpoint.go:37`: Hex-encodes encrypted JSON
- `internal/crypto/endpoint.go:45`: Hex-decodes before decryption
- Controllers decrypt JSON and select endpoint based on peer protocol

- `ErrInvalidEndpoint`: New error for STUN responses with port=0 or empty host
- Validation moved to `Resolver.Resolve()` before storage
- Warning logs (not errors) for expected STUN failures

- Updated README.md: Plugin protocol documentation with JSON format specification
- Updated CLAUDE.md: Linux-specific STUN implementation details and BPF behavior
- Added inline code comments explaining platform differences

- `internal/stun/stun_linux.go`: IPv6 raw socket implementation with BPF filters
- `internal/stun/resolver.go`: Protocol-aware STUN resolution with validation
- `internal/stun/helper.go`: Added `ErrInvalidEndpoint` error
- `internal/ctrl/publish.go`: Dual-protocol endpoint discovery and JSON marshaling
- `internal/ctrl/establish.go`: Protocol-based endpoint selection from JSON
- `internal/crypto/endpoint.go`: Hex encoding for encrypted JSON data

- `internal/entity/device.go`: Added protocol field and getter
- `internal/entity/peer.go`: Added protocol field and getter
- `internal/config/device.go`: Protocol validation and defaults

- Updated all test files with new constructor signatures
- Added protocol parameters to mock objects

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Date Huang <tjjh89017@hotmail.com>