### PR TITLE
docs: drop private-key rotation from the restart table

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ stunmesh-go reads the WireGuard device's state once at startup and keeps it for 
 | `wg-quick down` then `up`, or otherwise recreating the interface | If the WireGuard config does not pin `ListenPort`, the kernel picks a **new random port** every time. stunmesh-go would keep probing the old one and publish an endpoint nobody is listening on. |
 | `wg set <dev> listen-port ...` | Same as above. |
 | `wg set <dev> fwmark ...` | The probe socket keeps the old mark and stops matching the device's routing path. |
-| Rotating the interface's private key | Peers pin your old public key, so WireGuard itself will not pair until every side is reconfigured. |
 | Editing `config.yaml` | The config is read once at startup; there is no reload. |
 
 Under systemd, tie the two units together so this is enforced rather than remembered:


### PR DESCRIPTION
Follow-up to #204.

The "When stunmesh-go must be restarted" table is meant for wg-side changes that make stunmesh-go **silently** act on a stale value while the tunnel itself stays up — `ListenPort` and `fwmark`. Private-key rotation doesn't fit:

- WireGuard's own handshake breaks first and **loudly** — peers pin your old public key, so the tunnel is down at the WireGuard layer regardless of stunmesh-go.
- Restarting stunmesh-go isn't the remedy; re-keying every peer is. Listing it in a "restart stunmesh-go" table implied the restart was the fix.
- It's subsumed by the `config.yaml` row anyway — a mesh re-key means editing configs and restarting everything.

Keeping the table to the genuinely stunmesh-specific, silent-failure cases.