### PR TITLE
feat: add per-plugin dedup to skip unchanged endpoint publishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ plugins:
     type: exec
     command: /usr/local/bin/stunmesh-cloudflare
     args: ["-zone", "example.com", "-token", "${CLOUDFLARE_API_TOKEN}"]
+    dedup: true  # Optional, default false: skip store.Set when the peer's endpoint is unchanged
 
 interfaces:
   wg0:
@@ -150,6 +151,10 @@ Four main controllers orchestrate the application workflow:
    - Encrypts entire endpoint JSON (`{"ipv4": "...", "ipv6": "..."}`) and stores via plugins
    - Each peer uses its designated plugin instance
    - Logs discovered endpoints for debugging
+   - **Deduplication (`dedup`)**: per-plugin-instance boolean config option, default `false`
+     - When the peer's plugin instance has `dedup: true` and the plaintext endpoint JSON is unchanged since the last successful publish for that peer, `store.Set` is skipped
+     - When `dedup` is `false` (default), every peer is published every refresh cycle, unchanged from prior behavior
+     - **Do not enable `dedup` for storage backends with expiring/TTL values** (e.g. a short-TTL DHT) — skipping the write lets the value expire since there is no other mechanism to refresh it; only use `dedup` with persistent backends (e.g. Cloudflare DNS, GitHub Gist) where a written value stays until overwritten
 
 3. **EstablishController** (`internal/ctrl/establish.go`):
    - Retrieves peer endpoint data from storage plugins

--- a/README.md
+++ b/README.md
@@ -384,6 +384,28 @@ stunmesh-go supports three plugin types. **All are fully supported and productio
   - Simple integration with existing shell tools
 - Best for: Simple shell scripts without complex data handling
 
+#### Deduplication (`dedup`)
+
+Any plugin instance can set `dedup: true` to skip re-publishing a peer's endpoint when it hasn't changed since the last successful publish:
+
+- Type: boolean, default: `false`
+- Set inside the plugin instance block, alongside `type` (applies to all peers using that plugin instance)
+- The comparison is done on the plaintext endpoint (`{"ipv4": "...", "ipv6": "..."}`), not the stored ciphertext, so it correctly detects "no change" even though the encrypted value differs on every publish (a fresh nonce is used each time)
+- When enabled and the endpoint is unchanged, the storage write (`store.Set`) is skipped for that peer, reducing API calls and, for revision-tracking backends like a GitHub Gist, avoiding piling up unnecessary revisions
+- When disabled (the default), behavior is unchanged: every peer is published on every refresh cycle
+
+```yaml
+plugins:
+  cf_builtin:
+    type: builtin
+    name: cloudflare
+    zone: example.com
+    token: your_api_token_here
+    dedup: true  # Skip re-publishing when the endpoint hasn't changed
+```
+
+**Note: Do not enable `dedup` for backends whose stored values expire or have a TTL (e.g. a DHT with a short TTL).** Those backends rely on periodic re-publishing to keep the value alive; if `dedup` skips the write, the value can expire and peers will fail to discover the endpoint. Only enable `dedup` for persistent backends (e.g. Cloudflare DNS, GitHub Gist, a durable KV store) where a written value remains until explicitly overwritten.
+
 **Built-in Plugin Configuration Example:**
 ```yaml
 plugins:

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -30,6 +30,12 @@ type PublishController struct {
 	logger        zerolog.Logger
 	triggerQueue  *queue.Queue[struct{}]      // Trigger queue for full publish
 	peerQueue     *queue.Queue[entity.PeerId] // Trigger queue for specific peer
+
+	// lastPublished remembers the plaintext endpoint JSON last successfully
+	// published for each peer, keyed by peer.LocalId(). It is only read and
+	// written from Execute/ExecuteForPeer, both of which are driven
+	// sequentially from the single Run() goroutine, so no mutex is needed.
+	lastPublished map[string]string
 }
 
 func NewPublishController(devices DeviceRepository, peers PeerRepository, pluginManager *plugin.Manager, resolver StunResolver, encryptor EndpointEncryptor, deviceConfig DeviceConfigProvider, logger *zerolog.Logger) *PublishController {
@@ -43,6 +49,7 @@ func NewPublishController(devices DeviceRepository, peers PeerRepository, plugin
 		logger:        logger.With().Str("controller", "publish").Logger(),
 		triggerQueue:  queue.NewBuffered[struct{}](queue.TriggerQueueSize), // Buffered trigger queue
 		peerQueue:     queue.NewBuffered[entity.PeerId](queue.PeerQueueSize), // Buffered peer queue
+		lastPublished: make(map[string]string),
 	}
 }
 
@@ -165,6 +172,14 @@ func (c *PublishController) Execute(ctx context.Context) {
 				continue
 			}
 
+			// Skip publishing if the plaintext endpoint hasn't changed since
+			// the last successful publish for this peer, and the peer's
+			// plugin instance has dedup enabled.
+			if c.pluginManager.IsDedup(peer.Plugin()) && c.lastPublished[peer.LocalId()] == string(jsonPlain) {
+				logger.Debug().Msg("endpoint unchanged, skip publish")
+				continue
+			}
+
 			// Encrypt entire JSON content
 			res, err := c.encryptor.Encrypt(ctx, &EndpointEncryptRequest{
 				PeerPublicKey: peer.PublicKey(),
@@ -189,6 +204,8 @@ func (c *PublishController) Execute(ctx context.Context) {
 				logger.Error().Err(err).Msg("failed to store endpoint")
 				continue
 			}
+
+			c.lastPublished[peer.LocalId()] = string(jsonPlain)
 		}
 	}
 }
@@ -238,6 +255,14 @@ func (c *PublishController) ExecuteForPeer(ctx context.Context, peerId entity.Pe
 		return
 	}
 
+	// Skip publishing if the plaintext endpoint hasn't changed since the
+	// last successful publish for this peer, and the peer's plugin
+	// instance has dedup enabled.
+	if c.pluginManager.IsDedup(peer.Plugin()) && c.lastPublished[peer.LocalId()] == string(jsonPlain) {
+		logger.Debug().Msg("endpoint unchanged, skip publish")
+		return
+	}
+
 	// Encrypt entire JSON content
 	res, err := c.encryptor.Encrypt(ctx, &EndpointEncryptRequest{
 		PeerPublicKey: peer.PublicKey(),
@@ -263,6 +288,8 @@ func (c *PublishController) ExecuteForPeer(ctx context.Context, peerId entity.Pe
 		logger.Error().Err(err).Msg("failed to store endpoint for specific peer")
 		return
 	}
+
+	c.lastPublished[peer.LocalId()] = string(jsonPlain)
 
 	logger.Info().Msg("successfully published endpoint for specific peer")
 }

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -11,8 +11,55 @@ import (
 	mock "github.com/tjjh89017/stunmesh-go/internal/ctrl/mock"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
+	"github.com/tjjh89017/stunmesh-go/pluginapi"
 	"go.uber.org/mock/gomock"
 )
+
+// fakeDedupStore is a minimal pluginapi.Store used to observe how many
+// times Set/Get are invoked, without needing to fake encryption.
+type fakeDedupStore struct {
+	setCalls int
+	getCalls int
+}
+
+func (f *fakeDedupStore) Get(ctx context.Context, key string) (string, error) {
+	f.getCalls++
+	return "", nil
+}
+
+func (f *fakeDedupStore) Set(ctx context.Context, key string, value string) error {
+	f.setCalls++
+	return nil
+}
+
+// newDedupTestManager builds a real *plugin.Manager with a single "builtin"
+// plugin instance named "test_plugin" backed by a fakeDedupStore, with
+// dedup configured as requested. Using the real Manager (instead of a mock)
+// exercises the actual IsDedup() lookup path.
+func newDedupTestManager(t *testing.T, builtinName string, dedup bool) (*plugin.Manager, *fakeDedupStore) {
+	t.Helper()
+
+	store := &fakeDedupStore{}
+	plugin.RegisterBuiltin(builtinName, func(config pluginapi.PluginConfig) (pluginapi.Store, error) {
+		return store, nil
+	})
+
+	m := plugin.NewManager()
+	err := m.LoadPlugins(context.Background(), map[string]pluginapi.PluginDefinition{
+		"test_plugin": {
+			Type: "builtin",
+			Config: pluginapi.PluginConfig{
+				"name":  builtinName,
+				"dedup": dedup,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to load test plugin: %v", err)
+	}
+
+	return m, store
+}
 
 // Helper function to create test device
 func createTestDevice(name string, port int, protocol string) *entity.Device {
@@ -563,6 +610,158 @@ func TestPublishController_ExecuteForPeer_Success(t *testing.T) {
 	)
 
 	controller.ExecuteForPeer(ctx, peerId)
+}
+
+// Test Execute with dedup ON and a changed endpoint - should publish every time
+func TestPublishController_Execute_Dedup_ChangedEndpoint_Publishes(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_changed", true)
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
+
+	// Two calls, two different resolved endpoints.
+	gomock.InOrder(
+		mockResolver.EXPECT().
+			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Return("1.2.3.4", 51820, nil),
+		mockResolver.EXPECT().
+			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Return("5.6.7.8", 51820, nil),
+	)
+
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(2)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.Execute(ctx)
+	controller.Execute(ctx)
+
+	if store.setCalls != 2 {
+		t.Errorf("store.Set call count = %d, want 2 (endpoint changed between calls)", store.setCalls)
+	}
+}
+
+// Test Execute with dedup ON and an unchanged endpoint - second publish should be skipped
+func TestPublishController_Execute_Dedup_UnchangedEndpoint_Skips(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_unchanged", true)
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
+
+	// Same endpoint resolved both times.
+	mockResolver.EXPECT().
+		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Return("1.2.3.4", 51820, nil).
+		Times(2)
+
+	// Encrypt must only happen on the first (non-duplicate) publish.
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(1)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.Execute(ctx)
+	controller.Execute(ctx)
+
+	if store.setCalls != 1 {
+		t.Errorf("store.Set call count = %d, want 1 (second publish should be deduped)", store.setCalls)
+	}
+}
+
+// Test Execute with dedup OFF (default) and an unchanged endpoint - should publish every time
+func TestPublishController_Execute_Dedup_OffByDefault_AlwaysPublishes(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_off", false)
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
+
+	// Same endpoint resolved both times.
+	mockResolver.EXPECT().
+		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Return("1.2.3.4", 51820, nil).
+		Times(2)
+
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(2)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.Execute(ctx)
+	controller.Execute(ctx)
+
+	if store.setCalls != 2 {
+		t.Errorf("store.Set call count = %d, want 2 (dedup disabled, default behavior unchanged)", store.setCalls)
+	}
 }
 
 // Test Trigger - should not panic

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -20,6 +20,11 @@ import (
 type fakeDedupStore struct {
 	setCalls int
 	getCalls int
+
+	// setErr, if non-nil, is returned by the next Set call and then cleared,
+	// so it simulates a single transient storage failure without affecting
+	// subsequent calls.
+	setErr error
 }
 
 func (f *fakeDedupStore) Get(ctx context.Context, key string) (string, error) {
@@ -29,6 +34,11 @@ func (f *fakeDedupStore) Get(ctx context.Context, key string) (string, error) {
 
 func (f *fakeDedupStore) Set(ctx context.Context, key string, value string) error {
 	f.setCalls++
+	if f.setErr != nil {
+		err := f.setErr
+		f.setErr = nil
+		return err
+	}
 	return nil
 }
 
@@ -761,6 +771,173 @@ func TestPublishController_Execute_Dedup_OffByDefault_AlwaysPublishes(t *testing
 
 	if store.setCalls != 2 {
 		t.Errorf("store.Set call count = %d, want 2 (dedup disabled, default behavior unchanged)", store.setCalls)
+	}
+}
+
+// Test ExecuteForPeer with dedup ON and an unchanged endpoint - second call
+// should skip both encryption and storage.
+func TestPublishController_ExecuteForPeer_Dedup_UnchangedEndpoint_Skips(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_peer_unchanged", true)
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+	publicKey := peer.PublicKey()
+	peerId := entity.NewPeerId(make([]byte, 32), publicKey[:])
+
+	mockPeers.EXPECT().Find(ctx, peerId).Return(peer, nil).Times(2)
+	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil).Times(2)
+
+	// Same endpoint resolved both times.
+	mockResolver.EXPECT().
+		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Return("1.2.3.4", 51820, nil).
+		Times(2)
+
+	// Encrypt must only happen on the first (non-duplicate) publish; a
+	// second Encrypt call would fail the test via gomock's unmet/overrun
+	// expectation check.
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(1)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.ExecuteForPeer(ctx, peerId)
+	controller.ExecuteForPeer(ctx, peerId)
+
+	if store.setCalls != 1 {
+		t.Errorf("store.Set call count = %d, want 1 (second publish should be deduped)", store.setCalls)
+	}
+}
+
+// Test ExecuteForPeer with dedup ON and a changed endpoint - should publish
+// every time.
+func TestPublishController_ExecuteForPeer_Dedup_ChangedEndpoint_Publishes(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_peer_changed", true)
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+	publicKey := peer.PublicKey()
+	peerId := entity.NewPeerId(make([]byte, 32), publicKey[:])
+
+	mockPeers.EXPECT().Find(ctx, peerId).Return(peer, nil).Times(2)
+	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil).Times(2)
+
+	// Two calls, two different resolved endpoints.
+	gomock.InOrder(
+		mockResolver.EXPECT().
+			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Return("1.2.3.4", 51820, nil),
+		mockResolver.EXPECT().
+			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Return("5.6.7.8", 51820, nil),
+	)
+
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(2)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.ExecuteForPeer(ctx, peerId)
+	controller.ExecuteForPeer(ctx, peerId)
+
+	if store.setCalls != 2 {
+		t.Errorf("store.Set call count = %d, want 2 (endpoint changed between calls)", store.setCalls)
+	}
+}
+
+// Test that a failed store.Set is not cached as a successful publish, so a
+// retry with the identical endpoint still attempts to store again instead
+// of being deduped.
+func TestPublishController_Execute_Dedup_FailedStore_DoesNotCacheAndRetries(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager, store := newDedupTestManager(t, "dedup_test_failed_store", true)
+	// The first Set call fails; the second (retry) succeeds.
+	store.setErr = errors.New("store unavailable")
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
+
+	// Same endpoint resolved both times.
+	mockResolver.EXPECT().
+		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Return("1.2.3.4", 51820, nil).
+		Times(2)
+
+	// Encrypt runs on both attempts: since the first store.Set failed,
+	// lastPublished was never updated, so the second Execute call (with the
+	// identical endpoint) is not deduped and retries the full publish.
+	mockEncryptor.EXPECT().
+		Encrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil).
+		Times(2)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	controller.Execute(ctx)
+	controller.Execute(ctx)
+
+	if store.setCalls != 2 {
+		t.Errorf("store.Set call count = %d, want 2 (failed publish must not be cached as success)", store.setCalls)
 	}
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -9,11 +9,13 @@ import (
 
 type Manager struct {
 	plugins map[string]pluginapi.Store
+	dedup   map[string]bool
 }
 
 func NewManager() *Manager {
 	return &Manager{
 		plugins: make(map[string]pluginapi.Store),
+		dedup:   make(map[string]bool),
 	}
 }
 
@@ -24,6 +26,7 @@ func (m *Manager) LoadPlugins(ctx context.Context, definitions map[string]plugin
 			return fmt.Errorf("failed to create plugin %s: %w", name, err)
 		}
 		m.plugins[name] = store
+		m.dedup[name] = parseDedup(def.Config["dedup"])
 	}
 	return nil
 }
@@ -34,6 +37,26 @@ func (m *Manager) GetPlugin(name string) (pluginapi.Store, error) {
 		return nil, fmt.Errorf("plugin %s not found", name)
 	}
 	return store, nil
+}
+
+// IsDedup reports whether the named plugin instance has dedup enabled.
+// Unknown plugin names return false.
+func (m *Manager) IsDedup(name string) bool {
+	return m.dedup[name]
+}
+
+// parseDedup coerces a raw config value into a dedup flag. It accepts a
+// real bool, or a string such as "true"/"1" (e.g. from a viper env
+// override). Anything else, including an absent value (nil), is false.
+func parseDedup(value interface{}) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	default:
+		return false
+	}
 }
 
 func (m *Manager) createPlugin(ctx context.Context, def pluginapi.PluginDefinition) (pluginapi.Store, error) {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -152,6 +152,82 @@ func TestLoadPlugins_InvalidPluginConfig(t *testing.T) {
 	}
 }
 
+func TestIsDedup_DefaultsToFalseWhenNotSet(t *testing.T) {
+	m := NewManager()
+	ctx := context.Background()
+
+	definitions := map[string]pluginapi.PluginDefinition{
+		"test_plugin": {
+			Type: "shell",
+			Config: pluginapi.PluginConfig{
+				"command": "/bin/true",
+			},
+		},
+	}
+
+	if err := m.LoadPlugins(ctx, definitions); err != nil {
+		t.Fatalf("LoadPlugins() unexpected error: %v", err)
+	}
+
+	if got := m.IsDedup("test_plugin"); got != false {
+		t.Errorf("IsDedup() = %v, want false when dedup is not set", got)
+	}
+}
+
+func TestIsDedup_TrueWhenConfigured(t *testing.T) {
+	m := NewManager()
+	ctx := context.Background()
+
+	definitions := map[string]pluginapi.PluginDefinition{
+		"test_plugin": {
+			Type: "shell",
+			Config: pluginapi.PluginConfig{
+				"command": "/bin/true",
+				"dedup":   true,
+			},
+		},
+	}
+
+	if err := m.LoadPlugins(ctx, definitions); err != nil {
+		t.Fatalf("LoadPlugins() unexpected error: %v", err)
+	}
+
+	if got := m.IsDedup("test_plugin"); got != true {
+		t.Errorf("IsDedup() = %v, want true when dedup: true is configured", got)
+	}
+}
+
+func TestIsDedup_StringCoercion(t *testing.T) {
+	m := NewManager()
+	ctx := context.Background()
+
+	definitions := map[string]pluginapi.PluginDefinition{
+		"test_plugin": {
+			Type: "shell",
+			Config: pluginapi.PluginConfig{
+				"command": "/bin/true",
+				"dedup":   "true",
+			},
+		},
+	}
+
+	if err := m.LoadPlugins(ctx, definitions); err != nil {
+		t.Fatalf("LoadPlugins() unexpected error: %v", err)
+	}
+
+	if got := m.IsDedup("test_plugin"); got != true {
+		t.Errorf("IsDedup() = %v, want true when dedup: \"true\" (string) is configured", got)
+	}
+}
+
+func TestIsDedup_UnknownPluginReturnsFalse(t *testing.T) {
+	m := NewManager()
+
+	if got := m.IsDedup("nonexistent"); got != false {
+		t.Errorf("IsDedup() = %v, want false for unknown plugin name", got)
+	}
+}
+
 func TestCreatePlugin_SwitchCoverage(t *testing.T) {
 	m := NewManager()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Adds an optional per-plugin-instance `dedup` flag. When a plugin instance sets `dedup: true` (default `false`), `PublishController` skips re-publishing a peer's endpoint (skips `store.Set`) while that peer's **plaintext** endpoint is unchanged since the last successful publish.

Motivation: avoid redundant writes to the storage backend when the discovered endpoint hasn't changed — fewer API calls, and for git-history-style backends (e.g. GitHub Gist) it avoids piling up a revision on every refresh cycle.

## Design

- **Config toggle, per plugin instance** (`dedup: bool`, default `false`). No new config plumbing needed — `PluginDefinition.Config` already captures it via mapstructure `,remain`; the `Manager` reads `def.Config["dedup"]` and exposes `IsDedup(name) bool`.
- **Skip decision lives in the controller.** It records the last successfully-published plaintext endpoint JSON per peer and, when the peer's plugin has `dedup` enabled and the endpoint is unchanged, skips both encryption and `store.Set`.
- **Compares plaintext, not ciphertext.** NaCl box uses a fresh nonce each time, so the stored ciphertext always differs; only the plaintext comparison can detect "no change".
- **Zero breaking change.** The `pluginapi.Store` interface and the exec (JSON) / shell (env) wire protocols are untouched. `NewPublishController`'s signature is unchanged (the state map is internal). With `dedup` at its default `false`, behavior is byte-for-byte identical to before.
- The last-published value is updated **only after `store.Set` succeeds**, so a failed write retries on the next cycle.

## Behavior

| Backend value semantics | Recommended `dedup` |
|---|---|
| Persistent (Cloudflare DNS, GitHub Gist, durable KV) | `true` — safe, saves redundant writes |
| Expiring / TTL (e.g. a short-TTL DHT) | **`false`** — the periodic re-publish is what keeps the value alive; skipping it would let the value expire |

⚠️ Do not enable `dedup` for storage backends whose values expire. Documented in README.md and CLAUDE.md.

## Tests

`internal/ctrl/publish_test.go` (real `plugin.Manager` + stub `Store`, call-count assertions):
- changed endpoint → publishes
- unchanged + dedup on → skips (`store.Set` not called again)
- unchanged + dedup off (default) → always publishes (proves default behavior unchanged)
- `ExecuteForPeer` path: skip when unchanged, publish when changed
- failed `store.Set` is not cached → retries next cycle

`internal/plugin/manager_test.go`: default-false, enabled, unknown-name-false, string coercion. `go build ./...` and `go test ./...` pass.

## Commits

- `feat: add per-plugin dedup flag to plugin manager`
- `feat: skip publish when plaintext endpoint unchanged`
- `test: cover ExecuteForPeer dedup and failed-store retry`
- `docs: document per-plugin dedup option`
