### PR TITLE
ci: bump actions/checkout to v7 and track actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,12 @@ updates:
       - "/contrib/**"
     schedule:
       interval: "weekly"
+
+  # "/" only covers .github/workflows. The composite actions each need their own
+  # directory, and that is where golangci-lint-action and the docker actions live.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/**"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     name: Codegen
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Lint
         uses: ./.github/actions/lint
         with:
@@ -40,7 +40,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Test
         uses: ./.github/actions/test
         with:
@@ -71,7 +71,7 @@ jobs:
           - os: freebsd
             variant: extra-min
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build
         uses: ./.github/actions/build
         id: build
@@ -97,7 +97,7 @@ jobs:
       - lint
       - test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Test and build
         uses: vmactions/freebsd-vm@v1
         with:
@@ -131,7 +131,7 @@ jobs:
           - os: freebsd
             arch: mipsle
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build All Plugins
         uses: ./.github/actions/build-all-plugins
         id: build-plugins
@@ -153,7 +153,7 @@ jobs:
       - lint
       - test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build and Push Docker
         uses: ./.github/actions/docker
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Lint
         uses: ./.github/actions/lint
         with:
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Test
         uses: ./.github/actions/test
         with:
@@ -56,7 +56,7 @@ jobs:
           - os: freebsd
             variant: extra-min
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: tag
         id: tag
         run: echo "TAG=$(git describe --tags --dirty)" >> "$GITHUB_OUTPUT"
@@ -103,7 +103,7 @@ jobs:
           - os: freebsd
             arch: mipsle
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: tag
         id: tag
         run: echo "TAG=$(git describe --tags --dirty)" >> "$GITHUB_OUTPUT"
@@ -141,7 +141,7 @@ jobs:
       - lint
       - test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build and Push Docker
         uses: ./.github/actions/docker
         with:


### PR DESCRIPTION
## What changed

**`actions/checkout` v6 → v7** (12 occurrences). It was the only action behind a major — the other ten are already on their latest:

| action | current | latest |
| --- | --- | --- |
| `actions/checkout` | v6 | **v7.0.0** ← bumped |
| `actions/setup-go` | v6 | v6.5.0 |
| `actions/upload-artifact` | v7 | v7.0.1 |
| `softprops/action-gh-release` | v3 | v3.0.2 |
| `vmactions/freebsd-vm` | v1 | v1.5.0 |
| `golangci/golangci-lint-action` | v9 | v9.3.0 |
| `docker/*` (5 actions) | v4–v7 | all current |

v7.0.0 is a stable release (not a prerelease) and the `v7` major tag exists. Its one breaking change blocks checking out fork PRs for `pull_request_target` and `workflow_run` — this repo uses neither, only `pull_request` and `push`.

**Dependabot now tracks actions too.** The versions drifted in the first place because `dependabot.yml` only watched `gomod`, which is why the Go modules stay current on their own while actions need doing by hand.

The glob matters here. Per [dependabot-core's file fetcher](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_fetcher.rb), `directory: "/"` fetches only `.github/workflows/*.yml` plus a **root** `action.yml`. Most of this repo's third-party actions live in composite actions instead:

| location | actions |
| --- | --- |
| workflows (covered by `/`) | `checkout`, `setup-go`, `upload-artifact`, `freebsd-vm`, `action-gh-release` |
| `.github/actions/*/action.yml` (**needs the glob**) | `golangci-lint-action`, the five `docker/*` actions, `setup-go` |

So `/` alone would have left `golangci-lint-action` and every docker action unmanaged. `/.github/actions/**` covers all six composite action directories, and matches the style of the existing `/contrib/**` gomod entry.

## Notes

- Glob expansion happens service-side, so `*` vs `**` semantics aren't verifiable from dependabot-core; both behave identically for the current one-level layout, and `**` also covers any future nesting.
- A matched directory with no manifest is skipped rather than failing the job ([file_fetcher_command.rb](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/file_fetcher_command.rb): "surfaced downstream as skipped snapshots rather than aborting the whole job").