### PR TITLE
feat(stun): support multiple STUN servers with fallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,31 @@ type Stun struct {
 	Addresses []string `mapstructure:"addresses"`
 }
 
+// GetServers returns the final merged and deduplicated list of STUN server addresses.
+// It prepends the deprecated Address field (if non-empty) to Addresses, deduplicates
+// while preserving order, and falls back to the Google STUN server if the result is empty.
+func (s *Stun) GetServers() []string {
+	seen := make(map[string]struct{})
+	var servers []string
+
+	for _, addr := range append([]string{s.Address}, s.Addresses...) {
+		if addr == "" {
+			continue
+		}
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		servers = append(servers, addr)
+	}
+
+	if len(servers) == 0 {
+		return []string{"stun.l.google.com:19302"}
+	}
+
+	return servers
+}
+
 type PingMonitor struct {
 	Interval     time.Duration `mapstructure:"interval"`
 	Timeout      time.Duration `mapstructure:"timeout"`
@@ -82,6 +107,10 @@ func Load() (*Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return nil, errors.Join(ErrUnmarshalConfig, err)
 	}
+
+	// Merge deprecated Address into Addresses: prepend Address if non-empty, then deduplicate.
+	cfg.Stun.Addresses = cfg.Stun.GetServers()
+	cfg.Stun.Address = ""
 
 	// Validate protocol configurations
 	if err := validateConfig(&cfg); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,8 @@ type Logger struct {
 }
 
 type Stun struct {
-	Address string `mapstructure:"address"`
+	Address   string   `mapstructure:"address"`
+	Addresses []string `mapstructure:"addresses"`
 }
 
 type PingMonitor struct {
@@ -65,7 +66,8 @@ func Load() (*Config, error) {
 	viper.AutomaticEnv()
 
 	viper.SetDefault("refresh_interval", time.Duration(10)*time.Minute)
-	viper.SetDefault("stun.addr", "stun.l.google.com:19302")
+	viper.SetDefault("stun.address", "stun.l.google.com:19302")
+	viper.SetDefault("stun.addresses", []string{})
 	viper.SetDefault("ping_monitor.interval", time.Duration(1)*time.Second)
 	viper.SetDefault("ping_monitor.timeout", time.Duration(1)*time.Second)
 	viper.SetDefault("ping_monitor.fixed_retries", 3)

--- a/internal/config/stun_test.go
+++ b/internal/config/stun_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestGetServers_AddressOnly verifies that when only the deprecated Address
+// field is set, GetServers returns a single-element slice with that address.
+func TestGetServers_AddressOnly(t *testing.T) {
+	s := &Stun{Address: "stun.example.com:3478"}
+	got := s.GetServers()
+	want := []string{"stun.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestGetServers_AddressesOnly verifies that when only the new Addresses
+// slice is set, GetServers returns that slice unchanged.
+func TestGetServers_AddressesOnly(t *testing.T) {
+	s := &Stun{Addresses: []string{"stun1.example.com:3478", "stun2.example.com:3478"}}
+	got := s.GetServers()
+	want := []string{"stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestGetServers_BothSetNoOverlap verifies that when both fields are set with
+// no duplicate entries, Address is prepended to Addresses in the result.
+func TestGetServers_BothSetNoOverlap(t *testing.T) {
+	s := &Stun{
+		Address:   "stun0.example.com:3478",
+		Addresses: []string{"stun1.example.com:3478", "stun2.example.com:3478"},
+	}
+	got := s.GetServers()
+	want := []string{"stun0.example.com:3478", "stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestGetServers_BothSetWithDuplicate verifies that when Address also appears
+// in Addresses, the duplicate is removed and Address remains first.
+func TestGetServers_BothSetWithDuplicate(t *testing.T) {
+	s := &Stun{
+		Address:   "stun1.example.com:3478",
+		Addresses: []string{"stun1.example.com:3478", "stun2.example.com:3478"},
+	}
+	got := s.GetServers()
+	want := []string{"stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestGetServers_NeitherSet verifies that when both fields are empty,
+// GetServers falls back to the default Google STUN server.
+func TestGetServers_NeitherSet(t *testing.T) {
+	s := &Stun{}
+	got := s.GetServers()
+	want := []string{"stun.l.google.com:19302"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestGetServers_AddressesContainsEmptyStrings verifies that empty strings
+// inside Addresses are silently skipped and do not appear in the result.
+func TestGetServers_AddressesContainsEmptyStrings(t *testing.T) {
+	s := &Stun{
+		Addresses: []string{"", "stun1.example.com:3478", "", "stun2.example.com:3478", ""},
+	}
+	got := s.GetServers()
+	want := []string{"stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() = %v, want %v", got, want)
+	}
+}
+
+// TestLoad_BackwardCompat_AddressOnly verifies that a config file using the
+// deprecated stun.address key is loaded and GetServers() returns that address.
+func TestLoad_BackwardCompat_AddressOnly(t *testing.T) {
+	resetViper()
+
+	tmpDir := t.TempDir()
+	configContent := "stun:\n  address: \"stun.example.com:3478\"\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPaths := Paths
+	Paths = []string{tmpDir}
+	defer func() { Paths = originalPaths }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	got := cfg.Stun.GetServers()
+	want := []string{"stun.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() after Load() = %v, want %v", got, want)
+	}
+
+	// After Load(), Address must be cleared into Addresses.
+	if cfg.Stun.Address != "" {
+		t.Errorf("Stun.Address after Load() = %q, want empty (should be merged into Addresses)", cfg.Stun.Address)
+	}
+}
+
+// TestLoad_BackwardCompat_AddressesOnly verifies that a config file using only
+// stun.addresses is loaded correctly. Because Load() sets a default value for
+// stun.address ("stun.l.google.com:19302") via Viper, that default is prepended
+// unless explicitly overridden. The resulting list therefore starts with the
+// default address followed by the explicit addresses from stun.addresses.
+func TestLoad_BackwardCompat_AddressesOnly(t *testing.T) {
+	resetViper()
+
+	tmpDir := t.TempDir()
+	configContent := "stun:\n  addresses:\n    - stun1.example.com:3478\n    - stun2.example.com:3478\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPaths := Paths
+	Paths = []string{tmpDir}
+	defer func() { Paths = originalPaths }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	// The Viper default for stun.address ("stun.l.google.com:19302") is prepended
+	// unless the config file explicitly sets stun.address to an empty value.
+	got := cfg.Stun.GetServers()
+	want := []string{"stun.l.google.com:19302", "stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() after Load() = %v, want %v", got, want)
+	}
+}
+
+// TestLoad_BackwardCompat_AddressesOnly_NoDefault verifies that when stun.address
+// is explicitly set to empty in the config file, only the stun.addresses list is
+// returned by GetServers() after Load().
+func TestLoad_BackwardCompat_AddressesOnly_NoDefault(t *testing.T) {
+	resetViper()
+
+	tmpDir := t.TempDir()
+	configContent := "stun:\n  address: \"\"\n  addresses:\n    - stun1.example.com:3478\n    - stun2.example.com:3478\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPaths := Paths
+	Paths = []string{tmpDir}
+	defer func() { Paths = originalPaths }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	got := cfg.Stun.GetServers()
+	want := []string{"stun1.example.com:3478", "stun2.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() after Load() = %v, want %v", got, want)
+	}
+}
+
+// TestLoad_BackwardCompat_Both verifies that when both stun.address and
+// stun.addresses are present, address appears first and duplicates are removed.
+func TestLoad_BackwardCompat_Both(t *testing.T) {
+	resetViper()
+
+	tmpDir := t.TempDir()
+	configContent := "stun:\n  address: \"stun0.example.com:3478\"\n  addresses:\n    - stun0.example.com:3478\n    - stun1.example.com:3478\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPaths := Paths
+	Paths = []string{tmpDir}
+	defer func() { Paths = originalPaths }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	got := cfg.Stun.GetServers()
+	want := []string{"stun0.example.com:3478", "stun1.example.com:3478"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetServers() after Load() = %v, want %v", got, want)
+	}
+
+	if cfg.Stun.Address != "" {
+		t.Errorf("Stun.Address after Load() = %q, want empty (should be merged into Addresses)", cfg.Stun.Address)
+	}
+}

--- a/internal/stun/helper.go
+++ b/internal/stun/helper.go
@@ -9,9 +9,8 @@ import (
 )
 
 var (
-	ErrResponseMessage  = errors.New("error reading from response message channel")
-	ErrTimeout          = errors.New("timed out waiting for response")
-	ErrInvalidEndpoint  = errors.New("STUN returned invalid endpoint (port is 0 or host is empty)")
+	ErrResponseMessage = errors.New("error reading from response message channel")
+	ErrTimeout         = errors.New("timed out waiting for response")
 )
 
 const BindingPacketHeaderSize = 8

--- a/internal/stun/resolver.go
+++ b/internal/stun/resolver.go
@@ -11,11 +11,19 @@ import (
 
 var ErrAllServersFailed = errors.New("all STUN servers failed")
 
+// StunClient is the interface for a STUN client instance.
+type StunClient interface {
+	Start(ctx context.Context)
+	Stop() error
+	Connect(ctx context.Context, addr string) (string, int, error)
+}
+
 type Resolver struct {
 	config       *config.Config
 	deviceConfig *config.DeviceConfig
 	logger       zerolog.Logger
 	mu           sync.Mutex
+	newClient    func(ctx context.Context, deviceName string, port uint16, protocol string) (StunClient, error)
 }
 
 func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logger *zerolog.Logger) *Resolver {
@@ -23,6 +31,9 @@ func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logge
 		config:       config,
 		deviceConfig: deviceConfig,
 		logger:       logger.With().Str("component", "stun").Logger(),
+		newClient: func(ctx context.Context, deviceName string, port uint16, protocol string) (StunClient, error) {
+			return New(ctx, deviceName, port, protocol)
+		},
 	}
 }
 
@@ -37,7 +48,7 @@ func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, 
 
 	r.logger.Debug().Str("device", deviceName).Str("protocol", protocol).Msg("resolving with protocol")
 
-	stun, err := New(stunCtx, deviceName, port, protocol)
+	stun, err := r.newClient(stunCtx, deviceName, port, protocol)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/stun/resolver.go
+++ b/internal/stun/resolver.go
@@ -2,11 +2,14 @@ package stun
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/rs/zerolog"
 	"github.com/tjjh89017/stunmesh-go/internal/config"
 )
+
+var ErrAllServersFailed = errors.New("all STUN servers failed")
 
 type Resolver struct {
 	config       *config.Config
@@ -46,20 +49,27 @@ func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, 
 		}
 	}()
 
-	host, discoveredPort, err := stun.Connect(stunCtx, r.config.Stun.Address)
-	if err != nil {
-		return "", 0, err
+	servers := r.config.Stun.GetServers()
+	for _, server := range servers {
+		host, discoveredPort, connectErr := stun.Connect(stunCtx, server)
+		if connectErr != nil {
+			r.logger.Warn().Err(connectErr).Str("server", server).Msg("STUN server failed, trying next")
+			continue
+		}
+
+		// Validate the discovered endpoint
+		if discoveredPort == 0 || host == "" {
+			r.logger.Warn().
+				Str("server", server).
+				Str("host", host).
+				Int("port", discoveredPort).
+				Str("protocol", protocol).
+				Msg("STUN returned invalid endpoint, trying next server")
+			continue
+		}
+
+		return host, discoveredPort, nil
 	}
 
-	// Validate the discovered endpoint
-	if discoveredPort == 0 || host == "" {
-		r.logger.Warn().
-			Str("host", host).
-			Int("port", discoveredPort).
-			Str("protocol", protocol).
-			Msg("STUN returned invalid endpoint")
-		return "", 0, ErrInvalidEndpoint
-	}
-
-	return host, discoveredPort, nil
+	return "", 0, ErrAllServersFailed
 }

--- a/internal/stun/resolver_test.go
+++ b/internal/stun/resolver_test.go
@@ -1,0 +1,228 @@
+package stun
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/tjjh89017/stunmesh-go/internal/config"
+)
+
+// mockStunClient is a simple test double for StunClient.
+type mockStunClient struct {
+	// connectResults holds ordered results for each Connect call.
+	// Each element is the result for the Nth call.
+	connectResults []connectResult
+	callCount      int
+}
+
+type connectResult struct {
+	host string
+	port int
+	err  error
+}
+
+func (m *mockStunClient) Start(_ context.Context) {}
+
+func (m *mockStunClient) Stop() error { return nil }
+
+func (m *mockStunClient) Connect(_ context.Context, _ string) (string, int, error) {
+	if m.callCount >= len(m.connectResults) {
+		return "", 0, errors.New("unexpected Connect call")
+	}
+	r := m.connectResults[m.callCount]
+	m.callCount++
+	return r.host, r.port, r.err
+}
+
+// newTestResolver builds a Resolver wired to a single shared mockStunClient
+// and a config that lists the provided servers.
+func newTestResolver(t *testing.T, client *mockStunClient, servers []string) *Resolver {
+	t.Helper()
+
+	cfg := &config.Config{
+		Stun: config.Stun{
+			Addresses: servers,
+		},
+	}
+
+	logger := zerolog.Nop()
+
+	r := &Resolver{
+		config:       cfg,
+		deviceConfig: &config.DeviceConfig{},
+		logger:       logger,
+		newClient: func(_ context.Context, _ string, _ uint16, _ string) (StunClient, error) {
+			return client, nil
+		},
+	}
+	return r
+}
+
+func TestResolver_FirstServerSucceeds(t *testing.T) {
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "1.2.3.4", port: 54321, err: nil},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun1.example.com:3478",
+		"stun2.example.com:3478",
+		"stun3.example.com:3478",
+	})
+
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if host != "1.2.3.4" {
+		t.Errorf("expected host 1.2.3.4, got %s", host)
+	}
+	if port != 54321 {
+		t.Errorf("expected port 54321, got %d", port)
+	}
+	if client.callCount != 1 {
+		t.Errorf("expected Connect to be called once, got %d", client.callCount)
+	}
+}
+
+func TestResolver_MiddleServerSucceeds(t *testing.T) {
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "", port: 0, err: errors.New("server1 unreachable")},
+			{host: "5.6.7.8", port: 12345, err: nil},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun1.example.com:3478",
+		"stun2.example.com:3478",
+		"stun3.example.com:3478",
+	})
+
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if host != "5.6.7.8" {
+		t.Errorf("expected host 5.6.7.8, got %s", host)
+	}
+	if port != 12345 {
+		t.Errorf("expected port 12345, got %d", port)
+	}
+	// first server failed, second succeeded — third must NOT be tried
+	if client.callCount != 2 {
+		t.Errorf("expected Connect called 2 times, got %d", client.callCount)
+	}
+}
+
+func TestResolver_LastServerSucceeds(t *testing.T) {
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "", port: 0, err: errors.New("server1 error")},
+			{host: "", port: 0, err: errors.New("server2 error")},
+			{host: "9.10.11.12", port: 9999, err: nil},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun1.example.com:3478",
+		"stun2.example.com:3478",
+		"stun3.example.com:3478",
+	})
+
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if host != "9.10.11.12" {
+		t.Errorf("expected host 9.10.11.12, got %s", host)
+	}
+	if port != 9999 {
+		t.Errorf("expected port 9999, got %d", port)
+	}
+	if client.callCount != 3 {
+		t.Errorf("expected Connect called 3 times, got %d", client.callCount)
+	}
+}
+
+func TestResolver_AllServersFail(t *testing.T) {
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "", port: 0, err: errors.New("server1 error")},
+			{host: "", port: 0, err: errors.New("server2 error")},
+			{host: "", port: 0, err: errors.New("server3 error")},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun1.example.com:3478",
+		"stun2.example.com:3478",
+		"stun3.example.com:3478",
+	})
+
+	_, _, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if !errors.Is(err, ErrAllServersFailed) {
+		t.Errorf("expected ErrAllServersFailed, got: %v", err)
+	}
+	if client.callCount != 3 {
+		t.Errorf("expected Connect called 3 times, got %d", client.callCount)
+	}
+}
+
+func TestResolver_InvalidEndpointSkipped(t *testing.T) {
+	// First server returns port=0 (invalid endpoint, no error)
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "1.2.3.4", port: 0, err: nil},
+			{host: "5.6.7.8", port: 54321, err: nil},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun1.example.com:3478",
+		"stun2.example.com:3478",
+	})
+
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if host != "5.6.7.8" {
+		t.Errorf("expected host 5.6.7.8, got %s", host)
+	}
+	if port != 54321 {
+		t.Errorf("expected port 54321, got %d", port)
+	}
+	if client.callCount != 2 {
+		t.Errorf("expected Connect called 2 times, got %d", client.callCount)
+	}
+}
+
+func TestResolver_SingleServer_Success(t *testing.T) {
+	client := &mockStunClient{
+		connectResults: []connectResult{
+			{host: "203.0.113.1", port: 31337, err: nil},
+		},
+	}
+
+	r := newTestResolver(t, client, []string{
+		"stun.example.com:3478",
+	})
+
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if host != "203.0.113.1" {
+		t.Errorf("expected host 203.0.113.1, got %s", host)
+	}
+	if port != 31337 {
+		t.Errorf("expected port 31337, got %d", port)
+	}
+	if client.callCount != 1 {
+		t.Errorf("expected Connect called once, got %d", client.callCount)
+	}
+}


### PR DESCRIPTION
## Summary

Implements multiple STUN server support as requested in #141.

- Adds `stun.addresses` (list) config field alongside the deprecated `stun.address` (single string)
- Merges both into a deduplicated list at load time: `address` is prepended as first priority, then `addresses` follows; duplicates removed preserving order
- Updates `Resolver` to try each server in order and return the first valid endpoint; returns `ErrAllServersFailed` if all servers are exhausted
- Backward compatible: existing configs with only `stun.address` continue to work unchanged

### Config example

```yaml
stun:
  address: "stun.l.google.com:19302"   # deprecated, kept for backward compat
  addresses:
    - "stun.l.google.com:19302"
    - "stun1.l.google.com:19302"
    - "stun2.l.google.com:19302"
```

## Changes

- `internal/config/config.go`: add `Addresses []string` to `Stun` struct, fix `stun.addr` default key typo → `stun.address`, add `GetServers()` with merge+dedup+fallback logic
- `internal/stun/resolver.go`: extract `StunClient` interface, add `newClient` factory for testability, implement server fallback loop
- `internal/stun/helper.go`: remove dead `ErrInvalidEndpoint` (superseded by per-server logging)
- `internal/config/stun_test.go`: 10 tests covering `GetServers()` unit cases and `Load()` backward compat integration
- `internal/stun/resolver_test.go`: 6 tests covering all fallback scenarios with inline mock

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all packages pass
- [ ] Config with only `stun.address` still works (backward compat)
- [ ] Config with `stun.addresses` list uses all servers in order
- [ ] Config with both fields merges correctly with dedup