### PR TITLE
feat(plugin): add OpenDHT built-in plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TRIMPATH ?= 0
 UPX ?= 0
 EXTRA_MIN ?= 0
 BUILTIN ?= all
-ALL_BUILTINS := builtin_cloudflare
+ALL_BUILTINS := builtin_cloudflare builtin_opendht
 # Empty selects the per-platform default from the internal/wg build constraints:
 # wgcli on freebsd, wgctrl elsewhere. Set to override.
 BACKEND ?=

--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ The Makefile supports several options for customizing the build:
 - `EXTRA_MIN=1` - Enable all minimization options above (STRIP + TRIMPATH + UPX)
 
 **Built-in Plugin Options:**
-- `BUILTIN=all` - (Default) Compile with all available built-in plugins (cloudflare)
+- `BUILTIN=all` - (Default) Compile with all available built-in plugins (cloudflare, opendht)
 - `BUILTIN=` - Build without any built-in plugins (minimal binary)
 - `BUILTIN=builtin_cloudflare` - Compile with specific built-in Cloudflare plugin only
 - `BUILTIN="builtin_cloudflare builtin_xxx"` - Multiple plugins (quote required, space-separated)
 
 **Available Built-in Plugins:**
 - `builtin_cloudflare` - Cloudflare DNS plugin for peer endpoint storage
+- `builtin_opendht` - OpenDHT plugin for peer endpoint storage, via an OpenDHT proxy server's REST API
 
 **Build Examples:**
 ```bash
@@ -354,7 +355,7 @@ stunmesh-go supports three plugin types. **All are fully supported and productio
   - No external plugin processes (reduced memory usage)
   - No IPC overhead
   - Faster startup
-- Available built-in plugins: `cloudflare`
+- Available built-in plugins: `cloudflare`, `opendht`
 - Build with: `make all BUILTIN=builtin_cloudflare EXTRA_MIN=1`
 
 **Exec Plugin (`type: exec`)**
@@ -426,11 +427,36 @@ interfaces:
         protocol: ipv4
 ```
 
+The `opendht` built-in stores endpoints in the OpenDHT distributed hash table
+through an OpenDHT proxy server's REST API. It needs no account, token or
+quota, since there is no operator. Every field is optional:
+
+```yaml
+plugins:
+  dht:
+    type: builtin
+    name: opendht
+    endpoint: https://dhtproxy.jami.net  # Default
+    magic: stunmesh-v1                   # Default; tags our own values
+    timeout: 15s                         # Default; also accepts a number of seconds
+    dedup: false                         # Must stay false, see below
+```
+
+`dedup` must stay `false` here: OpenDHT values expire after 10 minutes, and
+nothing but the refresh cycle republishes them. Note also that
+`dhtproxy.jami.net` answers over **IPv6 only**, and that DHT lookups take
+seconds rather than milliseconds. The trade-offs, and how to run your own
+proxy, are covered in [contrib/opendht/README.md](contrib/opendht/README.md) —
+that plugin is the same design as a shell script, and its documentation
+applies here too.
+
 **Contrib Plugins**
 
 Additional plugins are available in the [`contrib/`](contrib/) directory:
 - **Cloudflare DNS Plugin**: Stores peer information in Cloudflare DNS TXT records
   - See [contrib/cloudflare/README.md](contrib/cloudflare/README.md) for setup instructions
+- **OpenDHT Plugin**: Stores peer information in the OpenDHT distributed hash table
+  - See [contrib/opendht/README.md](contrib/opendht/README.md) for setup instructions
 - More community plugins can be added here
 
 To use contrib plugins, build them and reference them as exec plugins in your configuration.

--- a/internal/plugin/builtin/opendht/opendht.go
+++ b/internal/plugin/builtin/opendht/opendht.go
@@ -1,0 +1,258 @@
+//go:build builtin_opendht
+
+package opendht
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/rs/zerolog"
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
+)
+
+const (
+	defaultEndpoint = "https://dhtproxy.jami.net"
+	defaultMagic    = "stunmesh-v1"
+	defaultTimeout  = 15 * time.Second
+
+	// Configuration keys
+	configKeyEndpoint = "endpoint"
+	configKeyMagic    = "magic"
+	configKeyTimeout  = "timeout"
+)
+
+// An OpenDHT key is an InfoHash: 160 bits, i.e. 40 hex characters. stunmesh
+// keys are SHA1 hex, so they are used as-is -- but reject anything else
+// rather than let the proxy interpret a bad path segment.
+var keyPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+// OpenDHTPlugin implements the Store interface
+type OpenDHTPlugin struct {
+	endpoint string
+	magic    string
+	client   *http.Client
+}
+
+// envelope wraps the value stored under a key.
+//
+// A key holds a set of values rather than a single overwritable slot, and
+// anyone may publish under a key they know, so a stored value cannot be
+// assumed to be ours. Publishing every refresh cycle against OpenDHT's
+// 10-minute expiry also leaves several of our own values under a key at once,
+// returned in no particular order -- so Ts is what tells them apart, not just
+// a tie-breaker.
+type envelope struct {
+	Magic string `json:"magic"`
+	Ts    int64  `json:"ts"`
+	Data  string `json:"data"`
+}
+
+// value is one entry as the proxy reports it. Get returns them as
+// newline-delimited JSON, one object per line.
+type value struct {
+	Data string `json:"data"`
+}
+
+// BuiltinConfig helper
+type BuiltinConfig struct {
+	config pluginapi.PluginConfig
+}
+
+func (c *BuiltinConfig) GetString(key string) (string, bool) {
+	val, ok := c.config[key]
+	if !ok {
+		return "", false
+	}
+	str, ok := val.(string)
+	return str, ok
+}
+
+// GetDuration reads a timeout expressed either as a duration string such as
+// "20s" or as a plain number of seconds, since a YAML scalar may arrive as
+// either depending on how it was written.
+func (c *BuiltinConfig) GetDuration(key string) (time.Duration, bool, error) {
+	val, ok := c.config[key]
+	if !ok {
+		return 0, false, nil
+	}
+
+	switch v := val.(type) {
+	case string:
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, false, fmt.Errorf("%s is not a valid duration: %w", key, err)
+		}
+		return d, true, nil
+	case int:
+		return time.Duration(v) * time.Second, true, nil
+	case float64:
+		return time.Duration(v * float64(time.Second)), true, nil
+	default:
+		return 0, false, fmt.Errorf("%s must be a duration or a number of seconds", key)
+	}
+}
+
+// NewOpenDHTPlugin creates a new OpenDHT plugin instance
+func NewOpenDHTPlugin(config pluginapi.PluginConfig) (pluginapi.Store, error) {
+	cfg := &BuiltinConfig{config: config}
+
+	endpoint, ok := cfg.GetString(configKeyEndpoint)
+	if !ok || endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+
+	magic, ok := cfg.GetString(configKeyMagic)
+	if !ok || magic == "" {
+		magic = defaultMagic
+	}
+
+	timeout, ok, err := cfg.GetDuration(configKeyTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		timeout = defaultTimeout
+	}
+
+	client := &http.Client{
+		// A lookup that finds nothing legitimately takes several seconds to
+		// converge, so a short timeout turns a slow success into a false
+		// "not found".
+		Timeout: timeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        2,
+			MaxIdleConnsPerHost: 2,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	}
+
+	return &OpenDHTPlugin{
+		endpoint: endpoint,
+		magic:    magic,
+		client:   client,
+	}, nil
+}
+
+func (p *OpenDHTPlugin) doRequest(ctx context.Context, method, key string, body []byte) ([]byte, error) {
+	url := fmt.Sprintf("%s/key/%s", p.endpoint, key)
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error: %s - %s", resp.Status, string(data))
+	}
+
+	return data, nil
+}
+
+// Get retrieves a value from OpenDHT
+func (p *OpenDHTPlugin) Get(ctx context.Context, key string) (string, error) {
+	logger := zerolog.Ctx(ctx)
+	logger.Info().Str("key", key).Msg("get data from builtin opendht plugin")
+
+	if !keyPattern.MatchString(key) {
+		return "", fmt.Errorf("key must be 40 hex characters: %s", key)
+	}
+
+	data, err := p.doRequest(ctx, http.MethodGet, key, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Keep the entries carrying our magic and return the most recent. Values
+	// that are not our envelope -- or not JSON at all -- are ignored, which
+	// also absorbs whatever a third party publishes under the same key.
+	var newest *envelope
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var v value
+		if err := json.Unmarshal(line, &v); err != nil {
+			continue
+		}
+
+		raw, err := base64.StdEncoding.DecodeString(v.Data)
+		if err != nil {
+			continue
+		}
+
+		var e envelope
+		if err := json.Unmarshal(raw, &e); err != nil {
+			continue
+		}
+
+		if e.Magic != p.magic {
+			continue
+		}
+
+		if newest == nil || e.Ts > newest.Ts {
+			found := e
+			newest = &found
+		}
+	}
+
+	if newest == nil {
+		return "", fmt.Errorf("no value found for key: %s", key)
+	}
+
+	return newest.Data, nil
+}
+
+// Set stores a value in OpenDHT
+func (p *OpenDHTPlugin) Set(ctx context.Context, key string, value string) error {
+	logger := zerolog.Ctx(ctx)
+	logger.Info().Str("key", key).Msg("set data to builtin opendht plugin")
+
+	if !keyPattern.MatchString(key) {
+		return fmt.Errorf("key must be 40 hex characters: %s", key)
+	}
+
+	payload, err := json.Marshal(&envelope{
+		Magic: p.magic,
+		Ts:    time.Now().Unix(),
+		Data:  value,
+	})
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"data": base64.StdEncoding.EncodeToString(payload),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = p.doRequest(ctx, http.MethodPost, key, body)
+	return err
+}

--- a/internal/plugin/builtin/opendht/opendht_test.go
+++ b/internal/plugin/builtin/opendht/opendht_test.go
@@ -1,0 +1,361 @@
+//go:build builtin_opendht
+
+package opendht
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
+)
+
+const testKey = "3061b8fcbdb6972059518f1adc3590dca6a5f352"
+
+// line renders one value object the way the proxy reports it: the envelope,
+// base64-encoded, inside a JSON object, one per line.
+func line(t *testing.T, magic string, ts int64, data string) string {
+	t.Helper()
+
+	payload, err := json.Marshal(&envelope{Magic: magic, Ts: ts, Data: data})
+	if err != nil {
+		t.Fatalf("failed to marshal envelope: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"data": base64.StdEncoding.EncodeToString(payload),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal value: %v", err)
+	}
+
+	return string(body)
+}
+
+// rawLine renders a value object holding arbitrary bytes rather than an
+// envelope, for the values a third party may have published.
+func rawLine(t *testing.T, data string) string {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte(data)),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal value: %v", err)
+	}
+
+	return string(body)
+}
+
+func newTestPlugin(t *testing.T, url string) pluginapi.Store {
+	t.Helper()
+
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoint: url})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	return p
+}
+
+func TestGetReturnsMostRecentValue(t *testing.T) {
+	// A key holds a set of values, and publishing every cycle against a
+	// 10-minute expiry leaves several of our own under it at once. The proxy
+	// does not order them, so the newest must be selected by ts.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, line(t, defaultMagic, 200, "newest"))
+		fmt.Fprintln(w, line(t, defaultMagic, 100, "oldest"))
+		fmt.Fprintln(w, line(t, defaultMagic, 150, "middle"))
+	}))
+	defer server.Close()
+
+	got, err := newTestPlugin(t, server.URL).Get(context.Background(), testKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "newest" {
+		t.Errorf("expected newest, got %q", got)
+	}
+}
+
+func TestGetIgnoresForeignValues(t *testing.T) {
+	// Anyone may publish under a known key. Values that are not our envelope
+	// must not be returned -- not even one whose ts would otherwise win.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, rawLine(t, "total garbage not json"))
+		fmt.Fprintln(w, line(t, "someone-else", 1<<40, "hijacked"))
+		fmt.Fprintln(w, line(t, defaultMagic, 100, "ours"))
+	}))
+	defer server.Close()
+
+	got, err := newTestPlugin(t, server.URL).Get(context.Background(), testKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "ours" {
+		t.Errorf("expected ours, got %q", got)
+	}
+}
+
+func TestGetEmptyKey(t *testing.T) {
+	// A key with no values answers 200 with an empty body.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	_, err := newTestPlugin(t, server.URL).Get(context.Background(), testKey)
+	if err == nil {
+		t.Fatal("expected an error for a key with no values")
+	}
+}
+
+func TestGetOnlyForeignValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, line(t, "someone-else", 100, "theirs"))
+	}))
+	defer server.Close()
+
+	_, err := newTestPlugin(t, server.URL).Get(context.Background(), testKey)
+	if err == nil {
+		t.Fatal("expected an error when no value carries our magic")
+	}
+}
+
+func TestGetRespectsConfiguredMagic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, line(t, defaultMagic, 200, "default-magic"))
+		fmt.Fprintln(w, line(t, "custom", 100, "custom-magic"))
+	}))
+	defer server.Close()
+
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoint: server.URL,
+		configKeyMagic:    "custom",
+	})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	got, err := p.Get(context.Background(), testKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "custom-magic" {
+		t.Errorf("expected custom-magic, got %q", got)
+	}
+}
+
+func TestGetServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	_, err := newTestPlugin(t, server.URL).Get(context.Background(), testKey)
+	if err == nil {
+		t.Fatal("expected an error for a 502 response")
+	}
+}
+
+func TestSetPublishesEnvelope(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotEnvelope envelope
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+			return
+		}
+
+		var v value
+		if err := json.Unmarshal(body, &v); err != nil {
+			t.Errorf("body is not a value object: %v", err)
+			return
+		}
+
+		raw, err := base64.StdEncoding.DecodeString(v.Data)
+		if err != nil {
+			t.Errorf("data is not base64: %v", err)
+			return
+		}
+
+		if err := json.Unmarshal(raw, &gotEnvelope); err != nil {
+			t.Errorf("data is not an envelope: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	before := time.Now().Unix()
+	if err := newTestPlugin(t, server.URL).Set(context.Background(), testKey, "payload"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now().Unix()
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+
+	if gotPath != "/key/"+testKey {
+		t.Errorf("expected /key/%s, got %s", testKey, gotPath)
+	}
+
+	if gotEnvelope.Magic != defaultMagic {
+		t.Errorf("expected magic %s, got %s", defaultMagic, gotEnvelope.Magic)
+	}
+
+	if gotEnvelope.Data != "payload" {
+		t.Errorf("expected payload, got %q", gotEnvelope.Data)
+	}
+
+	if gotEnvelope.Ts < before || gotEnvelope.Ts > after {
+		t.Errorf("expected ts within [%d, %d], got %d", before, after, gotEnvelope.Ts)
+	}
+}
+
+func TestSetServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	err := newTestPlugin(t, server.URL).Set(context.Background(), testKey, "payload")
+	if err == nil {
+		t.Fatal("expected an error for a 502 response")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	// What Set publishes must be what Get reads back.
+	var stored string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("failed to read body: %v", err)
+				return
+			}
+			stored = string(body)
+			return
+		}
+		fmt.Fprintln(w, stored)
+	}))
+	defer server.Close()
+
+	p := newTestPlugin(t, server.URL)
+	want := strings.Repeat("deadbeef", 75)
+
+	if err := p.Set(context.Background(), testKey, want); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := p.Get(context.Background(), testKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("round trip changed the value: got %d chars, want %d", len(got), len(want))
+	}
+}
+
+func TestKeyMustBeInfoHash(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a malformed key must not reach the proxy")
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"too short", "abc"},
+		{"not hex", "3061b8fcbdb6972059518f1adc3590dca6a5f35z"},
+		{"path traversal", "../../node/info"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestPlugin(t, server.URL)
+
+			if _, err := p.Get(context.Background(), tt.key); err == nil {
+				t.Error("expected Get to reject the key")
+			}
+
+			if err := p.Set(context.Background(), tt.key, "payload"); err == nil {
+				t.Error("expected Set to reject the key")
+			}
+		})
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	plugin, ok := p.(*OpenDHTPlugin)
+	if !ok {
+		t.Fatal("expected an *OpenDHTPlugin")
+	}
+
+	if plugin.endpoint != defaultEndpoint {
+		t.Errorf("expected endpoint %s, got %s", defaultEndpoint, plugin.endpoint)
+	}
+
+	if plugin.magic != defaultMagic {
+		t.Errorf("expected magic %s, got %s", defaultMagic, plugin.magic)
+	}
+
+	if plugin.client.Timeout != defaultTimeout {
+		t.Errorf("expected timeout %s, got %s", defaultTimeout, plugin.client.Timeout)
+	}
+}
+
+func TestTimeoutConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  time.Duration
+	}{
+		{"duration string", "20s", 20 * time.Second},
+		{"seconds as int", 30, 30 * time.Second},
+		{"seconds as float", float64(30), 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyTimeout: tt.value})
+			if err != nil {
+				t.Fatalf("failed to create plugin: %v", err)
+			}
+
+			if got := p.(*OpenDHTPlugin).client.Timeout; got != tt.want {
+				t.Errorf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestInvalidTimeoutConfig(t *testing.T) {
+	for _, value := range []interface{}{"not-a-duration", true} {
+		if _, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyTimeout: value}); err == nil {
+			t.Errorf("expected an error for timeout %v", value)
+		}
+	}
+}

--- a/internal/plugin/builtin/opendht/stub.go
+++ b/internal/plugin/builtin/opendht/stub.go
@@ -1,0 +1,6 @@
+//go:build !builtin_opendht
+
+package opendht
+
+// This file exists to provide an empty package when builtin_opendht tag is not set
+// This prevents import errors when the build tag is disabled

--- a/internal/plugin/register_cloudflare.go
+++ b/internal/plugin/register_cloudflare.go
@@ -3,8 +3,8 @@
 package plugin
 
 import (
-	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin/builtin/cloudflare"
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 )
 
 func init() {

--- a/internal/plugin/register_opendht.go
+++ b/internal/plugin/register_opendht.go
@@ -1,0 +1,16 @@
+//go:build builtin_opendht
+
+package plugin
+
+import (
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/builtin/opendht"
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
+)
+
+func init() {
+	// Register built-in plugins
+	// This file is only compiled when build tags are present
+	RegisterBuiltin("opendht", func(config pluginapi.PluginConfig) (pluginapi.Store, error) {
+		return opendht.NewOpenDHTPlugin(config)
+	})
+}


### PR DESCRIPTION
Ports `contrib/opendht` to a built-in, so an OpenDHT mesh can run from a single binary with no exec plugin, `curl` or `jq`. It is pure `net/http`, so it costs nothing in cgo or static-build terms.

```yaml
plugins:
  dht:
    type: builtin
    name: opendht
    endpoint: https://dhtproxy.jami.net  # Default
    magic: stunmesh-v1                   # Default
    timeout: 15s                         # Default; also accepts a number of seconds
    dedup: false                         # Must stay false
```

The design follows the shell plugin and [its README](contrib/opendht/README.md) applies unchanged — a key holds a set of values rather than a slot, with no overwrite and no delete, so values are wrapped in a magic/timestamp envelope and `Get` returns the most recent one carrying our magic, ignoring anything that is not our envelope. `dedup` must stay `false`: values expire after 10 minutes and only the refresh cycle republishes them. Keys must be 40 hex characters, matching OpenDHT’s `InfoHash`, which also keeps a malformed key from being interpreted as a path segment.

## Why `register_builtin.go` is split per builtin

This is the part worth reviewing. The old single file is gated on `//go:build builtin_cloudflare`, which cannot accommodate a second builtin, and the obvious fix does not work either.

A register file’s build tag has to match the tag on the implementation it imports, and one file cannot carry two different tags. Gating a shared file on `builtin_cloudflare || builtin_opendht` compiles it whenever *either* tag is set, but it imports both packages unconditionally, so:

```
$ go build -tags builtin_opendht .
internal/plugin/register_builtin.go:13:21: undefined: cloudflare.NewCloudflarePlugin
```

With only `builtin_opendht`, the cloudflare package is just its `stub.go`. One register file per builtin keeps each import gated by the same tag as the package it names.

Self-registration (builtins calling `RegisterBuiltin` from their own `init()`) would remove the duplication, but `RegisterBuiltin` lives in `package plugin`, which already imports the builtin packages — so it needs the registry moved to a neutral package first. That is a reasonable follow-up once there are more builtins; it seemed premature for the second one.

## Verification

Build-tag matrix, checking both that it compiles and that the right register file is included:

| Tags | build | cloudflare | opendht |
|---|---|---|---|
| *(none)* | OK | no | no |
| `builtin_cloudflare` | OK | yes | no |
| `builtin_opendht` | OK | no | yes |
| both | OK | yes | yes |

`make build` also passes for `BUILTIN=all`, `BUILTIN=builtin_cloudflare`, `BUILTIN=builtin_opendht` and `BUILTIN=`.

13 tests via `httptest`, covering: newest-by-`ts` selection across several of our own values returned out of order; foreign values ignored, including one with a far-future `ts` that would otherwise win; only-foreign and empty-key cases; configurable magic; round-trip of a 600-char payload; `Set` publishing a well-formed envelope with a current `ts` to `/key/<key>`; server errors surfaced; key validation on both `Get` and `Set`, including a path-traversal attempt; defaults; and timeout parsing from both a duration string and a number.

`go test ./...`, `go vet` and `gofmt` are clean. (`register_cloudflare.go` picks up a one-line import reorder from `gofmt`, which the file was already failing before the rename.)