### PR TITLE
chore: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/actions/build-all-plugins/action.yml
+++ b/.github/actions/build-all-plugins/action.yml
@@ -21,7 +21,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -55,7 +55,7 @@ runs:
           echo "extra-min=0" >> "$GITHUB_OUTPUT"
         fi
     
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
 

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -23,21 +23,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: docker/setup-qemu-action@v3
-    
-    - uses: docker/setup-buildx-action@v3
-    
-    - uses: docker/login-action@v3
+    - uses: docker/setup-qemu-action@v4
+
+    - uses: docker/setup-buildx-action@v4
+
+    - uses: docker/login-action@v4
       with:
         username: ${{ inputs.repository-owner }}
         password: ${{ inputs.docker-token }}
-    
-    - uses: docker/metadata-action@v5
+
+    - uses: docker/metadata-action@v6
       id: meta
       with:
         images: ${{ inputs.repository-owner }}/${{ inputs.app-name }}
-    
-    - uses: docker/build-push-action@v6
+
+    - uses: docker/build-push-action@v7
       with:
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.push }}

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -10,12 +10,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
-    
+
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     name: Codegen
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Lint
         uses: ./.github/actions/lint
         with:
@@ -40,7 +40,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test
         uses: ./.github/actions/test
         with:
@@ -71,7 +71,7 @@ jobs:
           - os: freebsd
             variant: extra-min
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         uses: ./.github/actions/build
         id: build
@@ -81,7 +81,7 @@ jobs:
           app-name: ${{ env.APP }}
           go-version: ${{ env.GO_VERSION }}
           variant: ${{ matrix.variant }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -106,7 +106,7 @@ jobs:
           - os: freebsd
             arch: mipsle
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build All Plugins
         uses: ./.github/actions/build-all-plugins
         id: build-plugins
@@ -114,7 +114,7 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build-plugins.outputs.artifact-name }}
           path: plugins_dist/*
@@ -128,7 +128,7 @@ jobs:
       - lint
       - test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and Push Docker
         uses: ./.github/actions/docker
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Lint
         uses: ./.github/actions/lint
         with:
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test
         uses: ./.github/actions/test
         with:
@@ -56,7 +56,7 @@ jobs:
           - os: freebsd
             variant: extra-min
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: tag
         id: tag
         run: echo "TAG=$(git describe --tags --dirty)" >> "$GITHUB_OUTPUT"
@@ -71,7 +71,7 @@ jobs:
           tag: ${{ steps.tag.outputs.TAG }}
           variant: ${{ matrix.variant }}
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.build.outputs.binary-name }}
           draft: true
@@ -103,7 +103,7 @@ jobs:
           - os: freebsd
             arch: mipsle
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: tag
         id: tag
         run: echo "TAG=$(git describe --tags --dirty)" >> "$GITHUB_OUTPUT"
@@ -122,7 +122,7 @@ jobs:
           source-dir: plugins_dist
           tag: ${{ steps.tag.outputs.TAG }}
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ${{ steps.archive.outputs.zip-file }}
@@ -141,7 +141,7 @@ jobs:
       - lint
       - test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and Push Docker
         uses: ./.github/actions/docker
         with:


### PR DESCRIPTION
## Summary
- Bump all third-party GitHub Actions to their latest major versions across workflows and composite actions.
- `vmactions/freebsd-vm` kept at `@v1` (already latest major).

| Action | Old | New |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |
| actions/upload-artifact | v4 | v7 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| softprops/action-gh-release | v2 | v3 |
| golangci/golangci-lint-action | v8 | v9 |

## Test plan
- [ ] CI `lint` job passes with golangci-lint-action v9
- [ ] CI `test` job passes with setup-go v6
- [ ] CI `build` matrix passes for all OS/arch (linux/darwin/freebsd)
- [ ] CI `build-plugins` matrix passes
- [ ] Artifacts upload successfully with upload-artifact v7
- [ ] Docker build job succeeds with docker/* v4/v6/v7
- [ ] Release workflow dry-run considerations for action-gh-release v3