### PR TITLE
refactor: remove duplicated Store interface from cloudflare plugin

### DIFF
--- a/internal/plugin/builtin/cloudflare/cloudflare.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 )
 
 const (
@@ -22,15 +23,6 @@ const (
 	configKeyAPIToken  = "token"
 	configKeySubdomain = "subdomain"
 )
-
-// Store interface (copied to avoid import cycle)
-type Store interface {
-	Get(ctx context.Context, key string) (string, error)
-	Set(ctx context.Context, key string, value string) error
-}
-
-// PluginConfig type
-type PluginConfig map[string]interface{}
 
 // CloudflarePlugin implements the Store interface
 type CloudflarePlugin struct {
@@ -55,7 +47,7 @@ type cfError struct {
 
 // BuiltinConfig helper
 type BuiltinConfig struct {
-	config PluginConfig
+	config pluginapi.PluginConfig
 }
 
 func (c *BuiltinConfig) GetString(key string) (string, bool) {
@@ -76,7 +68,7 @@ func (c *BuiltinConfig) GetStringRequired(key string) (string, error) {
 }
 
 // NewCloudflarePlugin creates a new Cloudflare plugin instance
-func NewCloudflarePlugin(config PluginConfig) (Store, error) {
+func NewCloudflarePlugin(config pluginapi.PluginConfig) (pluginapi.Store, error) {
 	cfg := &BuiltinConfig{config: config}
 
 	zoneName, err := cfg.GetStringRequired(configKeyZoneName)

--- a/internal/plugin/register_builtin.go
+++ b/internal/plugin/register_builtin.go
@@ -11,6 +11,6 @@ func init() {
 	// Register built-in plugins
 	// This file is only compiled when build tags are present
 	RegisterBuiltin("cloudflare", func(config pluginapi.PluginConfig) (pluginapi.Store, error) {
-		return cloudflare.NewCloudflarePlugin(cloudflare.PluginConfig(config))
+		return cloudflare.NewCloudflarePlugin(config)
 	})
 }


### PR DESCRIPTION
Remove the duplicated Store interface and PluginConfig type definitions from the cloudflare builtin plugin. Instead, import and use the canonical pluginapi.Store interface and pluginapi.PluginConfig type.

This eliminates code duplication and ensures interface consistency across all plugins. The original comment indicated these were copied to avoid an import cycle, but testing confirms no import cycle exists when importing pluginapi directly.

Changes:
- Add pluginapi import to cloudflare.go
- Remove duplicated Store interface definition
- Remove duplicated PluginConfig type definition
- Update NewCloudflarePlugin signature to use pluginapi types
- Remove unnecessary type conversion in register_builtin.go