### PR TITLE
chore: check formatting in CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,3 +2,6 @@ version: "2"
 linters:
   enable:
     - protogetter
+formatters:
+  enable:
+    - gofmt

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/queue"
 )
 
-
 type DeviceConfigProvider interface {
 	GetInterfaceProtocol(deviceName string) string
 }
@@ -47,7 +46,7 @@ func NewPublishController(devices DeviceRepository, peers PeerRepository, plugin
 		encryptor:     encryptor,
 		deviceConfig:  deviceConfig,
 		logger:        logger.With().Str("controller", "publish").Logger(),
-		triggerQueue:  queue.NewBuffered[struct{}](queue.TriggerQueueSize), // Buffered trigger queue
+		triggerQueue:  queue.NewBuffered[struct{}](queue.TriggerQueueSize),   // Buffered trigger queue
 		peerQueue:     queue.NewBuffered[entity.PeerId](queue.PeerQueueSize), // Buffered peer queue
 		lastPublished: make(map[string]string),
 	}


### PR DESCRIPTION
CI has never checked formatting.

`golangci-lint` v2 enables `errcheck`, `govet`, `ineffassign`, `staticcheck` and `unused` by default — no formatter — and v2 moved formatters into their own section, which `.golangci.yaml` does not have:

```yaml
version: "2"
linters:
  enable:
    - protogetter
```

So `internal/ctrl/publish.go` has been sitting on `main` unformatted since e70e9b9 (a stray blank line and a misaligned comment), and nothing would have said so.

This enables the `gofmt` formatter and fixes the file, in that order — the file has to be clean before the check goes in, or CI fails on merge.

```yaml
formatters:
  enable:
    - gofmt
```

Worth doing now rather than later: left unchecked, the next person to run `gofmt -w` produces a diff unrelated to their change. One file needs fixing today, which is as cheap as this will ever be.

## Verification

Against `golangci-lint` 2.12.2 locally:

- `golangci-lint config verify` passes — the `formatters:` key is valid v2 syntax
- `golangci-lint run ./...` reports **0 issues**
- deliberately misformatting a file **is** caught, confirming the check actually runs rather than being silently absent:
  ```
  internal/ctrl/publish.go:330:1: File is not properly formatted (gofmt)
  ```
- `gofmt -l .` is clean across the repo, `go build ./...` and `go test ./internal/ctrl/` pass