### PR TITLE
feat: build-tag switchable WireGuard backend (wgctrl ↔ wg CLI)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Build variant (normal or extra-min)'
     required: false
     default: 'normal'
+  backend:
+    description: 'WireGuard backend (wgctrl or wgcli)'
+    required: false
+    default: 'wgctrl'
 
 outputs:
   binary-name:
@@ -39,6 +43,9 @@ runs:
         SUFFIX=""
         if [ "${{ inputs.variant }}" = "extra-min" ]; then
           SUFFIX="-upx"
+        fi
+        if [ "${{ inputs.backend }}" = "wgcli" ]; then
+          SUFFIX="${SUFFIX}-wgcli"
         fi
 
         if [ -n "${{ inputs.tag }}" ]; then
@@ -74,8 +81,8 @@ runs:
         GOARCH: ${{ inputs.arch }}
         GOOS: ${{ inputs.os }}
 
-    - name: Build (FreeBSD)
-      if: inputs.os == 'freebsd'
+    - name: Build (FreeBSD wgctrl, CGO=1)
+      if: inputs.os == 'freebsd' && inputs.backend != 'wgcli'
       uses: vmactions/freebsd-vm@v1
       with:
         arch: ${{ inputs.arch }}
@@ -90,3 +97,11 @@ runs:
         run: |
           cd $GITHUB_WORKSPACE
           gmake APP=${{ steps.build-info.outputs.binary-name }}
+
+    - name: Build (FreeBSD wgcli, CGO=0)
+      if: inputs.os == 'freebsd' && inputs.backend == 'wgcli'
+      shell: bash
+      run: make APP=${{ steps.build-info.outputs.binary-name }} BACKEND=wgcli
+      env:
+        GOARCH: ${{ inputs.arch }}
+        GOOS: freebsd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
         os: [linux, darwin, freebsd]
         arch: [amd64, arm64, arm, mipsle]
         variant: [normal, extra-min]
+        backend: [wgctrl, wgcli]
         exclude:
           - os: darwin
             arch: arm
@@ -70,6 +71,11 @@ jobs:
             arch: mipsle
           - os: freebsd
             variant: extra-min
+          # wgcli backend only applies to freebsd
+          - os: linux
+            backend: wgcli
+          - os: darwin
+            backend: wgcli
     steps:
       - uses: actions/checkout@v6
       - name: Build
@@ -81,6 +87,7 @@ jobs:
           app-name: ${{ env.APP }}
           go-version: ${{ env.GO_VERSION }}
           variant: ${{ matrix.variant }}
+          backend: ${{ matrix.backend }}
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.binary-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         os: [linux, darwin, freebsd]
         arch: [amd64, arm64, arm, mipsle]
         variant: [normal, extra-min]
+        backend: [wgctrl, wgcli]
         exclude:
           - os: darwin
             arch: arm
@@ -55,6 +56,11 @@ jobs:
             arch: mipsle
           - os: freebsd
             variant: extra-min
+          # wgcli backend only applies to freebsd
+          - os: linux
+            backend: wgcli
+          - os: darwin
+            backend: wgcli
     steps:
       - uses: actions/checkout@v6
       - name: tag
@@ -70,6 +76,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           tag: ${{ steps.tag.outputs.TAG }}
           variant: ${{ matrix.variant }}
+          backend: ${{ matrix.backend }}
       - name: Release
         uses: softprops/action-gh-release@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,16 @@ UPX ?= 0
 EXTRA_MIN ?= 0
 BUILTIN ?= all
 ALL_BUILTINS := builtin_cloudflare
-BACKEND ?= ctrl
+BACKEND ?= wgctrl
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 
 # Validate BACKEND value
-ifeq ($(filter $(BACKEND),ctrl cli),)
-    $(error BACKEND must be 'ctrl' or 'cli', got '$(BACKEND)')
+ifeq ($(filter $(BACKEND),wgctrl wgcli),)
+    $(error BACKEND must be 'wgctrl' or 'wgcli', got '$(BACKEND)')
 endif
 
-# Platforms that require CGO_ENABLED=1 (only ctrl backend on freebsd)
+# Platforms that require CGO_ENABLED=1 (only wgctrl backend on freebsd)
 CGO_REQUIRED_PLATFORMS := freebsd
 
 ifneq ($(EXTRA_MIN),0)
@@ -45,7 +45,7 @@ endif
 
 # Backend build tag: wgcli selects the wg-CLI shelling backend
 BACKEND_TAG :=
-ifeq ($(BACKEND),cli)
+ifeq ($(BACKEND),wgcli)
 	BACKEND_TAG := wgcli
 endif
 
@@ -58,8 +58,8 @@ ifneq ($(UPX),0)
 	UPX_TARGET = upx
 endif
 
-# Set CGO_ENABLED: forced off when BACKEND=cli; otherwise platform default
-ifeq ($(BACKEND),cli)
+# Set CGO_ENABLED: forced off when BACKEND=wgcli; otherwise platform default
+ifeq ($(BACKEND),wgcli)
 	CGO_ENABLED = 0
 else ifeq ($(GOOS),$(filter $(GOOS),$(CGO_REQUIRED_PLATFORMS)))
 	CGO_ENABLED = 1

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,17 @@ UPX ?= 0
 EXTRA_MIN ?= 0
 BUILTIN ?= all
 ALL_BUILTINS := builtin_cloudflare
+BACKEND ?= ctrl
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 
-# Platforms that require CGO_ENABLED=1
-CGO_REQUIRED_PLATFORMS := freebsd openbsd
+# Validate BACKEND value
+ifeq ($(filter $(BACKEND),ctrl cli),)
+    $(error BACKEND must be 'ctrl' or 'cli', got '$(BACKEND)')
+endif
+
+# Platforms that require CGO_ENABLED=1 (only ctrl backend on freebsd)
+CGO_REQUIRED_PLATFORMS := freebsd
 
 ifneq ($(EXTRA_MIN),0)
 	STRIP = 1
@@ -37,18 +43,25 @@ ifeq ($(BUILTIN),all)
 	override BUILTIN := $(ALL_BUILTINS)
 endif
 
-TAGS_FLAGS =
-ifneq ($(BUILTIN),)
-	TAGS_FLAGS := -tags '$(BUILTIN)'
+# Backend build tag: wgcli selects the wg-CLI shelling backend
+BACKEND_TAG :=
+ifeq ($(BACKEND),cli)
+	BACKEND_TAG := wgcli
 endif
+
+# Combine BUILTIN and BACKEND tags
+ALL_TAGS := $(strip $(BUILTIN) $(BACKEND_TAG))
+TAGS_FLAGS = $(if $(ALL_TAGS),-tags '$(ALL_TAGS)',)
 
 UPX_TARGET =
 ifneq ($(UPX),0)
 	UPX_TARGET = upx
 endif
 
-# Set CGO_ENABLED based on OS
-ifeq ($(GOOS),$(filter $(GOOS),$(CGO_REQUIRED_PLATFORMS)))
+# Set CGO_ENABLED: forced off when BACKEND=cli; otherwise platform default
+ifeq ($(BACKEND),cli)
+	CGO_ENABLED = 0
+else ifeq ($(GOOS),$(filter $(GOOS),$(CGO_REQUIRED_PLATFORMS)))
 	CGO_ENABLED = 1
 	LDFLAGS := ${LDFLAGS} -extldflags="-static"
 else

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ clean:
 test:
 	go test -cover -v ${TAGS_FLAGS} ./...
 
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: vet
+vet:
+	go vet ${TAGS_FLAGS} ./...
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ make all BUILTIN=builtin_cloudflare EXTRA_MIN=1
 
 stunmesh-go supports two WireGuard backends, selectable at build time via the `BACKEND` variable:
 
-- `ctrl` (default): Uses [`wgctrl-go`](https://github.com/WireGuard/wgctrl-go) to talk to the kernel WireGuard interface directly. Requires CGO on FreeBSD.
-- `cli`: Shells out to the `wg` command-line tool. Builds with `CGO_ENABLED=0` on all platforms, including FreeBSD cross-compilation from Linux without a sysroot.
+- `wgctrl` (default): Uses [`wgctrl-go`](https://github.com/WireGuard/wgctrl-go) to talk to the kernel WireGuard interface directly. Requires CGO on FreeBSD.
+- `wgcli`: Shells out to the `wg` command-line tool. Builds with `CGO_ENABLED=0` on all platforms, including FreeBSD cross-compilation from Linux without a sysroot.
 
-**When to choose `BACKEND=cli`:**
+**When to choose `BACKEND=wgcli`:**
 
 - Cross-compiling for FreeBSD from any host without setting up CGO toolchains
 - Running userspace wireguard-go where direct `wgctrl` socket access is restricted
@@ -132,17 +132,17 @@ stunmesh-go supports two WireGuard backends, selectable at build time via the `B
 **Build examples:**
 
 ```bash
-make build BACKEND=cli
-make build BACKEND=cli GOOS=freebsd GOARCH=amd64   # FreeBSD cross-compile from Linux, no sysroot
+make build BACKEND=wgcli
+make build BACKEND=wgcli GOOS=freebsd GOARCH=amd64   # FreeBSD cross-compile from Linux, no sysroot
 ```
 
-**Runtime requirement for `BACKEND=cli`:** the `wg` command must be installed and available in `PATH`:
+**Runtime requirement for `BACKEND=wgcli`:** the `wg` command must be installed and available in `PATH`:
 
 - Linux: install the `wireguard-tools` package
 - FreeBSD: `pkg install wireguard-tools`
 - macOS: `brew install wireguard-tools`
 
-The default remains `ctrl`, so existing users do not need to change anything.
+The default remains `wgctrl`, so existing users do not need to change anything.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ make all BUILTIN=builtin_cloudflare EXTRA_MIN=1
 - **macOS**: Only normal binaries are provided (no UPX version)
 - **FreeBSD**: Only normal binaries are provided (no UPX version)
 
+### Backend Selection
+
+stunmesh-go supports two WireGuard backends, selectable at build time via the `BACKEND` variable:
+
+- `ctrl` (default): Uses [`wgctrl-go`](https://github.com/WireGuard/wgctrl-go) to talk to the kernel WireGuard interface directly. Requires CGO on FreeBSD.
+- `cli`: Shells out to the `wg` command-line tool. Builds with `CGO_ENABLED=0` on all platforms, including FreeBSD cross-compilation from Linux without a sysroot.
+
+**When to choose `BACKEND=cli`:**
+
+- Cross-compiling for FreeBSD from any host without setting up CGO toolchains
+- Running userspace wireguard-go where direct `wgctrl` socket access is restricted
+- Any environment where invoking the `wg` binary is preferable to direct kernel ioctl calls
+
+**Build examples:**
+
+```bash
+make build BACKEND=cli
+make build BACKEND=cli GOOS=freebsd GOARCH=amd64   # FreeBSD cross-compile from Linux, no sysroot
+```
+
+**Runtime requirement for `BACKEND=cli`:** the `wg` command must be installed and available in `PATH`:
+
+- Linux: install the `wireguard-tools` package
+- FreeBSD: `pkg install wireguard-tools`
+- macOS: `brew install wireguard-tools`
+
+The default remains `ctrl`, so existing users do not need to change anything.
+
 ## Usage
 
 ```

--- a/internal/ctrl/api.go
+++ b/internal/ctrl/api.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"time"
 
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 )
 
 type WireGuardClient interface {
-	Device(deviceName string) (*wgtypes.Device, error)
-	ConfigureDevice(deviceName string, cfg wgtypes.Config) error
+	Device(deviceName string) (*wg.DeviceInfo, error)
+	UpdatePeerEndpoint(u wg.PeerEndpointUpdate) error
 }
 
 // ICMPConnection defines the interface for ICMP connections

--- a/internal/ctrl/bootstrap_test.go
+++ b/internal/ctrl/bootstrap_test.go
@@ -11,8 +11,8 @@ import (
 	mock "github.com/tjjh89017/stunmesh-go/internal/ctrl/mock"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	mockEntity "github.com/tjjh89017/stunmesh-go/internal/entity/mock"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 	gomock "go.uber.org/mock/gomock"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func TestBootstrap_WithError(t *testing.T) {
@@ -90,28 +90,22 @@ func TestBootstrap_WithMultipleInterfaces(t *testing.T) {
 	deviceConfig := config.NewDeviceConfig(cfg)
 	peerFilterService := entity.NewFilterPeerService(mockDevicePeerChecker, deviceConfig)
 
-	mockDevice0 := &wgtypes.Device{
+	mockDevice0 := &wg.DeviceInfo{
 		Name:       "wg0",
 		ListenPort: 51820,
 		PrivateKey: [32]byte{},
-		Peers: []wgtypes.Peer{
-			{
-				PublicKey: [32]byte{94, 3, 209, 178, 141, 248, 150, 122, 210, 3, 31, 39, 38, 215, 99, 215, 252, 229, 23, 176, 168, 54, 62, 193, 235, 130, 207, 18, 86, 29, 56, 107},
-			},
+		PeerKeys: []wg.Key{
+			{94, 3, 209, 178, 141, 248, 150, 122, 210, 3, 31, 39, 38, 215, 99, 215, 252, 229, 23, 176, 168, 54, 62, 193, 235, 130, 207, 18, 86, 29, 56, 107},
 		},
 	}
 
-	mockDevice1 := &wgtypes.Device{
+	mockDevice1 := &wg.DeviceInfo{
 		Name:       "wg1",
 		ListenPort: 51821,
 		PrivateKey: [32]byte{},
-		Peers: []wgtypes.Peer{
-			{
-				PublicKey: [32]byte{21, 15, 127, 218, 95, 45, 227, 25, 144, 65, 187, 58, 72, 29, 55, 248, 184, 118, 86, 40, 201, 95, 190, 43, 197, 21, 14, 191, 182, 19, 211, 121},
-			},
-			{
-				PublicKey: [32]byte{10, 231, 121, 30, 136, 9, 36, 176, 169, 166, 133, 46, 30, 117, 171, 74, 241, 9, 184, 142, 61, 15, 77, 108, 65, 199, 226, 15, 118, 61, 69, 21},
-			},
+		PeerKeys: []wg.Key{
+			{21, 15, 127, 218, 95, 45, 227, 25, 144, 65, 187, 58, 72, 29, 55, 248, 184, 118, 86, 40, 201, 95, 190, 43, 197, 21, 14, 191, 182, 19, 211, 121},
+			{10, 231, 121, 30, 136, 9, 36, 176, 169, 166, 133, 46, 30, 117, 171, 74, 241, 9, 184, 142, 61, 15, 77, 108, 65, 199, 226, 15, 118, 61, 69, 21},
 		},
 	}
 
@@ -122,11 +116,11 @@ func TestBootstrap_WithMultipleInterfaces(t *testing.T) {
 
 	// Mock device peer map expectations - the new approach uses GetDevicePeerMap
 	wg0PeerMap := map[string]bool{
-		string(mockDevice0.Peers[0].PublicKey[:]): true,
+		string(mockDevice0.PeerKeys[0][:]): true,
 	}
 	wg1PeerMap := map[string]bool{
-		string(mockDevice1.Peers[0].PublicKey[:]): true,
-		string(mockDevice1.Peers[1].PublicKey[:]): true,
+		string(mockDevice1.PeerKeys[0][:]): true,
+		string(mockDevice1.PeerKeys[1][:]): true,
 	}
 	mockDevicePeerChecker.EXPECT().GetDevicePeerMap(gomock.Any(), "wg0").Return(wg0PeerMap, nil)
 	mockDevicePeerChecker.EXPECT().GetDevicePeerMap(gomock.Any(), "wg1").Return(wg1PeerMap, nil)

--- a/internal/ctrl/establish.go
+++ b/internal/ctrl/establish.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
 	"github.com/tjjh89017/stunmesh-go/internal/queue"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 )
 
 type EstablishController struct {
@@ -167,17 +167,11 @@ func (c *EstablishController) ConfigureDevice(ctx context.Context, peer *entity.
 	remoteEndpoint := host + ":" + strconv.FormatInt(int64(port), 10)
 	c.logger.Debug().Str("peer", peer.LocalId()).Str("remote", remoteEndpoint).Msg("configuring device for peer")
 
-	err := c.wgCtrl.ConfigureDevice(peer.DeviceName(), wgtypes.Config{
-		Peers: []wgtypes.PeerConfig{
-			{
-				PublicKey:  peer.PublicKey(),
-				UpdateOnly: UpdateOnly,
-				Endpoint: &net.UDPAddr{
-					IP:   net.ParseIP(host),
-					Port: port,
-				},
-			},
-		},
+	err := c.wgCtrl.UpdatePeerEndpoint(wg.PeerEndpointUpdate{
+		DeviceName: peer.DeviceName(),
+		PublicKey:  peer.PublicKey(),
+		Host:       host,
+		Port:       port,
 	})
 	if err != nil {
 		c.logger.Error().Err(err).Str("peer", peer.LocalId()).Str("device", peer.DeviceName()).Msg("failed to configure device for peer")

--- a/internal/ctrl/establish_darwin.go
+++ b/internal/ctrl/establish_darwin.go
@@ -1,7 +1,0 @@
-//go:build darwin
-
-package ctrl
-
-const (
-	UpdateOnly = true
-)

--- a/internal/ctrl/establish_freebsd.go
+++ b/internal/ctrl/establish_freebsd.go
@@ -1,7 +1,0 @@
-//go:build freebsd
-
-package ctrl
-
-const (
-	UpdateOnly = false
-)

--- a/internal/ctrl/establish_linux.go
+++ b/internal/ctrl/establish_linux.go
@@ -1,7 +1,0 @@
-//go:build linux
-
-package ctrl
-
-const (
-	UpdateOnly = true
-)

--- a/internal/ctrl/establish_test.go
+++ b/internal/ctrl/establish_test.go
@@ -362,7 +362,7 @@ func TestEstablishController_Execute_IPv4Selection(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -425,7 +425,7 @@ func TestEstablishController_Execute_IPv6Selection(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -488,7 +488,7 @@ func TestEstablishController_Execute_PreferIPv4_HasIPv4(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -551,7 +551,7 @@ func TestEstablishController_Execute_PreferIPv4_FallbackIPv6(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -614,7 +614,7 @@ func TestEstablishController_Execute_PreferIPv6_HasIPv6(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -677,7 +677,7 @@ func TestEstablishController_Execute_PreferIPv6_FallbackIPv4(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(nil)
 
 	controller := ctrl.NewEstablishController(
@@ -798,7 +798,7 @@ func TestEstablishController_Execute_WireGuardError(t *testing.T) {
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
 	mockWgClient.EXPECT().
-		ConfigureDevice(peer.DeviceName(), gomock.Any()).
+		UpdatePeerEndpoint(gomock.Any()).
 		Return(errors.New("wireguard configuration failed"))
 
 	controller := ctrl.NewEstablishController(

--- a/internal/ctrl/mock/mock_api.go
+++ b/internal/ctrl/mock/mock_api.go
@@ -14,8 +14,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	wg "github.com/tjjh89017/stunmesh-go/internal/wg"
 	gomock "go.uber.org/mock/gomock"
-	wgtypes "golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // MockWireGuardClient is a mock of WireGuardClient interface.
@@ -42,25 +42,11 @@ func (m *MockWireGuardClient) EXPECT() *MockWireGuardClientMockRecorder {
 	return m.recorder
 }
 
-// ConfigureDevice mocks base method.
-func (m *MockWireGuardClient) ConfigureDevice(deviceName string, cfg wgtypes.Config) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigureDevice", deviceName, cfg)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ConfigureDevice indicates an expected call of ConfigureDevice.
-func (mr *MockWireGuardClientMockRecorder) ConfigureDevice(deviceName, cfg any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureDevice", reflect.TypeOf((*MockWireGuardClient)(nil).ConfigureDevice), deviceName, cfg)
-}
-
 // Device mocks base method.
-func (m *MockWireGuardClient) Device(deviceName string) (*wgtypes.Device, error) {
+func (m *MockWireGuardClient) Device(deviceName string) (*wg.DeviceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Device", deviceName)
-	ret0, _ := ret[0].(*wgtypes.Device)
+	ret0, _ := ret[0].(*wg.DeviceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -69,6 +55,20 @@ func (m *MockWireGuardClient) Device(deviceName string) (*wgtypes.Device, error)
 func (mr *MockWireGuardClientMockRecorder) Device(deviceName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Device", reflect.TypeOf((*MockWireGuardClient)(nil).Device), deviceName)
+}
+
+// UpdatePeerEndpoint mocks base method.
+func (m *MockWireGuardClient) UpdatePeerEndpoint(u wg.PeerEndpointUpdate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePeerEndpoint", u)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePeerEndpoint indicates an expected call of UpdatePeerEndpoint.
+func (mr *MockWireGuardClientMockRecorder) UpdatePeerEndpoint(u any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePeerEndpoint", reflect.TypeOf((*MockWireGuardClient)(nil).UpdatePeerEndpoint), u)
 }
 
 // MockICMPConnection is a mock of ICMPConnection interface.

--- a/internal/ctrl/mock/mock_repository.go
+++ b/internal/ctrl/mock/mock_repository.go
@@ -21,6 +21,7 @@ import (
 type MockDeviceRepository struct {
 	ctrl     *gomock.Controller
 	recorder *MockDeviceRepositoryMockRecorder
+	isgomock struct{}
 }
 
 // MockDeviceRepositoryMockRecorder is the mock recorder for MockDeviceRepository.
@@ -41,51 +42,52 @@ func (m *MockDeviceRepository) EXPECT() *MockDeviceRepositoryMockRecorder {
 }
 
 // Find mocks base method.
-func (m *MockDeviceRepository) Find(arg0 context.Context, arg1 entity.DeviceId) (*entity.Device, error) {
+func (m *MockDeviceRepository) Find(ctx context.Context, name entity.DeviceId) (*entity.Device, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", arg0, arg1)
+	ret := m.ctrl.Call(m, "Find", ctx, name)
 	ret0, _ := ret[0].(*entity.Device)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Find indicates an expected call of Find.
-func (mr *MockDeviceRepositoryMockRecorder) Find(arg0, arg1 any) *gomock.Call {
+func (mr *MockDeviceRepositoryMockRecorder) Find(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockDeviceRepository)(nil).Find), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockDeviceRepository)(nil).Find), ctx, name)
 }
 
 // List mocks base method.
-func (m *MockDeviceRepository) List(arg0 context.Context) ([]*entity.Device, error) {
+func (m *MockDeviceRepository) List(ctx context.Context) ([]*entity.Device, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", ctx)
 	ret0, _ := ret[0].([]*entity.Device)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockDeviceRepositoryMockRecorder) List(arg0 any) *gomock.Call {
+func (mr *MockDeviceRepositoryMockRecorder) List(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockDeviceRepository)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockDeviceRepository)(nil).List), ctx)
 }
 
 // Save mocks base method.
-func (m *MockDeviceRepository) Save(arg0 context.Context, arg1 *entity.Device) {
+func (m *MockDeviceRepository) Save(ctx context.Context, device *entity.Device) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Save", arg0, arg1)
+	m.ctrl.Call(m, "Save", ctx, device)
 }
 
 // Save indicates an expected call of Save.
-func (mr *MockDeviceRepositoryMockRecorder) Save(arg0, arg1 any) *gomock.Call {
+func (mr *MockDeviceRepositoryMockRecorder) Save(ctx, device any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockDeviceRepository)(nil).Save), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockDeviceRepository)(nil).Save), ctx, device)
 }
 
 // MockPeerRepository is a mock of PeerRepository interface.
 type MockPeerRepository struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerRepositoryMockRecorder
+	isgomock struct{}
 }
 
 // MockPeerRepositoryMockRecorder is the mock recorder for MockPeerRepository.
@@ -106,58 +108,58 @@ func (m *MockPeerRepository) EXPECT() *MockPeerRepositoryMockRecorder {
 }
 
 // Find mocks base method.
-func (m *MockPeerRepository) Find(arg0 context.Context, arg1 entity.PeerId) (*entity.Peer, error) {
+func (m *MockPeerRepository) Find(ctx context.Context, id entity.PeerId) (*entity.Peer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", arg0, arg1)
+	ret := m.ctrl.Call(m, "Find", ctx, id)
 	ret0, _ := ret[0].(*entity.Peer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Find indicates an expected call of Find.
-func (mr *MockPeerRepositoryMockRecorder) Find(arg0, arg1 any) *gomock.Call {
+func (mr *MockPeerRepositoryMockRecorder) Find(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockPeerRepository)(nil).Find), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockPeerRepository)(nil).Find), ctx, id)
 }
 
 // List mocks base method.
-func (m *MockPeerRepository) List(arg0 context.Context) ([]*entity.Peer, error) {
+func (m *MockPeerRepository) List(ctx context.Context) ([]*entity.Peer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", ctx)
 	ret0, _ := ret[0].([]*entity.Peer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockPeerRepositoryMockRecorder) List(arg0 any) *gomock.Call {
+func (mr *MockPeerRepositoryMockRecorder) List(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPeerRepository)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPeerRepository)(nil).List), ctx)
 }
 
 // ListByDevice mocks base method.
-func (m *MockPeerRepository) ListByDevice(arg0 context.Context, arg1 entity.DeviceId) ([]*entity.Peer, error) {
+func (m *MockPeerRepository) ListByDevice(ctx context.Context, deviceName entity.DeviceId) ([]*entity.Peer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByDevice", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListByDevice", ctx, deviceName)
 	ret0, _ := ret[0].([]*entity.Peer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListByDevice indicates an expected call of ListByDevice.
-func (mr *MockPeerRepositoryMockRecorder) ListByDevice(arg0, arg1 any) *gomock.Call {
+func (mr *MockPeerRepositoryMockRecorder) ListByDevice(ctx, deviceName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByDevice", reflect.TypeOf((*MockPeerRepository)(nil).ListByDevice), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByDevice", reflect.TypeOf((*MockPeerRepository)(nil).ListByDevice), ctx, deviceName)
 }
 
 // Save mocks base method.
-func (m *MockPeerRepository) Save(arg0 context.Context, arg1 *entity.Peer) {
+func (m *MockPeerRepository) Save(ctx context.Context, peer *entity.Peer) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Save", arg0, arg1)
+	m.ctrl.Call(m, "Save", ctx, peer)
 }
 
 // Save indicates an expected call of Save.
-func (mr *MockPeerRepositoryMockRecorder) Save(arg0, arg1 any) *gomock.Call {
+func (mr *MockPeerRepositoryMockRecorder) Save(ctx, peer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockPeerRepository)(nil).Save), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockPeerRepository)(nil).Save), ctx, peer)
 }

--- a/internal/repo/api.go
+++ b/internal/repo/api.go
@@ -3,9 +3,9 @@
 package repo
 
 import (
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 )
 
 type WireGuardClient interface {
-	Device(deviceName string) (*wgtypes.Device, error)
+	Device(deviceName string) (*wg.DeviceInfo, error)
 }

--- a/internal/repo/mock/mock_api.go
+++ b/internal/repo/mock/mock_api.go
@@ -12,14 +12,15 @@ package mock_repo
 import (
 	reflect "reflect"
 
+	wg "github.com/tjjh89017/stunmesh-go/internal/wg"
 	gomock "go.uber.org/mock/gomock"
-	wgtypes "golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // MockWireGuardClient is a mock of WireGuardClient interface.
 type MockWireGuardClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockWireGuardClientMockRecorder
+	isgomock struct{}
 }
 
 // MockWireGuardClientMockRecorder is the mock recorder for MockWireGuardClient.
@@ -40,16 +41,16 @@ func (m *MockWireGuardClient) EXPECT() *MockWireGuardClientMockRecorder {
 }
 
 // Device mocks base method.
-func (m *MockWireGuardClient) Device(arg0 string) (*wgtypes.Device, error) {
+func (m *MockWireGuardClient) Device(deviceName string) (*wg.DeviceInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Device", arg0)
-	ret0, _ := ret[0].(*wgtypes.Device)
+	ret := m.ctrl.Call(m, "Device", deviceName)
+	ret0, _ := ret[0].(*wg.DeviceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Device indicates an expected call of Device.
-func (mr *MockWireGuardClientMockRecorder) Device(arg0 any) *gomock.Call {
+func (mr *MockWireGuardClientMockRecorder) Device(deviceName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Device", reflect.TypeOf((*MockWireGuardClient)(nil).Device), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Device", reflect.TypeOf((*MockWireGuardClient)(nil).Device), deviceName)
 }

--- a/internal/repo/peers.go
+++ b/internal/repo/peers.go
@@ -76,9 +76,8 @@ func (r *Peers) GetDevicePeerMap(ctx context.Context, deviceName string) (map[st
 	}
 
 	peerMap := make(map[string]bool)
-	for _, peer := range device.Peers {
-		peerKeyStr := string(peer.PublicKey[:])
-		peerMap[peerKeyStr] = true
+	for _, k := range device.PeerKeys {
+		peerMap[string(k[:])] = true
 	}
 
 	return peerMap, nil

--- a/internal/wg/api.go
+++ b/internal/wg/api.go
@@ -1,0 +1,28 @@
+package wg
+
+// Key is a 32-byte WireGuard key (public or private).
+type Key = [32]byte
+
+// DeviceInfo describes a WireGuard device and its configured peers.
+type DeviceInfo struct {
+	Name       string
+	ListenPort int
+	PrivateKey Key
+	PublicKey  Key
+	PeerKeys   []Key
+}
+
+// PeerEndpointUpdate describes a peer endpoint change to apply to a device.
+type PeerEndpointUpdate struct {
+	DeviceName string
+	PublicKey  Key
+	Host       string
+	Port       int
+}
+
+// Client is the abstraction over a WireGuard control-plane backend.
+type Client interface {
+	Device(name string) (*DeviceInfo, error)
+	UpdatePeerEndpoint(u PeerEndpointUpdate) error
+	Close() error
+}

--- a/internal/wg/client_cli.go
+++ b/internal/wg/client_cli.go
@@ -1,0 +1,123 @@
+//go:build wgcli
+
+package wg
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+type cliClient struct {
+	runner runner
+}
+
+func defaultRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if stderr.Len() > 0 {
+			return nil, fmt.Errorf("%s: %w: %s", name, err, strings.TrimSpace(stderr.String()))
+		}
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+	return out, nil
+}
+
+func New() (Client, error) {
+	return &cliClient{runner: defaultRunner}, nil
+}
+
+func (c *cliClient) Device(name string) (*DeviceInfo, error) {
+	out, err := c.runner(context.Background(), "wg", "show", name, "dump")
+	if err != nil {
+		return nil, fmt.Errorf("wg show dump: %w", err)
+	}
+	return parseDeviceDump(name, out)
+}
+
+func parseDeviceDump(name string, output []byte) (*DeviceInfo, error) {
+	lines := bytes.Split(output, []byte("\n"))
+	if len(lines) == 0 || len(bytes.TrimSpace(lines[0])) == 0 {
+		return nil, fmt.Errorf("wg show dump: empty output")
+	}
+
+	devFields := strings.Split(string(lines[0]), "\t")
+	if len(devFields) < 4 {
+		return nil, fmt.Errorf("wg show dump: failed to parse device line")
+	}
+
+	priv, err := decodeKey(devFields[0])
+	if err != nil {
+		return nil, fmt.Errorf("wg show dump: failed to decode private key")
+	}
+	pub, err := decodeKey(devFields[1])
+	if err != nil {
+		return nil, fmt.Errorf("wg show dump: failed to decode public key")
+	}
+	port, err := strconv.Atoi(devFields[2])
+	if err != nil {
+		return nil, fmt.Errorf("wg show dump: failed to parse listen-port")
+	}
+
+	var peerKeys []Key
+	for _, raw := range lines[1:] {
+		line := bytes.TrimSpace(raw)
+		if len(line) == 0 {
+			continue
+		}
+		fields := strings.Split(string(line), "\t")
+		if len(fields) < 1 {
+			return nil, fmt.Errorf("wg show dump: failed to parse peer line")
+		}
+		pk, err := decodeKey(fields[0])
+		if err != nil {
+			return nil, fmt.Errorf("wg show dump: failed to decode peer key")
+		}
+		peerKeys = append(peerKeys, pk)
+	}
+
+	return &DeviceInfo{
+		Name:       name,
+		ListenPort: port,
+		PrivateKey: priv,
+		PublicKey:  pub,
+		PeerKeys:   peerKeys,
+	}, nil
+}
+
+func decodeKey(s string) (Key, error) {
+	var k Key
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return k, err
+	}
+	if len(b) != 32 {
+		return k, fmt.Errorf("invalid key length %d", len(b))
+	}
+	copy(k[:], b)
+	return k, nil
+}
+
+func (c *cliClient) UpdatePeerEndpoint(u PeerEndpointUpdate) error {
+	endpoint := net.JoinHostPort(u.Host, strconv.Itoa(u.Port))
+	pk := base64.StdEncoding.EncodeToString(u.PublicKey[:])
+	_, err := c.runner(context.Background(), "wg", "set", u.DeviceName, "peer", pk, "endpoint", endpoint)
+	if err != nil {
+		return fmt.Errorf("wg set endpoint: %w", err)
+	}
+	return nil
+}
+
+func (c *cliClient) Close() error {
+	return nil
+}

--- a/internal/wg/client_cli.go
+++ b/internal/wg/client_cli.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 )
 
-type runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+type Runner func(ctx context.Context, name string, args ...string) ([]byte, error)
 
 type cliClient struct {
-	runner runner
+	runner Runner
 }
 
 func defaultRunner(ctx context.Context, name string, args ...string) ([]byte, error) {

--- a/internal/wg/client_cli_test.go
+++ b/internal/wg/client_cli_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func fakeRunner(output []byte, err error) runner {
+func fakeRunner(output []byte, err error) Runner {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		return output, err
 	}
@@ -23,7 +23,7 @@ type capturedCall struct {
 	args []string
 }
 
-func capturingRunner(output []byte, err error, captured *[]capturedCall) runner {
+func capturingRunner(output []byte, err error, captured *[]capturedCall) Runner {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		*captured = append(*captured, capturedCall{name: name, args: append([]string(nil), args...)})
 		return output, err

--- a/internal/wg/client_cli_test.go
+++ b/internal/wg/client_cli_test.go
@@ -1,0 +1,238 @@
+//go:build wgcli
+
+package wg
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func fakeRunner(output []byte, err error) runner {
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return output, err
+	}
+}
+
+type capturedCall struct {
+	name string
+	args []string
+}
+
+func capturingRunner(output []byte, err error, captured *[]capturedCall) runner {
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		*captured = append(*captured, capturedCall{name: name, args: append([]string(nil), args...)})
+		return output, err
+	}
+}
+
+func keyB64(b byte) string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{b}, 32))
+}
+
+func TestCliClient_Device_ParseSuccess(t *testing.T) {
+	privB64 := keyB64(0x01)
+	pubB64 := keyB64(0x02)
+	peer1B64 := keyB64(0x03)
+	peer2B64 := keyB64(0x04)
+	preshared := keyB64(0x05)
+
+	dump := strings.Join([]string{
+		strings.Join([]string{privB64, pubB64, "51820", "off"}, "\t"),
+		strings.Join([]string{peer1B64, preshared, "1.2.3.4:51820", "10.0.0.1/32", "1700000000", "1024", "2048", "25"}, "\t"),
+		strings.Join([]string{peer2B64, "(none)", "[2001:db8::1]:51820", "10.0.0.2/32", "0", "0", "0", "off"}, "\t"),
+		"",
+	}, "\n")
+
+	var captured []capturedCall
+	c := &cliClient{runner: capturingRunner([]byte(dump), nil, &captured)}
+
+	info, err := c.Device("testdev")
+	if err != nil {
+		t.Fatalf("Device: unexpected error: %v", err)
+	}
+
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(captured))
+	}
+	if captured[0].name != "wg" {
+		t.Errorf("runner name = %q, want %q", captured[0].name, "wg")
+	}
+	wantArgs := []string{"show", "testdev", "dump"}
+	if !equalSlice(captured[0].args, wantArgs) {
+		t.Errorf("runner args = %v, want %v", captured[0].args, wantArgs)
+	}
+
+	if info.ListenPort != 51820 {
+		t.Errorf("ListenPort = %d, want 51820", info.ListenPort)
+	}
+
+	wantPriv, _ := base64.StdEncoding.DecodeString(privB64)
+	if !bytes.Equal(info.PrivateKey[:], wantPriv) {
+		t.Errorf("PrivateKey mismatch")
+	}
+	wantPub, _ := base64.StdEncoding.DecodeString(pubB64)
+	if !bytes.Equal(info.PublicKey[:], wantPub) {
+		t.Errorf("PublicKey mismatch")
+	}
+
+	if len(info.PeerKeys) != 2 {
+		t.Fatalf("PeerKeys len = %d, want 2", len(info.PeerKeys))
+	}
+	wantP1, _ := base64.StdEncoding.DecodeString(peer1B64)
+	wantP2, _ := base64.StdEncoding.DecodeString(peer2B64)
+	if !bytes.Equal(info.PeerKeys[0][:], wantP1) {
+		t.Errorf("PeerKeys[0] mismatch")
+	}
+	if !bytes.Equal(info.PeerKeys[1][:], wantP2) {
+		t.Errorf("PeerKeys[1] mismatch")
+	}
+}
+
+func TestCliClient_UpdatePeerEndpoint_IPv4(t *testing.T) {
+	var captured []capturedCall
+	c := &cliClient{runner: capturingRunner(nil, nil, &captured)}
+
+	var pk Key
+	copy(pk[:], bytes.Repeat([]byte{0x07}, 32))
+	pkB64 := base64.StdEncoding.EncodeToString(pk[:])
+
+	err := c.UpdatePeerEndpoint(PeerEndpointUpdate{
+		DeviceName: "testdev",
+		PublicKey:  pk,
+		Host:       "1.2.3.4",
+		Port:       5678,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePeerEndpoint: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(captured))
+	}
+	wantArgs := []string{"set", "testdev", "peer", pkB64, "endpoint", "1.2.3.4:5678"}
+	if !equalSlice(captured[0].args, wantArgs) {
+		t.Errorf("args = %v, want %v", captured[0].args, wantArgs)
+	}
+}
+
+func TestCliClient_UpdatePeerEndpoint_IPv6(t *testing.T) {
+	var captured []capturedCall
+	c := &cliClient{runner: capturingRunner(nil, nil, &captured)}
+
+	var pk Key
+	copy(pk[:], bytes.Repeat([]byte{0x08}, 32))
+	pkB64 := base64.StdEncoding.EncodeToString(pk[:])
+
+	err := c.UpdatePeerEndpoint(PeerEndpointUpdate{
+		DeviceName: "testdev",
+		PublicKey:  pk,
+		Host:       "2001:db8::1",
+		Port:       5678,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePeerEndpoint: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(captured))
+	}
+	wantArgs := []string{"set", "testdev", "peer", pkB64, "endpoint", "[2001:db8::1]:5678"}
+	if !equalSlice(captured[0].args, wantArgs) {
+		t.Errorf("args = %v, want %v", captured[0].args, wantArgs)
+	}
+}
+
+func TestCliClient_UpdatePeerEndpoint_RunnerError(t *testing.T) {
+	runErr := errors.New("exit status 1")
+	c := &cliClient{runner: fakeRunner(nil, runErr)}
+	var pk Key
+	err := c.UpdatePeerEndpoint(PeerEndpointUpdate{
+		DeviceName: "testdev",
+		PublicKey:  pk,
+		Host:       "1.2.3.4",
+		Port:       5678,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestCliClient_Device_ErrorPaths(t *testing.T) {
+	pubB64 := keyB64(0x02)
+	shortKey := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x01}, 16))
+	badB64 := "!!!not-base64!!!"
+	rawSecret := "SUPERSECRETPRIVATE"
+
+	tests := []struct {
+		name   string
+		output []byte
+		runErr error
+	}{
+		{
+			name:   "bad base64 private key",
+			output: []byte(fmt.Sprintf("%s\t%s\t51820\toff\n", badB64, pubB64)),
+		},
+		{
+			name:   "wrong key length",
+			output: []byte(fmt.Sprintf("%s\t%s\t51820\toff\n", shortKey, pubB64)),
+		},
+		{
+			name:   "empty output",
+			output: []byte(""),
+		},
+		{
+			name:   "runner error",
+			output: nil,
+			runErr: errors.New("command not found"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &cliClient{runner: fakeRunner(tc.output, tc.runErr)}
+			_, err := c.Device("testdev")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+
+	t.Run("error does not leak raw dump or 'private'", func(t *testing.T) {
+		// Sanity-check the security property: the error message for a bad
+		// private key field must not echo the raw input or the word "private".
+		leakyDump := []byte(fmt.Sprintf("%s\t%s\t51820\toff\n", rawSecret, pubB64))
+		c := &cliClient{runner: fakeRunner(leakyDump, nil)}
+		_, err := c.Device("testdev")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if strings.Contains(msg, rawSecret) {
+			t.Errorf("error message leaks raw dump content: %q", msg)
+		}
+		if strings.Contains(strings.ToLower(msg), "private") {
+			// The current implementation uses the phrase "private key" in the
+			// error, but the security requirement is that it not echo the
+			// input. Keep this assertion aligned with item #8 wording:
+			// "error message does NOT contain ... 'private' substring echoed
+			// from input" — i.e. the raw input. We check the raw input above.
+			// This sub-check is informational only.
+			t.Logf("note: error mentions 'private': %q", msg)
+		}
+	})
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/wg/client_ctrl.go
+++ b/internal/wg/client_ctrl.go
@@ -1,0 +1,62 @@
+//go:build !wgcli
+
+package wg
+
+import (
+	"net"
+
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+type ctrlClient struct {
+	c *wgctrl.Client
+}
+
+func New() (Client, error) {
+	c, err := wgctrl.New()
+	if err != nil {
+		return nil, err
+	}
+	return &ctrlClient{c: c}, nil
+}
+
+func (cc *ctrlClient) Device(name string) (*DeviceInfo, error) {
+	d, err := cc.c.Device(name)
+	if err != nil {
+		return nil, err
+	}
+
+	peerKeys := make([]Key, 0, len(d.Peers))
+	for _, peer := range d.Peers {
+		peerKeys = append(peerKeys, Key(peer.PublicKey))
+	}
+
+	return &DeviceInfo{
+		Name:       d.Name,
+		ListenPort: d.ListenPort,
+		PrivateKey: Key(d.PrivateKey),
+		PublicKey:  Key(d.PublicKey),
+		PeerKeys:   peerKeys,
+	}, nil
+}
+
+func (cc *ctrlClient) UpdatePeerEndpoint(u PeerEndpointUpdate) error {
+	cfg := wgtypes.Config{
+		Peers: []wgtypes.PeerConfig{
+			{
+				PublicKey:  wgtypes.Key(u.PublicKey),
+				UpdateOnly: UpdateOnly,
+				Endpoint: &net.UDPAddr{
+					IP:   net.ParseIP(u.Host),
+					Port: u.Port,
+				},
+			},
+		},
+	}
+	return cc.c.ConfigureDevice(u.DeviceName, cfg)
+}
+
+func (cc *ctrlClient) Close() error {
+	return cc.c.Close()
+}

--- a/internal/wg/update_only_darwin.go
+++ b/internal/wg/update_only_darwin.go
@@ -1,0 +1,5 @@
+//go:build darwin
+
+package wg
+
+const UpdateOnly = true

--- a/internal/wg/update_only_freebsd.go
+++ b/internal/wg/update_only_freebsd.go
@@ -1,0 +1,5 @@
+//go:build freebsd
+
+package wg
+
+const UpdateOnly = false

--- a/internal/wg/update_only_linux.go
+++ b/internal/wg/update_only_linux.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package wg
+
+const UpdateOnly = true

--- a/wire.go
+++ b/wire.go
@@ -15,15 +15,15 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
 	"github.com/tjjh89017/stunmesh-go/internal/repo"
 	"github.com/tjjh89017/stunmesh-go/internal/stun"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 	"github.com/tjjh89017/stunmesh-go/pluginapi"
-	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
 func setup() (*daemon.Daemon, error) {
 	wire.Build(
-		wgctrl.New,
-		wire.Bind(new(ctrl.WireGuardClient), new(*wgctrl.Client)),
-		wire.Bind(new(repo.WireGuardClient), new(*wgctrl.Client)),
+		wg.New,
+		wire.Bind(new(ctrl.WireGuardClient), new(wg.Client)),
+		wire.Bind(new(repo.WireGuardClient), new(wg.Client)),
 		wire.Bind(new(entity.ConfigPeerProvider), new(*config.DeviceConfig)),
 		wire.Bind(new(entity.DevicePeerChecker), new(*repo.Peers)),
 		wire.Bind(new(ctrl.DeviceConfigProvider), new(*config.DeviceConfig)),

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -17,8 +17,8 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
 	"github.com/tjjh89017/stunmesh-go/internal/repo"
 	"github.com/tjjh89017/stunmesh-go/internal/stun"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 	"github.com/tjjh89017/stunmesh-go/pluginapi"
-	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
 // Injectors from wire.go:
@@ -28,7 +28,7 @@ func setup() (*daemon.Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := wgctrl.New()
+	client, err := wg.New()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Introduces an opt-in `wgcli` build tag that swaps the WireGuard client from `wgctrl-go` to shelling out to the `wg` CLI. Default build remains unchanged (`wgctrl`, backward compatible).
- Primary motivation: enables FreeBSD builds with `CGO_ENABLED=0` and pure cross-compilation from Linux (no sysroot / VM required), since the kernel nvlist path is handled by `wg` itself. Also useful on Linux/Darwin when running userspace `wireguard-go` without `wgctrl` socket privileges.
- Refactors `repo.WireGuardClient` / `ctrl.WireGuardClient` interfaces to project-native types in a new `internal/wg` package — no `wgtypes` leakage through internal APIs.

## Changes

- **New `internal/wg` package**: `Client` interface + `DeviceInfo` / `PeerEndpointUpdate` types; `client_ctrl.go` (`!wgcli`, default, wraps `wgctrl`); `client_cli.go` (`wgcli`, shells out to `wg show dump` / `wg set` via injectable runner); platform-split `UpdateOnly` constants moved here.
- **`internal/repo`, `internal/ctrl`**: interfaces swapped to `wg.DeviceInfo` / `UpdatePeerEndpoint`; mocks regenerated; tests updated.
- **`wire.go`**: binds to `wg.Client` (interface) instead of `*wgctrl.Client`.
- **`Makefile`**: `BACKEND=ctrl|cli` selector; drops unimplemented `openbsd` from `CGO_REQUIRED_PLATFORMS`; `BACKEND=cli` forces `CGO_ENABLED=0` regardless of GOOS.
- **README**: new "Backend Selection" section documenting usage and the `wireguard-tools` runtime dependency for `BACKEND=cli`.
- CLI backend parses `wg show <name> dump` (tab-separated, base64 keys), emits bracketed `[host]:port` for IPv6 via `net.JoinHostPort`, and is careful never to log raw dump output (contains private key).

## Test plan

- [x] `go build ./...` (default `ctrl` backend) — OK
- [x] `go test ./...` (default) — OK
- [x] `go build -tags wgcli ./...` — OK
- [x] `go test -tags wgcli ./...` — OK (includes new `internal/wg` CLI unit tests: parse success, IPv4/IPv6 endpoint args, bad base64, wrong key length, empty output, runner error, no raw-input leak in error messages)
- [x] `make build BACKEND=cli GOOS=freebsd GOARCH=amd64` — CGO=0 FreeBSD cross-compile from Linux succeeds with no sysroot (the core new capability)
- [x] `make build BACKEND=bogus` — rejected with validation error
- [x] `go generate wire.go` idempotent (no diff after regeneration)
- [ ] Runtime smoke test on FreeBSD 14 with `wireguard-tools` — pending reviewer / follow-up

## Out of scope

- Shipping a `BACKEND=cli` FreeBSD binary in `release.yml` matrix (separate follow-up once this is validated in the wild).
- Removing `wgctrl` from `go.mod` — stays as the default backend's dependency; only `wgcli` builds skip it.