### PR TITLE
feat: mirror WireGuard fwmark onto the STUN probe socket

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -14,6 +14,10 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
 
+    # Run as root so the tests that need CAP_NET_RAW / CAP_NET_ADMIN actually
+    # execute instead of skipping themselves. `sudo -E env "PATH=$PATH"` rather
+    # than a bare `sudo`, because sudo's secure_path drops the Go that
+    # setup-go put on PATH.
     - name: Test
       shell: bash
-      run: make test
+      run: sudo -E env "PATH=$PATH" make test

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Once getting info from internet, it will setup peer endpoint with wireguard tool
 
 **FreeBSD and macOS (BSD-based systems)**: Uses BPF with interface-specific packet capture. stunmesh-go will listen on all eligible network interfaces for STUN response messages, excluding the specific WireGuard interface being managed. This provides better resilience for systems with multiple network paths or backup routes compared to single default route dependency.
 
+### Firewall mark (Linux only)
+
+STUN discovery probes from the WireGuard listen port to learn the NAT mapping that WireGuard's own traffic will use. That only holds if the probe and the tunnel traffic leave by the same route.
+
+They need not. WireGuard stamps an fwmark on the packets it sends so that policy routing can keep its own traffic out of the tunnel it manages — this is what `wg-quick` sets up when `Table = auto` installs a default route through the tunnel. An unmarked probe would miss those rules, take a different path, and report a mapping that belongs to some other route.
+
+So on Linux, stunmesh-go reads the device's fwmark and applies it to the probe socket with `SO_MARK`. This is automatic, needs no configuration, and does nothing when the device has no fwmark set — which is the common case.
+
+Two caveats:
+
+- **It does not make an exit-node / full-tunnel setup work on its own.** stunmesh-go never touches the routing table. The `ip rule` and routing table entries that consume the mark are `wg-quick`'s job (or yours). stunmesh-go only makes sure its probe joins the traffic class WireGuard already put itself in.
+- **`SO_MARK` is Linux-only.** FreeBSD and macOS have no equivalent, so the probe socket cannot be pinned to the device's routing path there.
+
 ## Build
 
 ```bash
@@ -170,6 +183,29 @@ Or use STUNMESH-go in the container
 ```
 docker pull tjjh89017/stunmesh
 ```
+
+### When stunmesh-go must be restarted
+
+stunmesh-go reads the WireGuard device's state once at startup and keeps it for the life of the process. Restart it after any of the following, or it will keep acting on stale values — usually without any error, because a stale port or mark still looks perfectly valid:
+
+| Change | Why a restart is needed |
+|---|---|
+| `wg-quick down` then `up`, or otherwise recreating the interface | If the WireGuard config does not pin `ListenPort`, the kernel picks a **new random port** every time. stunmesh-go would keep probing the old one and publish an endpoint nobody is listening on. |
+| `wg set <dev> listen-port ...` | Same as above. |
+| `wg set <dev> fwmark ...` | The probe socket keeps the old mark and stops matching the device's routing path. |
+| Rotating the interface's private key | Peers pin your old public key, so WireGuard itself will not pair until every side is reconfigured. |
+| Editing `config.yaml` | The config is read once at startup; there is no reload. |
+
+Under systemd, tie the two units together so this is enforced rather than remembered:
+
+```ini
+# /etc/systemd/system/stunmesh-go.service
+[Unit]
+After=wg-quick@wg0.service
+BindsTo=wg-quick@wg0.service
+```
+
+`After=` also keeps stunmesh-go from starting before the interface exists; `BindsTo=` restarts it whenever `wg-quick@wg0` is restarted.
 
 ### Configuration
 

--- a/internal/ctrl/bootstrap.go
+++ b/internal/ctrl/bootstrap.go
@@ -52,6 +52,7 @@ func (ctrl *BootstrapController) registerDevice(ctx context.Context, deviceName 
 		device.ListenPort,
 		device.PrivateKey[:],
 		protocol,
+		device.FirewallMark,
 	)
 
 	allowPeers, err := ctrl.filterService.Execute(ctx, deviceEntity.Name(), device.PublicKey[:])

--- a/internal/ctrl/mock/mock_stun.go
+++ b/internal/ctrl/mock/mock_stun.go
@@ -41,9 +41,9 @@ func (m *MockStunResolver) EXPECT() *MockStunResolverMockRecorder {
 }
 
 // Resolve mocks base method.
-func (m *MockStunResolver) Resolve(ctx context.Context, deviceName string, port uint16, protocol string) (string, int, error) {
+func (m *MockStunResolver) Resolve(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (string, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ctx, deviceName, port, protocol)
+	ret := m.ctrl.Call(m, "Resolve", ctx, deviceName, port, protocol, firewallMark)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -51,7 +51,7 @@ func (m *MockStunResolver) Resolve(ctx context.Context, deviceName string, port 
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockStunResolverMockRecorder) Resolve(ctx, deviceName, port, protocol any) *gomock.Call {
+func (mr *MockStunResolverMockRecorder) Resolve(ctx, deviceName, port, protocol, firewallMark any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockStunResolver)(nil).Resolve), ctx, deviceName, port, protocol)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockStunResolver)(nil).Resolve), ctx, deviceName, port, protocol, firewallMark)
 }

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -76,7 +76,7 @@ func (c *PublishController) discoverEndpoints(ctx context.Context, device *entit
 	// Perform IPv4 STUN discovery if needed
 	var ipv4Err error
 	if resolveIPv4 {
-		host, port, err := c.resolver.Resolve(ctx, string(device.Name()), uint16(device.ListenPort()), "ipv4")
+		host, port, err := c.resolver.Resolve(ctx, string(device.Name()), uint16(device.ListenPort()), "ipv4", device.FirewallMark())
 		if err != nil {
 			ipv4Err = err
 		} else {
@@ -88,7 +88,7 @@ func (c *PublishController) discoverEndpoints(ctx context.Context, device *entit
 	// Perform IPv6 STUN discovery if needed
 	var ipv6Err error
 	if resolveIPv6 {
-		host, port, err := c.resolver.Resolve(ctx, string(device.Name()), uint16(device.ListenPort()), "ipv6")
+		host, port, err := c.resolver.Resolve(ctx, string(device.Name()), uint16(device.ListenPort()), "ipv6", device.FirewallMark())
 		if err != nil {
 			ipv6Err = err
 		} else {

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -132,7 +132,7 @@ func TestPublishController_Execute_STUNError(t *testing.T) {
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("", 0, errors.New("STUN failed"))
 
 	controller := ctrl.NewPublishController(
@@ -146,6 +146,43 @@ func TestPublishController_Execute_STUNError(t *testing.T) {
 	)
 
 	// Should continue without panic
+	controller.Execute(ctx)
+}
+
+// The device's fwmark has to reach the resolver, or the STUN probe leaves
+// unmarked and takes a different route than the WireGuard traffic it is
+// measuring. gomock fails the exact-value expectation if it does not.
+func TestPublishController_Execute_ForwardsDeviceFirewallMark(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager := plugin.NewManager()
+
+	const mark = 0xca6c
+	device := entity.NewDevice(entity.DeviceId("wg0"), 51820, make([]byte, 32), "ipv4", mark)
+
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	// Exact value, not gomock.Any(): this is the assertion. Erroring out here
+	// keeps the test to the one thing it is about.
+	mockResolver.EXPECT().
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", mark).
+		Return("", 0, errors.New("stop after the resolver call"))
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		nil,
+		pluginManager,
+		mockResolver,
+		nil,
+		nil,
+		&logger,
+	)
+
 	controller.Execute(ctx)
 }
 
@@ -167,7 +204,7 @@ func TestPublishController_Execute_PeerListError(t *testing.T) {
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).
 		Return(nil, errors.New("failed to list peers"))
@@ -207,7 +244,7 @@ func TestPublishController_Execute_EncryptionError(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 
 	// Expect encryption to fail
@@ -250,7 +287,7 @@ func TestPublishController_Execute_SuccessfulEncryption(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 
 	// Verify the JSON content being encrypted
@@ -311,7 +348,7 @@ func TestPublishController_Execute_IPv6(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6").
+		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -366,10 +403,10 @@ func TestPublishController_Execute_Dualstack(t *testing.T) {
 
 	// Expect both IPv4 and IPv6 resolution
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6").
+		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -421,10 +458,10 @@ func TestPublishController_Execute_Dualstack_BothFail(t *testing.T) {
 
 	// Both resolutions fail
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("", 0, errors.New("IPv4 failed"))
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6").
+		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("", 0, errors.New("IPv6 failed"))
 
 	controller := ctrl.NewPublishController(
@@ -468,7 +505,7 @@ func TestPublishController_Execute_MultipleDevices(t *testing.T) {
 	// Device 1 (wg0)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer1}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockEncryptor.EXPECT().
 		Encrypt(ctx, gomock.Any()).
@@ -477,7 +514,7 @@ func TestPublishController_Execute_MultipleDevices(t *testing.T) {
 	// Device 2 (wg1)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg1")).Return([]*entity.Peer{peer2}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg1", uint16(51821), "ipv6").
+		Resolve(ctx, "wg1", uint16(51821), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51821, nil)
 	mockEncryptor.EXPECT().
 		Encrypt(ctx, gomock.Any()).
@@ -587,10 +624,10 @@ func TestPublishController_ExecuteForPeer_Success(t *testing.T) {
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6").
+		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -646,10 +683,10 @@ func TestPublishController_Execute_Dedup_ChangedEndpoint_Publishes(t *testing.T)
 	// Two calls, two different resolved endpoints.
 	gomock.InOrder(
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("1.2.3.4", 51820, nil),
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("5.6.7.8", 51820, nil),
 	)
 
@@ -698,7 +735,7 @@ func TestPublishController_Execute_Dedup_UnchangedEndpoint_Skips(t *testing.T) {
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -748,7 +785,7 @@ func TestPublishController_Execute_Dedup_OffByDefault_AlwaysPublishes(t *testing
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -800,7 +837,7 @@ func TestPublishController_ExecuteForPeer_Dedup_UnchangedEndpoint_Skips(t *testi
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -856,10 +893,10 @@ func TestPublishController_ExecuteForPeer_Dedup_ChangedEndpoint_Publishes(t *tes
 	// Two calls, two different resolved endpoints.
 	gomock.InOrder(
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("1.2.3.4", 51820, nil),
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4").
+			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("5.6.7.8", 51820, nil),
 	)
 
@@ -912,7 +949,7 @@ func TestPublishController_Execute_Dedup_FailedStore_DoesNotCacheAndRetries(t *t
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4").
+		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -74,7 +74,7 @@ func newDedupTestManager(t *testing.T, builtinName string, dedup bool) (*plugin.
 
 // Helper function to create test device
 func createTestDevice(name string, port int, protocol string) *entity.Device {
-	return entity.NewDevice(entity.DeviceId(name), port, make([]byte, 32), protocol)
+	return entity.NewDevice(entity.DeviceId(name), port, make([]byte, 32), protocol, 0)
 }
 
 // Helper function to create test peer

--- a/internal/ctrl/stun.go
+++ b/internal/ctrl/stun.go
@@ -5,5 +5,5 @@ package ctrl
 import "context"
 
 type StunResolver interface {
-	Resolve(ctx context.Context, deviceName string, port uint16, protocol string) (string, int, error)
+	Resolve(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (string, int, error)
 }

--- a/internal/entity/device.go
+++ b/internal/entity/device.go
@@ -9,18 +9,20 @@ var (
 type DeviceId string
 
 type Device struct {
-	name       DeviceId
-	listenPort int
-	privateKey []byte
-	protocol   string
+	name         DeviceId
+	listenPort   int
+	privateKey   []byte
+	protocol     string
+	firewallMark int
 }
 
-func NewDevice(name DeviceId, listenPort int, privateKey []byte, protocol string) *Device {
+func NewDevice(name DeviceId, listenPort int, privateKey []byte, protocol string, firewallMark int) *Device {
 	return &Device{
-		name:       name,
-		listenPort: listenPort,
-		privateKey: privateKey,
-		protocol:   protocol,
+		name:         name,
+		listenPort:   listenPort,
+		privateKey:   privateKey,
+		protocol:     protocol,
+		firewallMark: firewallMark,
 	}
 }
 
@@ -40,4 +42,8 @@ func (d *Device) ListenPort() int {
 
 func (d *Device) Protocol() string {
 	return d.protocol
+}
+
+func (d *Device) FirewallMark() int {
+	return d.firewallMark
 }

--- a/internal/entity/device_test.go
+++ b/internal/entity/device_test.go
@@ -12,8 +12,9 @@ func TestNewDevice(t *testing.T) {
 	privateKey := make([]byte, 32)
 	privateKey[0] = 1
 	protocol := "ipv4"
+	firewallMark := 0xca6c
 
-	device := entity.NewDevice(name, listenPort, privateKey, protocol)
+	device := entity.NewDevice(name, listenPort, privateKey, protocol, firewallMark)
 
 	if device == nil {
 		t.Fatal("Expected device to be created")
@@ -29,6 +30,10 @@ func TestNewDevice(t *testing.T) {
 
 	if device.Protocol() != protocol {
 		t.Errorf("Expected protocol %s, got %s", protocol, device.Protocol())
+	}
+
+	if device.FirewallMark() != firewallMark {
+		t.Errorf("Expected firewall mark %#x, got %#x", firewallMark, device.FirewallMark())
 	}
 
 	// Check private key
@@ -51,7 +56,7 @@ func TestDevice_Name(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			device := entity.NewDevice(tt.deviceName, 51820, make([]byte, 32), "ipv4")
+			device := entity.NewDevice(tt.deviceName, 51820, make([]byte, 32), "ipv4", 0)
 
 			if device.Name() != tt.deviceName {
 				t.Errorf("Expected name %s, got %s", tt.deviceName, device.Name())
@@ -73,7 +78,7 @@ func TestDevice_ListenPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			device := entity.NewDevice("wg0", tt.listenPort, make([]byte, 32), "ipv4")
+			device := entity.NewDevice("wg0", tt.listenPort, make([]byte, 32), "ipv4", 0)
 
 			if device.ListenPort() != tt.listenPort {
 				t.Errorf("Expected listen port %d, got %d", tt.listenPort, device.ListenPort())
@@ -88,7 +93,7 @@ func TestDevice_PrivateKey(t *testing.T) {
 		privateKey[i] = byte(i)
 	}
 
-	device := entity.NewDevice("wg0", 51820, privateKey, "ipv4")
+	device := entity.NewDevice("wg0", 51820, privateKey, "ipv4", 0)
 	retrievedKey := device.PrivateKey()
 
 	// Verify key is copied correctly
@@ -118,7 +123,7 @@ func TestDevice_Protocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			device := entity.NewDevice("wg0", 51820, make([]byte, 32), tt.protocol)
+			device := entity.NewDevice("wg0", 51820, make([]byte, 32), tt.protocol, 0)
 
 			if device.Protocol() != tt.protocol {
 				t.Errorf("Expected protocol %s, got %s", tt.protocol, device.Protocol())
@@ -129,7 +134,7 @@ func TestDevice_Protocol(t *testing.T) {
 
 func TestDevice_GettersImmutability(t *testing.T) {
 	// Test that getters return values, not references that can be modified
-	device := entity.NewDevice("wg0", 51820, make([]byte, 32), "ipv4")
+	device := entity.NewDevice("wg0", 51820, make([]byte, 32), "ipv4", 0)
 
 	// Get private key twice and modify first
 	key1 := device.PrivateKey()

--- a/internal/repo/devices_test.go
+++ b/internal/repo/devices_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_DeviceFind(t *testing.T) {
 	deviceName := entity.DeviceId("wg0")
-	device := entity.NewDevice(deviceName, 6379, []byte{}, "ipv4")
+	device := entity.NewDevice(deviceName, 6379, []byte{}, "ipv4", 0)
 
 	devices := repo.NewDevices()
 	devices.Save(context.TODO(), device)
@@ -57,15 +57,15 @@ func Test_DeviceList(t *testing.T) {
 		{
 			name: "single device",
 			devices: []*entity.Device{
-				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4"),
+				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4", 0),
 			},
 		},
 		{
 			name: "multiple devices",
 			devices: []*entity.Device{
-				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4"),
-				entity.NewDevice(entity.DeviceId("wg1"), 6380, []byte{}, "ipv4"),
-				entity.NewDevice(entity.DeviceId("wg2"), 6381, []byte{}, "ipv4"),
+				entity.NewDevice(entity.DeviceId("wg0"), 6379, []byte{}, "ipv4", 0),
+				entity.NewDevice(entity.DeviceId("wg1"), 6380, []byte{}, "ipv4", 0),
+				entity.NewDevice(entity.DeviceId("wg2"), 6381, []byte{}, "ipv4", 0),
 			},
 		},
 	}

--- a/internal/stun/resolver.go
+++ b/internal/stun/resolver.go
@@ -23,7 +23,7 @@ type Resolver struct {
 	deviceConfig *config.DeviceConfig
 	logger       zerolog.Logger
 	mu           sync.Mutex
-	newClient    func(ctx context.Context, deviceName string, port uint16, protocol string) (StunClient, error)
+	newClient    func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (StunClient, error)
 }
 
 func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logger *zerolog.Logger) *Resolver {
@@ -31,16 +31,18 @@ func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logge
 		config:       config,
 		deviceConfig: deviceConfig,
 		logger:       logger.With().Str("component", "stun").Logger(),
-		newClient: func(ctx context.Context, deviceName string, port uint16, protocol string) (StunClient, error) {
-			return New(ctx, deviceName, port, protocol)
+		newClient: func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (StunClient, error) {
+			return New(ctx, deviceName, port, protocol, firewallMark)
 		},
 	}
 }
 
 // Resolve performs STUN discovery for the specified device and protocol
 // protocol must be "ipv4" or "ipv6" (not "dualstack")
+// firewallMark is the device's fwmark, mirrored onto the probe socket so it
+// follows the same routing path as the traffic it measures (Linux only)
 // Returns error if STUN discovery fails or returns invalid endpoint (port=0 or empty host)
-func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, protocol string) (_ string, _ int, err error) {
+func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (_ string, _ int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -48,7 +50,7 @@ func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, 
 
 	r.logger.Debug().Str("device", deviceName).Str("protocol", protocol).Msg("resolving with protocol")
 
-	stun, err := r.newClient(stunCtx, deviceName, port, protocol)
+	stun, err := r.newClient(stunCtx, deviceName, port, protocol, firewallMark)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/stun/resolver_test.go
+++ b/internal/stun/resolver_test.go
@@ -53,11 +53,54 @@ func newTestResolver(t *testing.T, client *mockStunClient, servers []string) *Re
 		config:       cfg,
 		deviceConfig: &config.DeviceConfig{},
 		logger:       logger,
-		newClient: func(_ context.Context, _ string, _ uint16, _ string) (StunClient, error) {
+		newClient: func(_ context.Context, _ string, _ uint16, _ string, _ int) (StunClient, error) {
 			return client, nil
 		},
 	}
 	return r
+}
+
+// The mark only does its job if it reaches the socket, so pin the handoff:
+// Resolve must pass the caller's fwmark through to the client it builds.
+func TestResolver_ForwardsFirewallMarkToClient(t *testing.T) {
+	tests := []struct {
+		name string
+		mark int
+	}{
+		{name: "unset", mark: 0},
+		{name: "wg-quick style mark", mark: 0xca6c},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockStunClient{
+				connectResults: []connectResult{
+					{host: "1.2.3.4", port: 54321, err: nil},
+				},
+			}
+
+			gotMark := -1
+			logger := zerolog.Nop()
+			r := &Resolver{
+				config: &config.Config{
+					Stun: config.Stun{Addresses: []string{"stun.example.com:3478"}},
+				},
+				deviceConfig: &config.DeviceConfig{},
+				logger:       logger,
+				newClient: func(_ context.Context, _ string, _ uint16, _ string, firewallMark int) (StunClient, error) {
+					gotMark = firewallMark
+					return client, nil
+				},
+			}
+
+			if _, _, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", tt.mark); err != nil {
+				t.Fatalf("Resolve: unexpected error: %v", err)
+			}
+			if gotMark != tt.mark {
+				t.Errorf("firewallMark reaching the client = %#x, want %#x", gotMark, tt.mark)
+			}
+		})
+	}
 }
 
 func TestResolver_FirstServerSucceeds(t *testing.T) {
@@ -73,7 +116,7 @@ func TestResolver_FirstServerSucceeds(t *testing.T) {
 		"stun3.example.com:3478",
 	})
 
-	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -102,7 +145,7 @@ func TestResolver_MiddleServerSucceeds(t *testing.T) {
 		"stun3.example.com:3478",
 	})
 
-	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -133,7 +176,7 @@ func TestResolver_LastServerSucceeds(t *testing.T) {
 		"stun3.example.com:3478",
 	})
 
-	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -163,7 +206,7 @@ func TestResolver_AllServersFail(t *testing.T) {
 		"stun3.example.com:3478",
 	})
 
-	_, _, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	_, _, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if !errors.Is(err, ErrAllServersFailed) {
 		t.Errorf("expected ErrAllServersFailed, got: %v", err)
 	}
@@ -186,7 +229,7 @@ func TestResolver_InvalidEndpointSkipped(t *testing.T) {
 		"stun2.example.com:3478",
 	})
 
-	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -212,7 +255,7 @@ func TestResolver_SingleServer_Success(t *testing.T) {
 		"stun.example.com:3478",
 	})
 
-	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4")
+	host, port, err := r.Resolve(context.Background(), "wg0", 51820, "ipv4", 0)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/internal/stun/stun_darwinbsd.go
+++ b/internal/stun/stun_darwinbsd.go
@@ -75,7 +75,11 @@ func configureBPFFilter(ctx context.Context, linkType uint32, port uint16, proto
 	return filter, payloadOff, nil
 }
 
-func New(ctx context.Context, excludeInterface string, port uint16, protocol string) (*Stun, error) {
+// firewallMark is accepted and ignored here: SO_MARK is a Linux socket option
+// with no darwin/freebsd equivalent, so the STUN socket cannot be pinned to the
+// device's routing path the way it is on Linux. ping_monitor_darwinbsd.go gives
+// up on device binding for the same reason.
+func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int) (*Stun, error) {
 	logger := zerolog.Ctx(ctx)
 
 	// Get all eligible interfaces (excluding the specific WireGuard interface)

--- a/internal/stun/stun_linux.go
+++ b/internal/stun/stun_linux.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	stun "github.com/pion/stun/v3"
@@ -26,13 +27,37 @@ type Stun struct {
 	packetChan chan []byte
 }
 
-func createRawSocket(protocol string, logger zerolog.Logger) (net.PacketConn, error) {
+// markControl stamps firewallMark on the socket before it is bound, so the
+// probe is routed exactly like the WireGuard traffic whose NAT mapping it
+// measures. Without it a policy-routing rule keyed on the mark -- the one
+// wg-quick installs to keep WireGuard's own packets out of its tunnel -- sends
+// the probe down a different path, and the endpoint we discover is the wrong
+// NAT's.
+func markControl(firewallMark int) func(string, string, syscall.RawConn) error {
+	return func(_, _ string, c syscall.RawConn) error {
+		var setErr error
+		if err := c.Control(func(fd uintptr) {
+			setErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, firewallMark)
+		}); err != nil {
+			return err
+		}
+		return setErr
+	}
+}
+
+func createRawSocket(ctx context.Context, protocol string, firewallMark int, logger zerolog.Logger) (net.PacketConn, error) {
+	var lc net.ListenConfig
+	if firewallMark != 0 {
+		lc.Control = markControl(firewallMark)
+		logger.Debug().Int("fwmark", firewallMark).Msg("marking STUN socket to match the device")
+	}
+
 	if protocol == "ipv6" {
 		logger.Debug().Msg("creating IPv6 raw socket")
-		return net.ListenPacket("ip6:17", "")
+		return lc.ListenPacket(ctx, "ip6:17", "")
 	}
 	logger.Debug().Msg("creating IPv4 raw socket")
-	return net.ListenPacket("ip4:17", "0.0.0.0")
+	return lc.ListenPacket(ctx, "ip4:17", "0.0.0.0")
 }
 
 func setPacketConn(s *Stun, c net.PacketConn, filter []bpf.RawInstruction) error {
@@ -60,10 +85,10 @@ func setPacketConn(s *Stun, c net.PacketConn, filter []bpf.RawInstruction) error
 	return nil
 }
 
-func New(ctx context.Context, excludeInterface string, port uint16, protocol string) (*Stun, error) {
+func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int) (*Stun, error) {
 	logger := zerolog.Ctx(ctx)
 
-	c, err := createRawSocket(protocol, *logger)
+	c, err := createRawSocket(ctx, protocol, firewallMark, *logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stun/stun_linux_test.go
+++ b/internal/stun/stun_linux_test.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package stun
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// sockMark reads SO_MARK back off a socket.
+func sockMark(c net.PacketConn) (int, error) {
+	sc, ok := c.(syscall.Conn)
+	if !ok {
+		return 0, fmt.Errorf("%T does not expose its fd", c)
+	}
+	rc, err := sc.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+
+	var mark int
+	var getErr error
+	if err := rc.Control(func(fd uintptr) {
+		mark, getErr = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK)
+	}); err != nil {
+		return 0, err
+	}
+	return mark, getErr
+}
+
+// TestCreateRawSocket_AppliesFirewallMark covers the one step the resolver
+// tests cannot reach: that the mark actually lands on the socket. It needs
+// root, because a raw socket needs CAP_NET_RAW and SO_MARK needs
+// CAP_NET_ADMIN. Without it, nothing would catch createRawSocket silently
+// dropping the mark -- SO_MARK failing open looks exactly like success.
+func TestCreateRawSocket_AppliesFirewallMark(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: raw socket requires CAP_NET_RAW and SO_MARK requires CAP_NET_ADMIN")
+	}
+
+	tests := []struct {
+		name     string
+		protocol string
+		mark     int
+	}{
+		{name: "ipv4 marked", protocol: "ipv4", mark: 0xca6c},
+		{name: "ipv6 marked", protocol: "ipv6", mark: 0xca6c},
+		// The unmarked cases pin the no-op promise: with no fwmark on the
+		// device we must leave the socket exactly as it was.
+		{name: "ipv4 unmarked", protocol: "ipv4", mark: 0},
+		{name: "ipv6 unmarked", protocol: "ipv6", mark: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zerolog.Nop()
+
+			c, err := createRawSocket(t.Context(), tt.protocol, tt.mark, logger)
+			if err != nil {
+				// A kernel built without IPv6 cannot open the socket at all;
+				// that is the environment's answer, not a failure of ours.
+				if tt.protocol == "ipv6" && (errors.Is(err, syscall.EAFNOSUPPORT) || errors.Is(err, syscall.EPROTONOSUPPORT)) {
+					t.Skipf("no IPv6 support in this kernel: %v", err)
+				}
+				t.Fatalf("createRawSocket: %v", err)
+			}
+			defer func() {
+				if err := c.Close(); err != nil {
+					t.Errorf("close: %v", err)
+				}
+			}()
+
+			got, err := sockMark(c)
+			if err != nil {
+				t.Fatalf("read back SO_MARK: %v", err)
+			}
+			if got != tt.mark {
+				t.Errorf("SO_MARK on the socket = %#x, want %#x", got, tt.mark)
+			}
+		})
+	}
+}

--- a/internal/wg/api.go
+++ b/internal/wg/api.go
@@ -10,6 +10,8 @@ type DeviceInfo struct {
 	PrivateKey Key
 	PublicKey  Key
 	PeerKeys   []Key
+	// Zero means unset. int, not uint32, to match wgctrl's own type.
+	FirewallMark int
 }
 
 // PeerEndpointUpdate describes a peer endpoint change to apply to a device.

--- a/internal/wg/client_cli.go
+++ b/internal/wg/client_cli.go
@@ -73,6 +73,10 @@ func parseDeviceDump(name string, output []byte) (*DeviceInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("wg show dump: failed to parse listen-port")
 	}
+	fwmark, err := parseFwmark(devFields[3])
+	if err != nil {
+		return nil, fmt.Errorf("wg show dump: failed to parse fwmark")
+	}
 
 	var peerKeys []Key
 	for _, raw := range lines[1:] {
@@ -92,12 +96,31 @@ func parseDeviceDump(name string, output []byte) (*DeviceInfo, error) {
 	}
 
 	return &DeviceInfo{
-		Name:       name,
-		ListenPort: port,
-		PrivateKey: priv,
-		PublicKey:  pub,
-		PeerKeys:   peerKeys,
+		Name:         name,
+		ListenPort:   port,
+		PrivateKey:   priv,
+		PublicKey:    pub,
+		PeerKeys:     peerKeys,
+		FirewallMark: fwmark,
 	}, nil
+}
+
+// parseFwmark reads the fwmark field of a `wg show dump` device line, which
+// wg(8) prints as "off" or 0x%x. Anything else means the format moved, and
+// reporting no mark would silently cost STUN path parity.
+func parseFwmark(s string) (int, error) {
+	if s == "off" {
+		return 0, nil
+	}
+	hex, ok := strings.CutPrefix(s, "0x")
+	if !ok {
+		return 0, fmt.Errorf(`expected "off" or a 0x-prefixed hex value`)
+	}
+	v, err := strconv.ParseUint(hex, 16, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int(uint32(v)), nil
 }
 
 func decodeKey(s string) (Key, error) {

--- a/internal/wg/client_cli_test.go
+++ b/internal/wg/client_cli_test.go
@@ -93,6 +93,53 @@ func TestCliClient_Device_ParseSuccess(t *testing.T) {
 	}
 }
 
+func TestCliClient_Device_ParseFirewallMark(t *testing.T) {
+	privB64 := keyB64(0x01)
+	pubB64 := keyB64(0x02)
+
+	tests := []struct {
+		name    string
+		field   string
+		want    int
+		wantErr bool
+	}{
+		{name: "off means no mark", field: "off", want: 0},
+		{name: "wg-quick style mark", field: "0xca6c", want: 51820},
+		{name: "uppercase hex digits", field: "0xCA6C", want: 51820},
+		// Deliberately not 0xffffffff: FirewallMark is an int, matching
+		// wgctrl's own type, and the build matrix includes 32-bit mipsle and
+		// arm where an untyped 0xffffffff constant does not fit an int.
+		{name: "large mark", field: "0x7fffffff", want: 0x7fffffff},
+		{name: "not a number", field: "bogus", wantErr: true},
+		// wg(8) only ever emits "off" or 0x%x, so a bare decimal means the
+		// format moved. Reading it as "no mark" would silently cost STUN path
+		// parity, so fail loudly like every other field on this line does.
+		{name: "bare decimal is not wg's format", field: "51820", wantErr: true},
+		{name: "empty", field: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dump := strings.Join([]string{privB64, pubB64, "51820", tt.field}, "\t") + "\n"
+			c := &cliClient{runner: fakeRunner([]byte(dump), nil)}
+
+			info, err := c.Device("testdev")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Device: expected error for fwmark field %q, got none", tt.field)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Device: unexpected error: %v", err)
+			}
+			if info.FirewallMark != tt.want {
+				t.Errorf("FirewallMark = %#x, want %#x", info.FirewallMark, tt.want)
+			}
+		})
+	}
+}
+
 func TestCliClient_UpdatePeerEndpoint_IPv4(t *testing.T) {
 	var captured []capturedCall
 	c := &cliClient{runner: capturingRunner(nil, nil, &captured)}

--- a/internal/wg/client_ctrl.go
+++ b/internal/wg/client_ctrl.go
@@ -33,11 +33,12 @@ func (cc *ctrlClient) Device(name string) (*DeviceInfo, error) {
 	}
 
 	return &DeviceInfo{
-		Name:       d.Name,
-		ListenPort: d.ListenPort,
-		PrivateKey: Key(d.PrivateKey),
-		PublicKey:  Key(d.PublicKey),
-		PeerKeys:   peerKeys,
+		Name:         d.Name,
+		ListenPort:   d.ListenPort,
+		PrivateKey:   Key(d.PrivateKey),
+		PublicKey:    Key(d.PublicKey),
+		PeerKeys:     peerKeys,
+		FirewallMark: d.FirewallMark,
 	}, nil
 }
 


### PR DESCRIPTION
## What

STUN discovery probes from the WireGuard listen port to learn the NAT mapping WireGuard's own traffic will use. That only holds if the probe and the tunnel traffic take the same route — and they need not.

WireGuard stamps an fwmark on the packets it sends so policy routing can keep its own traffic out of the tunnel it manages (what `wg-quick` sets up with `Table = auto`). The STUN probe went out of an **unmarked** raw socket following the plain default route, so where the two diverge, discovery measures some other path's NAT and publishes an endpoint that never had a chance of working — **silently**.

This mirrors the device's fwmark onto the probe socket with `SO_MARK`, so the probe is routed by construction like the traffic it measures.

## How it's scoped

- **Load once at bootstrap, keep for the process lifetime** — fwmark joins `listenPort` / `privateKey` / `protocol` on `entity.Device`, under the same rule. A wg-side change already requires restarting stunmesh (now documented), so there is nothing to refresh.
- **Zero mark is a no-op** — the socket is left untouched, so the common case is unchanged.
- **Linux only** — `SO_MARK` has no darwin/freebsd equivalent; those platforms take the argument and ignore it, as `ping_monitor_darwinbsd.go` already does for device binding.
- **Does not touch routing** — the `ip rule` + table that consume the mark stay `wg-quick`'s job. This only makes the probe join the traffic class WireGuard already put itself in; it is not full-tunnel support on its own.

## Commits

1. `feat(wg)` — expose device fwmark from both backends (wgctrl direct; wgcli parses the 4th dump field, `off` / `0x%x`)
2. `feat(entity)` — carry fwmark on `Device`
3. `feat(stun)` — mark the probe socket via `SO_MARK`
4. `docs` — fwmark behaviour + the restart contract (incl. systemd `BindsTo=`)
5. `test(stun)` — read `SO_MARK` back off the socket; root-gated, CI runs the suite under sudo

## Testing

- Plumbing (fwmark reaches the socket call) verified via the resolver seam and a gomock exact-value expectation — no root needed. Both mutation-tested.
- The `setsockopt(SO_MARK)` itself is verified by reading the mark back with `getsockopt` (v4/v6, marked/unmarked). Needs `CAP_NET_RAW` + `CAP_NET_ADMIN`, so it skips without root and CI now runs `make test` under `sudo -E env`.
- Build matrix (linux/darwin/freebsd × amd64/arm64/arm/mipsle × wgctrl/wgcli) all green locally; `wire .` produces no diff.