### PR TITLE
refactor(ping): use Trigger/TriggerForPeer instead of Execute

### DIFF
--- a/internal/ctrl/establish.go
+++ b/internal/ctrl/establish.go
@@ -216,6 +216,15 @@ func (c *EstablishController) Trigger(ctx context.Context) {
 	c.logger.Debug().Int("queue_len", c.queue.Len()).Msg("current queue length")
 }
 
+// TriggerForPeer enqueues a specific peer for establishment (non-blocking)
+func (c *EstablishController) TriggerForPeer(peerId entity.PeerId) {
+	if c.queue.TryEnqueue(peerId) {
+		c.logger.Debug().Str("peer", peerId.String()).Msg("establish triggered for peer")
+	} else {
+		c.logger.Warn().Str("peer", peerId.String()).Msg("establish queue full, dropping trigger for peer")
+	}
+}
+
 // WaitForCompletion waits until the queue is empty or context is cancelled
 func (c *EstablishController) WaitForCompletion(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Second)

--- a/internal/ctrl/ping_monitor.go
+++ b/internal/ctrl/ping_monitor.go
@@ -293,7 +293,7 @@ func (m *DevicePingMonitor) deviceReaderLoop(ctx context.Context) {
 		}
 
 		// Parse and dispatch reply to correct peer
-		m.dispatchReply(ctx, reply[:n], addr)
+		m.dispatchReply(reply[:n], addr)
 	}
 }
 
@@ -315,12 +315,12 @@ func (m *DevicePingMonitor) deviceTimeoutChecker(ctx context.Context, timeout ti
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			m.checkForTimeouts(ctx)
+			m.checkForTimeouts()
 		}
 	}
 }
 
-func (m *DevicePingMonitor) checkForTimeouts(ctx context.Context) {
+func (m *DevicePingMonitor) checkForTimeouts() {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -344,7 +344,7 @@ func (m *DevicePingMonitor) checkForTimeouts(ctx context.Context) {
 			state.lastSentTime = time.Time{}
 			state.mu.Unlock()
 
-			m.handlePingResult(ctx, state, false)
+			m.handlePingResult(state, false)
 		}
 	}
 }
@@ -390,7 +390,7 @@ func (m *DevicePingMonitor) sendPingForPeer(state *PeerPingState) {
 		Msg("sent ping")
 }
 
-func (m *DevicePingMonitor) dispatchReply(ctx context.Context, reply []byte, addr net.Addr) {
+func (m *DevicePingMonitor) dispatchReply(reply []byte, addr net.Addr) {
 	// Parse ICMP reply (reply starts from ICMP header)
 	replyMsg, err := icmp.ParseMessage(ipv4.ICMPTypeEchoReply.Protocol(), reply)
 	if err != nil {
@@ -438,7 +438,7 @@ func (m *DevicePingMonitor) dispatchReply(ctx context.Context, reply []byte, add
 			Str("peer", state.peerId.String()).
 			Str("target", state.target).
 			Msg("ping success")
-		m.handlePingResult(ctx, state, true)
+		m.handlePingResult(state, true)
 	}
 }
 
@@ -480,7 +480,7 @@ func (m *DevicePingMonitor) validateReply(addr net.Addr, state *PeerPingState, i
 	return true
 }
 
-func (m *DevicePingMonitor) handlePingResult(ctx context.Context, state *PeerPingState, success bool) {
+func (m *DevicePingMonitor) handlePingResult(state *PeerPingState, success bool) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
@@ -512,8 +512,8 @@ func (m *DevicePingMonitor) handlePingResult(ctx context.Context, state *PeerPin
 		now := time.Now()
 		if m.shouldRetryPublishEstablish(state, now) {
 			// Always run publish to update our endpoint, then establish the specific peer
-			go m.controller.publishCtrl.ExecuteForPeer(ctx, state.peerId)
-			go m.controller.establishCtrl.Execute(ctx, state.peerId)
+			m.controller.publishCtrl.TriggerForPeer(state.peerId)
+			m.controller.establishCtrl.TriggerForPeer(state.peerId)
 
 			if state.retryCount < PeerSpecificRetryThreshold {
 				logger.Info().Msg("triggered publish and establish for specific peer (early retry)")


### PR DESCRIPTION
## Summary

- Add `EstablishController.TriggerForPeer` to mirror the existing `PublishController.TriggerForPeer` method
- Replace direct `go ExecuteForPeer(ctx, ...)` / `go Execute(ctx, ...)` goroutine spawns in `ping_monitor.go` with non-blocking `TriggerForPeer` calls
- Remove the `ctx` parameter from internal helpers (`handlePingResult`, `checkForTimeouts`, `dispatchReply`) that no longer need it

The ping monitor was bypassing the queue infrastructure used by the rest of the system. Work triggered by ping failures now goes through the same worker loops as periodic refresh triggers, keeping back-pressure and ordering consistent.

#146

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all existing tests green)
- [ ] Verify ping-triggered reconnects still work end-to-end