### PR TITLE
build: select wireguard backend per platform

### DIFF
--- a/.github/actions/build-all-plugins/action.yml
+++ b/.github/actions/build-all-plugins/action.yml
@@ -25,8 +25,7 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
 
-    - name: Build All Plugins (Linux/Darwin)
-      if: inputs.os != 'freebsd'
+    - name: Build All Plugins
       shell: bash
       run: |
         # Unset APP to avoid conflicts with workflow-level env.APP
@@ -53,33 +52,3 @@ runs:
       env:
         GOARCH: ${{ inputs.arch }}
         GOOS: ${{ inputs.os }}
-
-    - name: Build All Plugins (FreeBSD)
-      if: inputs.os == 'freebsd'
-      uses: vmactions/freebsd-vm@v1
-      with:
-        arch: ${{ inputs.arch }}
-        sync: sshfs
-        prepare: |
-          # use latest instead of quarterly
-          cat /etc/pkg/FreeBSD.conf
-          pkg update -f
-          pkg upgrade -y
-
-          pkg install -y gmake go
-        run: |
-          cd $GITHUB_WORKSPACE
-          # Unset APP to avoid conflicts with workflow-level env.APP
-          unset APP
-          mkdir -p plugins_dist
-          for plugin_dir in contrib/*/; do
-            if [ -f "${plugin_dir}Makefile" ]; then
-              plugin_name=$(basename "$plugin_dir")
-              echo "Building plugin: $plugin_name"
-              cd "$plugin_dir"
-              gmake build
-              # Move built binary to output directory
-              mv stunmesh-* ../../plugins_dist/ 2>/dev/null || true
-              cd ../..
-            fi
-          done

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: 'Build variant (normal or extra-min)'
     required: false
     default: 'normal'
-  backend:
-    description: 'WireGuard backend (wgctrl or wgcli)'
-    required: false
-    default: 'wgctrl'
 
 outputs:
   binary-name:
@@ -43,9 +39,6 @@ runs:
         SUFFIX=""
         if [ "${{ inputs.variant }}" = "extra-min" ]; then
           SUFFIX="-upx"
-        fi
-        if [ "${{ inputs.backend }}" = "wgcli" ]; then
-          SUFFIX="${SUFFIX}-wgcli"
         fi
 
         if [ -n "${{ inputs.tag }}" ]; then
@@ -66,42 +59,16 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
 
-    - name: Install UPX (Linux/Darwin)
-      if: inputs.os != 'freebsd' && inputs.variant == 'extra-min'
+    - name: Install UPX
+      if: inputs.variant == 'extra-min'
       shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y upx-ucl
 
-    - name: Build (Linux/Darwin)
-      if: inputs.os != 'freebsd'
+    - name: Build
       shell: bash
       run: make APP=${{ steps.build-info.outputs.binary-name }} EXTRA_MIN=${{ steps.build-info.outputs.extra-min }}
       env:
         GOARCH: ${{ inputs.arch }}
         GOOS: ${{ inputs.os }}
-
-    - name: Build (FreeBSD wgctrl, CGO=1)
-      if: inputs.os == 'freebsd' && inputs.backend != 'wgcli'
-      uses: vmactions/freebsd-vm@v1
-      with:
-        arch: ${{ inputs.arch }}
-        sync: sshfs
-        prepare: |
-          # use latest instead of quarterly
-          cat /etc/pkg/FreeBSD.conf
-          pkg update -f
-          pkg upgrade -y
-
-          pkg install -y gmake go
-        run: |
-          cd $GITHUB_WORKSPACE
-          gmake APP=${{ steps.build-info.outputs.binary-name }}
-
-    - name: Build (FreeBSD wgcli, CGO=0)
-      if: inputs.os == 'freebsd' && inputs.backend == 'wgcli'
-      shell: bash
-      run: make APP=${{ steps.build-info.outputs.binary-name }} BACKEND=wgcli
-      env:
-        GOARCH: ${{ inputs.arch }}
-        GOOS: freebsd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
         os: [linux, darwin, freebsd]
         arch: [amd64, arm64, arm, mipsle]
         variant: [normal, extra-min]
-        backend: [wgctrl, wgcli]
         exclude:
           - os: darwin
             arch: arm
@@ -71,11 +70,6 @@ jobs:
             arch: mipsle
           - os: freebsd
             variant: extra-min
-          # wgcli backend only applies to freebsd
-          - os: linux
-            backend: wgcli
-          - os: darwin
-            backend: wgcli
     steps:
       - uses: actions/checkout@v6
       - name: Build
@@ -87,11 +81,35 @@ jobs:
           app-name: ${{ env.APP }}
           go-version: ${{ env.GO_VERSION }}
           variant: ${{ matrix.variant }}
-          backend: ${{ matrix.backend }}
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
+
+  # The only job running on real FreeBSD. It covers the two things the
+  # cross-compiled matrix cannot: the wgcli tests on the platform where wgcli is
+  # the default, and a compile check of wgctrl, which needs CGO and so cannot be
+  # cross-compiled. amd64 only — arm64 runs emulated and is far too slow.
+  freebsd:
+    name: FreeBSD (test + wgctrl build)
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test and build
+        uses: vmactions/freebsd-vm@v1
+        with:
+          arch: amd64
+          sync: sshfs
+          prepare: |
+            pkg update -f
+            pkg install -y gmake go
+          run: |
+            cd $GITHUB_WORKSPACE
+            gmake test
+            gmake build BACKEND=wgctrl
 
   build-plugins:
     name: Build Plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         os: [linux, darwin, freebsd]
         arch: [amd64, arm64, arm, mipsle]
         variant: [normal, extra-min]
-        backend: [wgctrl, wgcli]
         exclude:
           - os: darwin
             arch: arm
@@ -56,11 +55,6 @@ jobs:
             arch: mipsle
           - os: freebsd
             variant: extra-min
-          # wgcli backend only applies to freebsd
-          - os: linux
-            backend: wgcli
-          - os: darwin
-            backend: wgcli
     steps:
       - uses: actions/checkout@v6
       - name: tag
@@ -76,7 +70,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           tag: ${{ steps.tag.outputs.TAG }}
           variant: ${{ matrix.variant }}
-          backend: ${{ matrix.backend }}
       - name: Release
         uses: softprops/action-gh-release@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,22 @@ UPX ?= 0
 EXTRA_MIN ?= 0
 BUILTIN ?= all
 ALL_BUILTINS := builtin_cloudflare
-BACKEND ?= wgctrl
+# Empty selects the per-platform default from the internal/wg build constraints:
+# wgcli on freebsd, wgctrl elsewhere. Set to override.
+BACKEND ?=
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 
-# Validate BACKEND value
-ifeq ($(filter $(BACKEND),wgctrl wgcli),)
-    $(error BACKEND must be 'wgctrl' or 'wgcli', got '$(BACKEND)')
+# Validate BACKEND value. filter-out rejects unknown words, and the word count
+# rejects a contradictory 'wgctrl wgcli', which filter alone would accept.
+ifneq ($(BACKEND),)
+    ifneq ($(filter-out wgctrl wgcli,$(BACKEND))$(filter-out 1,$(words $(BACKEND))),)
+        $(error BACKEND must be 'wgctrl' or 'wgcli', got '$(BACKEND)')
+    endif
 endif
 
-# Platforms that require CGO_ENABLED=1 (only wgctrl backend on freebsd)
+# Platforms whose wgctrl backend requires CGO_ENABLED=1. They default to wgcli,
+# so this only applies when wgctrl is explicitly requested.
 CGO_REQUIRED_PLATFORMS := freebsd
 
 ifneq ($(EXTRA_MIN),0)
@@ -43,14 +49,9 @@ ifeq ($(BUILTIN),all)
 	override BUILTIN := $(ALL_BUILTINS)
 endif
 
-# Backend build tag: wgcli selects the wg-CLI shelling backend
-BACKEND_TAG :=
-ifeq ($(BACKEND),wgcli)
-	BACKEND_TAG := wgcli
-endif
-
-# Combine BUILTIN and BACKEND tags
-ALL_TAGS := $(strip $(BUILTIN) $(BACKEND_TAG))
+# Combine BUILTIN and BACKEND tags. An empty BACKEND adds no tag, leaving the
+# backend choice to the build constraints in internal/wg.
+ALL_TAGS := $(strip $(BUILTIN) $(BACKEND))
 TAGS_FLAGS = $(if $(ALL_TAGS),-tags '$(ALL_TAGS)',)
 
 UPX_TARGET =
@@ -58,12 +59,15 @@ ifneq ($(UPX),0)
 	UPX_TARGET = upx
 endif
 
-# Set CGO_ENABLED: forced off when BACKEND=wgcli; otherwise platform default
-ifeq ($(BACKEND),wgcli)
-	CGO_ENABLED = 0
-else ifeq ($(GOOS),$(filter $(GOOS),$(CGO_REQUIRED_PLATFORMS)))
-	CGO_ENABLED = 1
-	LDFLAGS := ${LDFLAGS} -extldflags="-static"
+# Set CGO_ENABLED: only an explicit wgctrl on CGO_REQUIRED_PLATFORMS needs it,
+# so every default build is CGO-free.
+ifeq ($(BACKEND),wgctrl)
+	ifeq ($(GOOS),$(filter $(GOOS),$(CGO_REQUIRED_PLATFORMS)))
+		CGO_ENABLED = 1
+		LDFLAGS := ${LDFLAGS} -extldflags="-static"
+	else
+		CGO_ENABLED = 0
+	endif
 else
 	CGO_ENABLED = 0
 endif

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ For best results, ensure at least one peer is behind a cone NAT type.
 
 - **Linux** (amd64, arm, arm64, mipsle) - Normal and UPX-compressed binaries
 - **macOS** (amd64, arm64) - Normal binaries only
-- **FreeBSD** (amd64, arm64) - Normal binaries only
+- **FreeBSD** (amd64, arm64) - Normal binaries only, requires `wireguard-tools`
+
+> [!IMPORTANT]
+> FreeBSD binaries use the `wgcli` backend, which invokes `wg(8)`. The base system ships the
+> `if_wg` kernel module but not that tool, so `pkg install wireguard-tools` is required.
+> See [Backend Selection](#backend-selection).
 
 > [!NOTE]
 > We only support wireguard-go in MacOS, Wireguard App store version is not supported because of sandbox currently.
@@ -35,7 +40,7 @@ For best results, ensure at least one peer is behind a cone NAT type.
 - VyOS 2025.07.14-0022-rolling (built-in Wireguard kernel module)
 - Ubuntu with Wireguard in Kernel module
 - macOS Wireguard-go 0.0.20230223, Wireguard-tools 1.0.20210914
-- FreeBSD 14.3-RELEASE (built-in Wireguard)
+- FreeBSD 14.3-RELEASE (built-in Wireguard kernel module, with wireguard-tools installed)
 - OPNsense 25.1 (built-in Wireguard)
 - EdgeRouter X (EdgeOS 3.0.0)
 
@@ -107,8 +112,7 @@ make all BUILTIN=builtin_cloudflare EXTRA_MIN=1
 ```
 
 **Platform-Specific Notes:**
-- CGO is automatically enabled for FreeBSD (required for this platform)
-- CGO is disabled by default for Linux and Darwin (produces static binaries)
+- CGO is disabled for all default builds, on every platform (produces static binaries). See [Backend Selection](#backend-selection) for the one case that needs it
 - UPX compression significantly reduces binary size but requires the `upx` tool to be installed
 
 **Release Binaries:**
@@ -118,31 +122,41 @@ make all BUILTIN=builtin_cloudflare EXTRA_MIN=1
 
 ### Backend Selection
 
-stunmesh-go supports two WireGuard backends, selectable at build time via the `BACKEND` variable:
+stunmesh-go supports two WireGuard backends:
 
-- `wgctrl` (default): Uses [`wgctrl-go`](https://github.com/WireGuard/wgctrl-go) to talk to the kernel WireGuard interface directly. Requires CGO on FreeBSD.
-- `wgcli`: Shells out to the `wg` command-line tool. Builds with `CGO_ENABLED=0` on all platforms, including FreeBSD cross-compilation from Linux without a sysroot.
+- `wgctrl`: Uses [`wgctrl-go`](https://github.com/WireGuard/wgctrl-go) to talk to the kernel WireGuard interface directly. Requires CGO on FreeBSD.
+- `wgcli`: Shells out to the `wg` command-line tool. Builds with `CGO_ENABLED=0` on all platforms.
 
-**When to choose `BACKEND=wgcli`:**
+Each platform selects its own default, so a plain `make build` or `go build` needs no configuration:
 
-- Cross-compiling for FreeBSD from any host without setting up CGO toolchains
-- Running userspace wireguard-go where direct `wgctrl` socket access is restricted
-- Any environment where invoking the `wg` binary is preferable to direct kernel ioctl calls
+| Platform | Default backend | CGO |
+| --- | --- | --- |
+| Linux, macOS | `wgctrl` | disabled |
+| FreeBSD | `wgcli` | disabled |
 
-**Build examples:**
+FreeBSD defaults to `wgcli` because its `wgctrl` support requires CGO, which cannot be cross-compiled without a sysroot. Every released binary is therefore `CGO_ENABLED=0`.
 
-```bash
-make build BACKEND=wgcli
-make build BACKEND=wgcli GOOS=freebsd GOARCH=amd64   # FreeBSD cross-compile from Linux, no sysroot
+**Runtime requirement on FreeBSD:** because the default backend is `wgcli`, the `wg` command must be installed and available in `PATH`:
+
+```console
+# pkg install wireguard-tools
 ```
 
-**Runtime requirement for `BACKEND=wgcli`:** the `wg` command must be installed and available in `PATH`:
+On Linux and macOS the default needs no such tool: `wgctrl` speaks netlink on Linux and the
+userspace wireguard-go socket protocol on macOS, both in pure Go. There is no reason to select
+`wgcli` on those platforms, and it is neither tested nor supported there.
 
-- Linux: install the `wireguard-tools` package
-- FreeBSD: `pkg install wireguard-tools`
-- macOS: `brew install wireguard-tools`
+**Overriding the default** with the `BACKEND` variable:
 
-The default remains `wgctrl`, so existing users do not need to change anything.
+```bash
+make build BACKEND=wgctrl    # force wgctrl; on FreeBSD this needs CGO and a native toolchain
+```
+
+Building `BACKEND=wgctrl` on FreeBSD must be done natively (`gmake BACKEND=wgctrl`) — it cannot be
+cross-compiled from Linux, and it is not part of any release.
+
+If you build directly with `go build` instead of `make`, the same defaults apply; override with
+`-tags wgctrl`.
 
 ## Usage
 

--- a/internal/wg/client_cli.go
+++ b/internal/wg/client_cli.go
@@ -1,4 +1,4 @@
-//go:build wgcli
+//go:build wgcli || (freebsd && !wgctrl)
 
 package wg
 
@@ -34,6 +34,11 @@ func defaultRunner(ctx context.Context, name string, args ...string) ([]byte, er
 }
 
 func New() (Client, error) {
+	// Fail at startup rather than once per refresh: this backend is useless
+	// without wg(8), and the bootstrap controller only logs device errors.
+	if _, err := exec.LookPath("wg"); err != nil {
+		return nil, fmt.Errorf("wg command not found in PATH, install wireguard-tools: %w", err)
+	}
 	return &cliClient{runner: defaultRunner}, nil
 }
 

--- a/internal/wg/client_cli_test.go
+++ b/internal/wg/client_cli_test.go
@@ -1,4 +1,4 @@
-//go:build wgcli
+//go:build wgcli || (freebsd && !wgctrl)
 
 package wg
 

--- a/internal/wg/client_ctrl.go
+++ b/internal/wg/client_ctrl.go
@@ -1,4 +1,4 @@
-//go:build !wgcli
+//go:build !wgcli && (wgctrl || !freebsd)
 
 package wg
 


### PR DESCRIPTION
## Why

FreeBSD's `wgctrl` support requires CGO, so releasing it meant building inside a `vmactions/freebsd-vm` — the reason release runs took ~33 minutes. This moves the backend choice into the `internal/wg` build constraints so every released binary is `CGO_ENABLED=0` and cross-compiled, and the VM drops out of the release path.

## What changed

**Backend defaulting is now Go's job, not the Makefile's.** A plain `go build` or `go install` picks the right backend, not just `make`:

| file | constraint | linux/darwin | freebsd |
| --- | --- | --- | --- |
| `client_cli.go` | `wgcli \|\| (freebsd && !wgctrl)` | off | **on** (default) |
| `client_ctrl.go` | `!wgcli && (wgctrl \|\| !freebsd)` | **on** (default) | off |

Exactly one compiles in every GOOS × tag combination; `-tags wgcli`/`-tags wgctrl` still override.

- **Makefile**: `BACKEND` is empty by default and only *overrides*; it no longer duplicates the platform-default logic. CGO is enabled solely for an explicit `BACKEND=wgctrl` on freebsd. Validation now rejects a contradictory `BACKEND="wgctrl wgcli"`, which `$(filter)` alone accepted.
- **CI**: the `backend` matrix dimension and the `-wgcli` asset suffix are gone — one binary per os/arch, all CGO-free. The freebsd-vm is removed from both the main binary and the plugin builds (contrib plugins are pure Go and cross-compile fine).
- **New `freebsd` job**: the one thing cross-compiling can't cover. Runs `gmake test` (freebsd's default *is* wgcli, so this tests wgcli natively on the platform where it ships — it was never tested before) and `gmake build BACKEND=wgctrl` for compile coverage, so a dependabot wgctrl bump can't break it silently. amd64 only; arm64 is emulated and too slow to be worth it.
- **Fail fast**: `wgcli`'s `New()` now checks `exec.LookPath("wg")`. Without it, `BootstrapController` only logged the device error and carried on, leaving a live daemon with zero devices registered and tunnels quietly going stale after NAT mappings expired. Now it dies at startup with `wg command not found in PATH, install wireguard-tools`.
- **README**: documents the new defaults, and drops the claim that `wgcli` is useful on Linux/macOS. It isn't — `wgctrl` is pure Go on both, and on macOS it *is* the userspace wireguard-go socket client, hitting the same `/var/run/wireguard/*.sock` as `wg(8)` with the same UAPI. That rationale was an editing artifact.

## Breaking changes

- **FreeBSD binaries now require `wireguard-tools`** (`pkg install wireguard-tools`). The base system ships the `if_wg` kernel module but not `wg(8)`. The asset name is unchanged, so an in-place upgrade will now fail at startup — loudly, by design.
- **The `-wgcli` suffixed assets are gone.** v1.7.0 published them; anything pinning that URL needs the unsuffixed name, which is now the wgcli build.
- `BACKEND=wgctrl` on FreeBSD is no longer released and must be built natively (`gmake BACKEND=wgctrl`).

## Verification

- Build constraints: all 9 GOOS × tag combinations resolve to exactly one backend.
- `make build` for linux/darwin/freebsd all cross-compile; the freebsd binary is a statically linked FreeBSD ELF built from Linux.
- `make test` and `go vet` pass for both the linux default and the freebsd default; every package's tests compile for freebsd.
- Drove the binary end-to-end: starts normally with `wg` present; panics at startup with the actionable message when `wg` is absent.
- CGO=0 vs CGO=1 on freebsd differ only by `runtime/cgo` — `go-pcap` is pure Go, so CGO is needed only by `wgctrl-go`'s `wgfreebsd`.

## Follow-ups (not in this PR)

- Peers are filtered only at bootstrap and `repo.Peers` has no delete, so `EstablishController` works from a stale list every tick. This is why `freebsd + wgctrl` never had phantom-peer protection — `wgfreebsd` returns `ErrUpdateOnlyNotSupported`, which is what forced `update_only_freebsd.go` to `false`. Fixing it in the controller would cover every backend at once.
- `GOOS=openbsd` fails to compile (`undefined: UpdateOnly`). Latent — OpenBSD was deliberately dropped in v1.7.0 and is referenced nowhere in CI or docs.