### PR TITLE
feat(contrib): add OpenDHT storage plugin

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -52,7 +52,7 @@ Stores peer endpoint information in the OpenDHT distributed hash table via an Op
 
 **Protocol:** Exec (JSON)
 
-**Best for:** Meshes that would rather not depend on a hosted service. Note that OpenDHT values expire after 10 minutes, so `dedup` must stay `false`, and DHT lookups take seconds rather than milliseconds.
+**Best for:** Meshes that would rather not depend on a hosted service. Note that the default `dhtproxy.jami.net` endpoint answers over **IPv6 only**, OpenDHT values expire after 10 minutes so `dedup` must stay `false`, and DHT lookups take seconds rather than milliseconds.
 
 See [opendht/README.md](opendht/README.md) for setup instructions and limitations.
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -38,6 +38,24 @@ Shell script implementation of the Cloudflare DNS plugin, demonstrating the **sh
 
 See [cloudflare-shell/README.md](cloudflare-shell/README.md) for setup instructions.
 
+### OpenDHT Plugin (Shell Script)
+
+Location: [`opendht/`](opendht/)
+
+Stores peer endpoint information in the OpenDHT distributed hash table via an OpenDHT proxy server's REST API. Unlike the other plugins, it needs no account, no API token and no quota — but nothing guarantees the data stays there.
+
+**Features:**
+- No account or credentials required
+- Uses the public `dhtproxy.jami.net` by default, or your own proxy
+- Requires curl, jq
+- Linux and macOS
+
+**Protocol:** Exec (JSON)
+
+**Best for:** Meshes that would rather not depend on a hosted service. Note that OpenDHT values expire after 10 minutes, so `dedup` must stay `false`, and DHT lookups take seconds rather than milliseconds.
+
+See [opendht/README.md](opendht/README.md) for setup instructions and limitations.
+
 ## Creating Your Own Plugin
 
 Stunmesh supports two plugin protocols: **exec** (JSON-based) and **shell** (shell variable-based).

--- a/contrib/opendht/Makefile
+++ b/contrib/opendht/Makefile
@@ -1,0 +1,26 @@
+PLUGIN ?= stunmesh-opendht
+SOURCE ?= opendht.sh
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+
+.PHONY: all
+all: clean build
+
+.PHONY: build
+build:
+	@echo "Building shell script plugin..."
+	cp $(SOURCE) $(PLUGIN)
+	chmod +x $(PLUGIN)
+
+.PHONY: clean
+clean:
+	rm -f $(PLUGIN)
+
+.PHONY: install
+install: build
+	install -d $(BINDIR)
+	install -m 755 $(PLUGIN) $(BINDIR)/$(PLUGIN)
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(BINDIR)/$(PLUGIN)

--- a/contrib/opendht/README.md
+++ b/contrib/opendht/README.md
@@ -143,20 +143,46 @@ at the cost of managing a second keypair; this plugin does not use it.
 
 ## Running your own proxy
 
-To avoid depending on Jami's infrastructure, run a node with the proxy
-interface enabled and point `-endpoint` at it:
+Hosts without IPv6 have to do this, since the default endpoint is
+unreachable for them. Run a node with the proxy interface enabled and point
+`-endpoint` at it:
 
 ```bash
-docker run -d --name dhtnode -p 8080:8080 \
+docker run -d -i --name dhtnode -p 8080:8080 \
   ghcr.io/savoirfairelinux/opendht/opendht \
-  dhtnode --proxyserver 8080
+  dhtnode -b bootstrap.jami.net:4222 --proxyserver 8080
 ```
 
 ```yaml
 args: ["-endpoint", "http://127.0.0.1:8080"]
 ```
 
-This still joins the public OpenDHT network (bootstrapping via
-`bootstrap.jami.net`), so it changes who runs the HTTP endpoint, not which
-DHT the data lives in. It needs outbound UDP, which some restrictive NATs
-block.
+Both flags matter, and getting either wrong fails quietly:
+
+- **`-i`** keeps stdin open. `dhtnode` runs an interactive command loop, so
+  without it the container reads EOF and exits `0` immediately — a clean exit
+  that does not look like a failure.
+- **`-b`** names a bootstrap node. `dhtnode` does not bootstrap on its own:
+  without it the node never joins the DHT (`.ipv4.good` stays at 0) and yet
+  `set` and `get` still appear to succeed, because values land in the node's
+  local storage and it reads them straight back. Nothing else on the network
+  can see them.
+
+Check readiness before trusting it:
+
+```bash
+curl -sS http://127.0.0.1:8080/node/info | jq '.ipv4.good'
+```
+
+`good` must be greater than zero. Do not gate on
+`network_size_estimation` — it is still `null` at `good=2`, when the node is
+already usable. Bootstrapping takes a few seconds.
+
+Note that `brew install opendht` does not help here: the formula builds with
+`-DOPENDHT_C=ON -DOPENDHT_TOOLS=ON` only, and `OPENDHT_PROXY_SERVER` defaults
+to `OFF`, so the resulting `dhtnode` has no proxy interface. Building it in
+means also supplying Restinio and jsoncpp.
+
+Running your own proxy changes who runs the HTTP endpoint, not which DHT the
+data lives in — the node still joins the public OpenDHT network. It needs
+outbound UDP, which some restrictive NATs block.

--- a/contrib/opendht/README.md
+++ b/contrib/opendht/README.md
@@ -12,6 +12,8 @@ before deploying this.
 
 - `curl`
 - `jq`
+- **IPv6 connectivity**, if you use the default `dhtproxy.jami.net` endpoint —
+  it does not answer over IPv4 at all. See [Limitations](#limitations).
 
 Tested on Linux and macOS.
 
@@ -94,11 +96,30 @@ peer would pick an arbitrary one of its own recent endpoints.
 
 ## Limitations
 
+**`dhtproxy.jami.net` is reachable over IPv6 only.** The name resolves to
+both an A record (`141.94.96.254`) and an AAAA record
+(`2001:41d0:403:4702::`), but nothing is listening on the IPv4 address — TCP
+80, 443 and 8080 are all closed there. An IPv4-only host therefore fails at
+connect:
+
+```
+exec plugin error: set request failed: curl: (7) Failed to connect to
+dhtproxy.jami.net port 443 after 299 ms: Couldn't connect to server
+```
+
+There is no client-side fix, because the IPv4 endpoint does not exist. Hosts
+without IPv6 have to run their own proxy (see below). This is worth weighing
+before choosing this plugin: NAT traversal is an IPv4 problem, so the peers
+that most need stunmesh are also the ones most likely to lack the IPv6 that
+the default endpoint requires.
+
 **The endpoint is somebody else's infrastructure.** `dhtproxy.jami.net` is
 run by Savoir-faire Linux for the Jami messenger. It publishes no terms of
 service, no SLA and no rate limits for third-party use. It may start refusing
-or throttling stunmesh traffic at any time, with no recourse. If that matters
-to you, run your own proxy (see below).
+or throttling stunmesh traffic at any time, with no recourse. The dead A
+record above is what that looks like in practice: a broken record nobody
+announces, fixes on your schedule, or answers questions about. If that
+matters to you, run your own proxy (see below).
 
 **The network is small.** `GET /node/info` on the public proxy reports a
 `network_size_estimation` of roughly 4096 IPv4 nodes — this is essentially

--- a/contrib/opendht/README.md
+++ b/contrib/opendht/README.md
@@ -1,0 +1,141 @@
+# OpenDHT Plugin
+
+Stores peer endpoint data in the [OpenDHT](https://github.com/savoirfairelinux/opendht)
+distributed hash table through an OpenDHT proxy server's REST API.
+
+Unlike the other plugins, this one needs no account, no API token and no
+quota: OpenDHT is a public Kademlia network with no operator. The trade-off
+is that nobody guarantees your data stays there — see [Limitations](#limitations)
+before deploying this.
+
+## Requirements
+
+- `curl`
+- `jq`
+
+Tested on Linux and macOS.
+
+## Configuration
+
+```yaml
+plugins:
+  opendht:
+    type: exec
+    command: /usr/local/bin/stunmesh-opendht
+    args: ["-endpoint", "https://dhtproxy.jami.net"]
+    dedup: false
+
+interfaces:
+  wg0:
+    peers:
+      peer1:
+        public_key: "base64_encoded_key"
+        plugin: opendht
+```
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `-endpoint` | `https://dhtproxy.jami.net` | OpenDHT proxy server base URL |
+| `-magic` | `stunmesh-v1` | Envelope tag used to recognise our own values |
+| `-timeout` | `15` | Per-request timeout in seconds |
+
+Do not lower `-timeout` much. A DHT lookup that finds nothing legitimately
+takes ~6 seconds to converge; a short timeout turns a slow success into a
+false "not found".
+
+## `dedup` must stay false
+
+**Never set `dedup: true` for this plugin.**
+
+OpenDHT values expire after 10 minutes (`DEFAULT_VALUE_EXPIRATION` in
+`opendht/value.h`). The mesh only stays reachable because every refresh cycle
+republishes the endpoint before the previous value expires. `dedup: true`
+skips the publish when the endpoint is unchanged — which is exactly when it
+must not be skipped, since nothing else refreshes the value. The mesh would
+keep working for up to 10 minutes and then quietly stop.
+
+This is the case the "expiring/TTL backends" warning in the root `CLAUDE.md`
+is about.
+
+## How it works
+
+`Get`/`Set` map onto the proxy's REST API:
+
+```
+POST /key/<sha1-hex>   {"data":"<base64>"}     -> store
+GET  /key/<sha1-hex>                           -> newline-delimited value objects
+```
+
+An OpenDHT key is an `InfoHash`: 160 bits, i.e. 40 hex characters. stunmesh
+keys are SHA1 hex, so they are used as-is with no transformation.
+
+A key holds a *set* of values, not a single overwritable slot. There is no
+overwrite and no delete: the proxy answers `DELETE` with `501 Not Implemented`,
+and re-publishing under the same key adds another value rather than replacing
+the previous one (supplying a fixed `id` does not change this — unsigned
+values have no owner, so nothing identifies them as versions of each other).
+Values only go away when they expire.
+
+That matters in normal operation, not just under attack. Publishing every 5
+minutes against a 10-minute expiry means a key always holds two or three of
+*our own* values at once, and the proxy does not return them in chronological
+order. The stored payload is therefore wrapped in an envelope:
+
+```json
+{"magic": "stunmesh-v1", "ts": 1752700000, "data": "<hex ciphertext>"}
+```
+
+`Get` decodes every value under the key, keeps the ones carrying our magic,
+and returns the most recent by `ts`. Values that are not our envelope — or
+not JSON at all — are ignored. The `ts` sort is load-bearing: without it a
+peer would pick an arbitrary one of its own recent endpoints.
+
+## Limitations
+
+**The endpoint is somebody else's infrastructure.** `dhtproxy.jami.net` is
+run by Savoir-faire Linux for the Jami messenger. It publishes no terms of
+service, no SLA and no rate limits for third-party use. It may start refusing
+or throttling stunmesh traffic at any time, with no recourse. If that matters
+to you, run your own proxy (see below).
+
+**The network is small.** `GET /node/info` on the public proxy reports a
+`network_size_estimation` of roughly 4096 IPv4 nodes — this is essentially
+Jami's online user base, not a BitTorrent-sized swarm. Your value lives on
+the handful of nodes closest to your key, and those are consumer machines
+that come and go.
+
+**Lookups are slow.** Measured against `dhtproxy.jami.net`: a `set` takes
+~1.9s, a `get` that hits ~2.3s, and a `get` that misses ~6s. This is inherent
+to a DHT lookup, not a fault of the proxy — but it is two orders of magnitude
+slower than an HTTP KV store, and `Establish` performs one `get` per peer.
+
+**Anyone can publish under your key.** Keys are derived from public peer
+identifiers, so they are not secret. The magic envelope filters out noise and
+accidental collisions; it is not a security boundary. Someone who deliberately
+publishes a value with our magic and a future `ts` will win the `sort_by(.ts)`
+and break that peer until they stop. The payload stays confidential regardless
+— it is NaCl-encrypted before it reaches this plugin — so the exposure is
+denial of service, not disclosure. OpenDHT's `putSigned` would close this gap
+at the cost of managing a second keypair; this plugin does not use it.
+
+## Running your own proxy
+
+To avoid depending on Jami's infrastructure, run a node with the proxy
+interface enabled and point `-endpoint` at it:
+
+```bash
+docker run -d --name dhtnode -p 8080:8080 \
+  ghcr.io/savoirfairelinux/opendht/opendht \
+  dhtnode --proxyserver 8080
+```
+
+```yaml
+args: ["-endpoint", "http://127.0.0.1:8080"]
+```
+
+This still joins the public OpenDHT network (bootstrapping via
+`bootstrap.jami.net`), so it changes who runs the HTTP endpoint, not which
+DHT the data lives in. It needs outbound UDP, which some restrictive NATs
+block.

--- a/contrib/opendht/opendht.sh
+++ b/contrib/opendht/opendht.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+#
+# OpenDHT Storage Plugin for stunmesh-go (exec protocol)
+#
+# Stores peer endpoint data in the OpenDHT distributed hash table via an
+# OpenDHT proxy server's REST API. No account, no API token, no quota.
+#
+# Configuration in config.yaml:
+#   plugins:
+#     opendht:
+#       type: exec
+#       command: /usr/local/bin/stunmesh-opendht
+#       args: ["-endpoint", "https://dhtproxy.jami.net"]
+#       dedup: false
+#
+# IMPORTANT: dedup must stay false. OpenDHT values expire after 10 minutes
+# (DEFAULT_VALUE_EXPIRATION); skipping an unchanged publish lets the value
+# expire and silently breaks the mesh. See README.md.
+#
+# Requires: curl, jq
+
+set -eu
+
+ENDPOINT="https://dhtproxy.jami.net"
+MAGIC="stunmesh-v1"
+TIMEOUT=15
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: stunmesh-opendht [-endpoint URL] [-magic STRING] [-timeout SECONDS]
+
+Reads an exec-protocol JSON request on stdin and writes a JSON response
+on stdout. Not intended to be run interactively.
+EOF
+	exit 2
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-endpoint)
+		[ $# -ge 2 ] || usage
+		ENDPOINT="$2"
+		shift 2
+		;;
+	-magic)
+		[ $# -ge 2 ] || usage
+		MAGIC="$2"
+		shift 2
+		;;
+	-timeout)
+		[ $# -ge 2 ] || usage
+		TIMEOUT="$2"
+		shift 2
+		;;
+	-h | -help | --help)
+		usage
+		;;
+	*)
+		printf 'unknown option: %s\n' "$1" >&2
+		usage
+		;;
+	esac
+done
+
+# jq builds every response, so its absence has to be reported without it.
+if ! command -v jq >/dev/null 2>&1; then
+	printf '{"success":false,"error":"jq not found in PATH"}\n'
+	exit 0
+fi
+
+respond_ok() {
+	jq -cn --arg v "${1-}" '{success: true, value: $v}'
+	exit 0
+}
+
+respond_error() {
+	jq -cn --arg e "$1" '{success: false, error: $e}'
+	exit 0
+}
+
+command -v curl >/dev/null 2>&1 || respond_error "curl not found in PATH"
+
+request=$(cat)
+
+action=$(printf '%s' "$request" | jq -r '.action // empty' 2>/dev/null) ||
+	respond_error "malformed JSON request"
+key=$(printf '%s' "$request" | jq -r '.key // empty' 2>/dev/null) ||
+	respond_error "malformed JSON request"
+value=$(printf '%s' "$request" | jq -r '.value // empty' 2>/dev/null) ||
+	respond_error "malformed JSON request"
+
+[ -n "$action" ] || respond_error "missing action"
+[ -n "$key" ] || respond_error "missing key"
+
+# OpenDHT addresses values by InfoHash: 160 bits, i.e. 40 hex characters.
+# stunmesh keys are SHA1 hex, so they map over directly -- but reject
+# anything else rather than let the proxy interpret a bad path segment.
+case "$key" in
+*[!0-9a-fA-F]* | "")
+	respond_error "key must be hex"
+	;;
+esac
+[ ${#key} -eq 40 ] || respond_error "key must be 40 hex characters, got ${#key}"
+
+case "$action" in
+get)
+	if ! body=$(curl -sS -f --max-time "$TIMEOUT" "$ENDPOINT/key/$key" 2>&1); then
+		respond_error "get request failed: $body"
+	fi
+
+	# The proxy answers with newline-delimited JSON: one value object per
+	# line, since a key holds a set of values rather than a single slot.
+	# Anyone can publish under a known key, so decode each candidate, keep
+	# the ones carrying our magic, and take the most recent. fromjson?
+	# discards entries that are not our envelope at all.
+	found=$(printf '%s' "$body" | jq -rs --arg m "$MAGIC" '
+		map(.data | @base64d | fromjson? | select(.magic == $m))
+		| sort_by(.ts)
+		| last
+		| .data // empty
+	' 2>/dev/null) || respond_error "failed to parse proxy response"
+
+	[ -n "$found" ] || respond_error "no value found for key"
+
+	respond_ok "$found"
+	;;
+set)
+	[ -n "$value" ] || respond_error "missing value"
+
+	payload=$(jq -cn \
+		--arg m "$MAGIC" \
+		--argjson ts "$(date +%s)" \
+		--arg d "$value" \
+		'{data: ({magic: $m, ts: $ts, data: $d} | tojson | @base64)}') ||
+		respond_error "failed to build request payload"
+
+	if ! out=$(curl -sS -f --max-time "$TIMEOUT" \
+		-X POST \
+		-H 'Content-Type: application/json' \
+		-d "$payload" \
+		"$ENDPOINT/key/$key" 2>&1); then
+		respond_error "set request failed: $out"
+	fi
+
+	respond_ok ""
+	;;
+*)
+	respond_error "unknown action: $action"
+	;;
+esac


### PR DESCRIPTION
Adds a storage plugin backed by the [OpenDHT](https://github.com/savoirfairelinux/opendht) distributed hash table, reached through an OpenDHT proxy server’s REST API. It speaks the exec protocol from a POSIX shell script, so it needs only `curl` and `jq`.

Unlike the existing backends, this one needs no account, no API token and no quota — there is no operator to have a free tier. The trade-offs are documented rather than hidden; see Limitations below.

## Design notes

An OpenDHT key is a 160-bit `InfoHash`, i.e. 40 hex characters, so stunmesh’s SHA1 hex keys are used as-is with no transformation.

A key holds a **set** of values rather than a single slot. There is no overwrite and no delete — the proxy answers `DELETE` with `501 Not Implemented`, and re-publishing adds another value instead of replacing the previous one (a fixed `id` does not change this, since unsigned values have no owner). Values only go away when they expire after 10 minutes.

That shapes the design in normal operation, not just under attack: publishing every refresh cycle against a 10-minute expiry means a key always holds two or three of *our own* values at once, and the proxy does not return them in chronological order. So values are wrapped in an envelope —

```json
{"magic": "stunmesh-v1", "ts": 1752700000, "data": "<hex ciphertext>"}
```

— and `Get` keeps the entries carrying our magic and returns the most recent by `ts`. Anything that is not our envelope, or not JSON at all, is ignored, which also absorbs whatever a third party publishes under the same key.

**`dedup` must stay `false`.** Skipping an unchanged publish lets the value expire, since nothing else refreshes it. This is the case the “expiring/TTL backends” warning in `CLAUDE.md` is about, and the plugin README says so prominently.

## Limitations (documented in the README)

- The default endpoint `dhtproxy.jami.net` is Savoir-faire Linux’s infrastructure for Jami. It publishes no terms of service, SLA or rate limits for third-party use and could throttle or refuse this traffic at any time. Running your own proxy is documented.
- `GET /node/info` reports a `network_size_estimation` of roughly 4096 IPv4 nodes — essentially Jami’s online user base, not a BitTorrent-sized swarm.
- Lookups are slow: measured ~1.9s for a `set`, ~2.3s for a `get` that hits, ~6s for a `get` that misses. `Establish` performs one `get` per peer.
- Keys are derived from public identifiers, so anyone can publish under them. The magic envelope filters noise, it is not a security boundary — a deliberate value with our magic and a future `ts` wins the sort. The payload is NaCl-encrypted before reaching the plugin, so the exposure is denial of service, not disclosure. `putSigned` would close this at the cost of a second keypair; this plugin does not use it.

## Testing

Verified end-to-end against the live `dhtproxy.jami.net`:

- 600-char hex round-trip returns the value unchanged
- error paths return well-formed JSON: non-hex key, wrong key length, unknown action, malformed JSON request, missing key/value
- with three junk values injected under the same key (non-JSON; correct JSON but foreign magic and a far-future `ts`; our magic with a stale `ts`), `Get` still returns the right value — confirming magic filtering happens before the `ts` sort
- `shellcheck` clean, `sh -n` passes, `make build` / `make clean` work, and the built artifact is already covered by `.gitignore`

Not covered: no automated tests (matching the existing `cloudflare-shell` plugin), and no two-node run against a real WireGuard mesh yet. A private DHT (`dhtnode -n <network_id>`) would let CI test this without touching Jami’s infrastructure.