### PR TITLE
feat(stun): restrict listen interfaces on darwin/bsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Once getting info from internet, it will setup peer endpoint with wireguard tool
 
 **Linux**: Uses raw sockets with BPF filtering to listen on all interfaces system-wide. No interface-specific limitations.
 
-**FreeBSD and macOS (BSD-based systems)**: Uses BPF with interface-specific packet capture. stunmesh-go will listen on all eligible network interfaces for STUN response messages, excluding the specific WireGuard interface being managed. This provides better resilience for systems with multiple network paths or backup routes compared to single default route dependency.
+**FreeBSD and macOS (BSD-based systems)**: Uses BPF with interface-specific packet capture. By default stunmesh-go listens on all eligible network interfaces for STUN response messages, excluding the specific WireGuard interface being managed. This provides better resilience for systems with multiple network paths or backup routes compared to single default route dependency. The set of interfaces can be narrowed — see [Restricting listen interfaces](#restricting-listen-interfaces-freebsdmacos).
 
 ### Firewall mark (Linux only)
 
@@ -71,6 +71,29 @@ Two caveats:
 
 - **It does not make an exit-node / full-tunnel setup work on its own.** stunmesh-go never touches the routing table. The `ip rule` and routing table entries that consume the mark are `wg-quick`'s job (or yours). stunmesh-go only makes sure its probe joins the traffic class WireGuard already put itself in.
 - **`SO_MARK` is Linux-only.** FreeBSD and macOS have no equivalent, so the probe socket cannot be pinned to the device's routing path there.
+
+### Restricting listen interfaces (FreeBSD/macOS)
+
+By default the BSD backend opens a capture handle on every eligible interface. On a host with many interfaces that is wasteful, and on some it is undesirable. Two per-interface options narrow it down:
+
+```yaml
+interfaces:
+  wg0:
+    protocol: "dualstack"
+    listen_interfaces: ["em0", "em1"]   # only capture on these
+    listen_default_route: true          # also capture on the default-route interface
+```
+
+- **`listen_interfaces`** (list of strings, default empty): the underlay interfaces to capture on. Empty means "all eligible" — the historical behavior.
+- **`listen_default_route`** (bool, default `false`): additionally capture on the interface that carries the default route, resolved per-protocol (the IPv4 and IPv6 default routes may live on different interfaces).
+
+The two are **additive, not mutually exclusive** — the effective set is the union of `listen_interfaces` and, when `listen_default_route` is `true`, the default-route interface. When both are unset the backend listens on all eligible interfaces, so existing configs are unaffected.
+
+Semantics:
+
+- If neither option is set, all eligible interfaces are used (unchanged default).
+- A name in `listen_interfaces` that does not exist on the system, or an interface that cannot be opened right now, is warned about and skipped rather than fatal — the daemon retries every refresh cycle. If the selection ends up empty, discovery fails loudly for that protocol (in `dualstack` a single failed family is tolerated as long as the other succeeds).
+- **Linux ignores both options.** Its raw socket is system-wide with no per-interface listen; setting either key logs a one-time warning and has no other effect.
 
 ## Build
 

--- a/internal/config/device.go
+++ b/internal/config/device.go
@@ -34,8 +34,16 @@ func (p *Peer) GetProtocol() string {
 }
 
 type Interface struct {
-	Protocol string          `mapstructure:"protocol"`
-	Peers    map[string]Peer `mapstructure:"peers"`
+	Protocol string `mapstructure:"protocol"`
+	// ListenInterfaces restricts which underlay interfaces STUN discovery
+	// listens on (darwin/bsd only; Linux uses a system-wide raw socket and
+	// ignores it). Empty means "all eligible interfaces" -- the default.
+	ListenInterfaces []string `mapstructure:"listen_interfaces"`
+	// ListenDefaultRoute additionally listens on the default-route interface,
+	// resolved per-protocol (darwin/bsd only). Combined with ListenInterfaces
+	// as a union; the two are additive, not mutually exclusive.
+	ListenDefaultRoute bool            `mapstructure:"listen_default_route"`
+	Peers              map[string]Peer `mapstructure:"peers"`
 }
 
 // GetProtocol returns the configured protocol, defaulting to "ipv4" for backward compatibility
@@ -68,6 +76,19 @@ func (c *DeviceConfig) GetInterfaceProtocol(deviceName string) string {
 		return "ipv4"
 	}
 	return device.GetProtocol()
+}
+
+// GetListenConfig returns the interface's underlay-listen restriction for STUN
+// discovery: the explicit interface names and whether to also include the
+// default-route interface. A nil/empty list with defaultRoute false means
+// "listen on all" -- the zero-breaking default. Only darwin/bsd honor these;
+// Linux ignores them (warned about at config load).
+func (c *DeviceConfig) GetListenConfig(deviceName string) (interfaces []string, defaultRoute bool) {
+	device, ok := c.interfaces[deviceName]
+	if !ok {
+		return nil, false
+	}
+	return device.ListenInterfaces, device.ListenDefaultRoute
 }
 
 func (c *DeviceConfig) GetConfigPeers(ctx context.Context, deviceName string, localPublicKey []byte) ([]*entity.Peer, error) {

--- a/internal/config/listen_test.go
+++ b/internal/config/listen_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadConfigFromYAML writes content to a temp config.yaml and loads it.
+func loadConfigFromYAML(t *testing.T, content string) *Config {
+	t.Helper()
+	resetViper()
+
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPaths := Paths
+	Paths = []string{tmpDir}
+	defer func() { Paths = originalPaths }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	return cfg
+}
+
+func TestGetListenConfig_Parsed(t *testing.T) {
+	cfg := loadConfigFromYAML(t, `
+interfaces:
+  wg0:
+    protocol: dualstack
+    listen_interfaces: ["em0", "em1"]
+    listen_default_route: true
+    peers: {}
+`)
+
+	dc := NewDeviceConfig(cfg)
+	interfaces, defaultRoute := dc.GetListenConfig("wg0")
+
+	if want := []string{"em0", "em1"}; len(interfaces) != 2 || interfaces[0] != want[0] || interfaces[1] != want[1] {
+		t.Errorf("interfaces = %v, want %v", interfaces, want)
+	}
+	if !defaultRoute {
+		t.Error("defaultRoute = false, want true")
+	}
+}
+
+// TestGetListenConfig_Defaults pins the zero-breaking default: an interface that
+// omits both keys reports no restriction, which the STUN layer reads as "listen
+// on all".
+func TestGetListenConfig_Defaults(t *testing.T) {
+	cfg := loadConfigFromYAML(t, `
+interfaces:
+  wg0:
+    protocol: ipv4
+    peers: {}
+`)
+
+	dc := NewDeviceConfig(cfg)
+	interfaces, defaultRoute := dc.GetListenConfig("wg0")
+
+	if len(interfaces) != 0 {
+		t.Errorf("interfaces = %v, want empty", interfaces)
+	}
+	if defaultRoute {
+		t.Error("defaultRoute = true, want false")
+	}
+}
+
+// TestGetListenConfig_UnknownDevice must not panic and reports no restriction.
+func TestGetListenConfig_UnknownDevice(t *testing.T) {
+	cfg := loadConfigFromYAML(t, `
+interfaces:
+  wg0:
+    protocol: ipv4
+    peers: {}
+`)
+
+	dc := NewDeviceConfig(cfg)
+	interfaces, defaultRoute := dc.GetListenConfig("does-not-exist")
+
+	if len(interfaces) != 0 || defaultRoute {
+		t.Errorf("GetListenConfig(unknown) = (%v, %v), want (empty, false)", interfaces, defaultRoute)
+	}
+}

--- a/internal/stun/resolver.go
+++ b/internal/stun/resolver.go
@@ -23,7 +23,7 @@ type Resolver struct {
 	deviceConfig *config.DeviceConfig
 	logger       zerolog.Logger
 	mu           sync.Mutex
-	newClient    func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (StunClient, error)
+	newClient    func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int, listenInterfaces []string, listenDefaultRoute bool) (StunClient, error)
 }
 
 func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logger *zerolog.Logger) *Resolver {
@@ -31,8 +31,8 @@ func NewResolver(config *config.Config, deviceConfig *config.DeviceConfig, logge
 		config:       config,
 		deviceConfig: deviceConfig,
 		logger:       logger.With().Str("component", "stun").Logger(),
-		newClient: func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int) (StunClient, error) {
-			return New(ctx, deviceName, port, protocol, firewallMark)
+		newClient: func(ctx context.Context, deviceName string, port uint16, protocol string, firewallMark int, listenInterfaces []string, listenDefaultRoute bool) (StunClient, error) {
+			return New(ctx, deviceName, port, protocol, firewallMark, listenInterfaces, listenDefaultRoute)
 		},
 	}
 }
@@ -50,7 +50,12 @@ func (r *Resolver) Resolve(ctx context.Context, deviceName string, port uint16, 
 
 	r.logger.Debug().Str("device", deviceName).Str("protocol", protocol).Msg("resolving with protocol")
 
-	stun, err := r.newClient(stunCtx, deviceName, port, protocol, firewallMark)
+	// The underlay-listen restriction is static interface config, so read it
+	// here rather than threading it through the publish controller. Only
+	// darwin/bsd act on it; Linux ignores it (warns once, see stun_linux.go).
+	listenInterfaces, listenDefaultRoute := r.deviceConfig.GetListenConfig(deviceName)
+
+	stun, err := r.newClient(stunCtx, deviceName, port, protocol, firewallMark, listenInterfaces, listenDefaultRoute)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/stun/resolver_test.go
+++ b/internal/stun/resolver_test.go
@@ -53,7 +53,7 @@ func newTestResolver(t *testing.T, client *mockStunClient, servers []string) *Re
 		config:       cfg,
 		deviceConfig: &config.DeviceConfig{},
 		logger:       logger,
-		newClient: func(_ context.Context, _ string, _ uint16, _ string, _ int) (StunClient, error) {
+		newClient: func(_ context.Context, _ string, _ uint16, _ string, _ int, _ []string, _ bool) (StunClient, error) {
 			return client, nil
 		},
 	}
@@ -87,7 +87,7 @@ func TestResolver_ForwardsFirewallMarkToClient(t *testing.T) {
 				},
 				deviceConfig: &config.DeviceConfig{},
 				logger:       logger,
-				newClient: func(_ context.Context, _ string, _ uint16, _ string, firewallMark int) (StunClient, error) {
+				newClient: func(_ context.Context, _ string, _ uint16, _ string, firewallMark int, _ []string, _ bool) (StunClient, error) {
 					gotMark = firewallMark
 					return client, nil
 				},

--- a/internal/stun/stun_darwinbsd.go
+++ b/internal/stun/stun_darwinbsd.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	pcap "github.com/packetcap/go-pcap"
@@ -16,6 +18,7 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+	"golang.org/x/net/route"
 )
 
 const PacketSize = 1600
@@ -79,26 +82,37 @@ func configureBPFFilter(ctx context.Context, linkType uint32, port uint16, proto
 // with no darwin/freebsd equivalent, so the STUN socket cannot be pinned to the
 // device's routing path the way it is on Linux. ping_monitor_darwinbsd.go gives
 // up on device binding for the same reason.
-func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int) (*Stun, error) {
+//
+// listenInterfaces and listenDefaultRoute restrict which underlay interfaces to
+// open (see resolveListenInterfaces). Empty list + false keeps the historical
+// "open every eligible interface" behavior.
+func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int, listenInterfaces []string, listenDefaultRoute bool) (*Stun, error) {
 	logger := zerolog.Ctx(ctx)
 
-	// Get all eligible interfaces (excluding the specific WireGuard interface)
-	interfaceNames, err := getAllEligibleInterfaces(excludeInterface)
+	interfaceNames, required, err := resolveListenInterfaces(logger, protocol, excludeInterface, listenInterfaces, listenDefaultRoute, net.Interfaces, defaultRouteInterface)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Debug().Msgf("found %d eligible interfaces (excluding %s): %v", len(interfaceNames), excludeInterface, interfaceNames)
+	logger.Debug().Msgf("listening on %d interface(s) (excluding %s): %v", len(interfaceNames), excludeInterface, interfaceNames)
 
 	var handles []interfaceHandle
 
-	// Create pcap handle for each eligible interface
+	// Create pcap handle for each selected interface
 	for _, ifaceName := range interfaceNames {
 		logger.Debug().Msgf("attempting to register OpenLive for interface: %s", ifaceName)
 		handle, err := pcap.OpenLive(ctx, ifaceName, PacketSize, false, time.Duration(StunTimeout)*time.Second, pcap.DefaultSyscalls)
 		if err != nil {
-			logger.Debug().Msgf("failed to open interface %s: %v", ifaceName, err)
-			// Skip interfaces that can't be opened
+			// Tolerate open failures and move on; the daemon retries every
+			// refresh cycle, so a transiently-down interface heals itself. An
+			// interface the user named explicitly gets a louder warn (they
+			// asked for it), the scan-all default stays at debug. If nothing
+			// opens at all, the len(handles)==0 check below still errors.
+			if required[ifaceName] {
+				logger.Warn().Err(err).Msgf("requested interface %s could not be opened, skipping", ifaceName)
+			} else {
+				logger.Debug().Msgf("failed to open interface %s: %v", ifaceName, err)
+			}
 			continue
 		}
 
@@ -319,29 +333,155 @@ func createStunBindingPacket(srcPort, dstPort uint16) ([]byte, error) {
 	return append(buf, msg.Raw...), nil
 }
 
-func getAllEligibleInterfaces(excludeInterface string) ([]string, error) {
-	interfaces, err := net.Interfaces()
+// resolveListenInterfaces decides which underlay interfaces STUN discovery
+// should open for the given protocol.
+//
+// With no selector (empty listenInterfaces and listenDefaultRoute false) it
+// returns every eligible interface -- up, non-loopback, and not the WireGuard
+// interface itself -- preserving the historical open-everything behavior.
+//
+// With a selector active it returns the union of the explicitly named
+// interfaces and, when listenDefaultRoute is set, the default-route interface
+// for this protocol (the two are additive, not mutually exclusive). Names
+// absent from the system (typos) and a missing default route are warned and
+// skipped rather than fatal; New's "no usable interfaces" check is the backstop
+// when the union comes out empty. The returned required set marks the
+// explicitly named interfaces so New can warn louder if one fails to open.
+func resolveListenInterfaces(
+	logger *zerolog.Logger,
+	protocol, excludeInterface string,
+	listenInterfaces []string,
+	listenDefaultRoute bool,
+	allInterfaces func() ([]net.Interface, error),
+	defaultRoute func(protocol string) (string, error),
+) ([]string, map[string]bool, error) {
+	interfaces, err := allInterfaces()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var eligible []string
+	if len(listenInterfaces) == 0 && !listenDefaultRoute {
+		var eligible []string
+		for _, iface := range interfaces {
+			// Skip loopback, down, and the WireGuard interface we're excluding
+			if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+				continue
+			}
+			if iface.Name == excludeInterface {
+				continue
+			}
+			eligible = append(eligible, iface.Name)
+		}
+		if len(eligible) == 0 {
+			return nil, nil, errors.New("no eligible interfaces found")
+		}
+		return eligible, nil, nil
+	}
+
+	present := make(map[string]bool, len(interfaces))
 	for _, iface := range interfaces {
-		// Skip loopback, down, and the specific WireGuard interface we're excluding
-		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-		if iface.Name == excludeInterface {
-			continue
-		}
-		eligible = append(eligible, iface.Name)
+		present[iface.Name] = true
 	}
 
-	if len(eligible) == 0 {
-		return nil, errors.New("no eligible interfaces found")
+	var names []string
+	required := make(map[string]bool)
+	seen := make(map[string]bool)
+	add := func(name string, req bool) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+		if req {
+			required[name] = true
+		}
 	}
 
-	return eligible, nil
+	for _, name := range listenInterfaces {
+		switch {
+		case name == excludeInterface:
+			logger.Warn().Msgf("listen_interfaces names the WireGuard interface %q itself; skipping (STUN cannot run through the tunnel)", name)
+		case !present[name]:
+			logger.Warn().Msgf("listen_interfaces names unknown interface %q; skipping", name)
+		default:
+			add(name, true)
+		}
+	}
+
+	if listenDefaultRoute {
+		name, err := defaultRoute(protocol)
+		switch {
+		case err != nil:
+			logger.Warn().Err(err).Str("protocol", protocol).Msg("could not resolve default-route interface; skipping")
+		case name == "":
+			logger.Debug().Str("protocol", protocol).Msg("no default-route interface for protocol; skipping")
+		case name == excludeInterface:
+			logger.Debug().Msgf("default route points at the WireGuard interface %q; skipping", name)
+		default:
+			add(name, false)
+		}
+	}
+
+	if len(names) == 0 {
+		return nil, nil, fmt.Errorf("listen restriction for %s resolved to no interfaces", protocol)
+	}
+
+	return names, required, nil
+}
+
+// defaultRouteInterface returns the interface carrying the default route for
+// the given protocol ("ipv4"/"ipv6"), read straight from the kernel routing
+// table via a routing-socket RIB dump -- no exec, no netstat parsing. v4 and v6
+// default routes can sit on different interfaces, hence per-protocol. An empty
+// name with nil error means there simply is no default route for that family
+// (a host may legitimately lack an IPv6 one).
+func defaultRouteInterface(protocol string) (string, error) {
+	af := syscall.AF_INET
+	if protocol == "ipv6" {
+		af = syscall.AF_INET6
+	}
+
+	rib, err := route.FetchRIB(af, route.RIBTypeRoute, 0)
+	if err != nil {
+		return "", err
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return "", err
+	}
+
+	for _, m := range msgs {
+		rm, ok := m.(*route.RouteMessage)
+		if !ok {
+			continue
+		}
+		// A default route goes via a gateway and its destination is the
+		// zero address (0.0.0.0 / ::). Addrs[0] is the destination.
+		if rm.Flags&syscall.RTF_GATEWAY == 0 || rm.Flags&syscall.RTF_UP == 0 {
+			continue
+		}
+		if len(rm.Addrs) == 0 || !isDefaultDestination(rm.Addrs[0]) {
+			continue
+		}
+		iface, err := net.InterfaceByIndex(rm.Index)
+		if err != nil {
+			return "", err
+		}
+		return iface.Name, nil
+	}
+
+	return "", nil
+}
+
+func isDefaultDestination(a route.Addr) bool {
+	switch v := a.(type) {
+	case *route.Inet4Addr:
+		return v.IP == [4]byte{}
+	case *route.Inet6Addr:
+		return v.IP == [16]byte{}
+	default:
+		return false
+	}
 }
 
 func stunNullBpfFilter(ctx context.Context, port uint16, protocol string) ([]bpf.RawInstruction, error) {

--- a/internal/stun/stun_darwinbsd_test.go
+++ b/internal/stun/stun_darwinbsd_test.go
@@ -88,12 +88,13 @@ func TestResolveListenInterfaces(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "naming the wg interface itself is skipped",
-			exclude:   "wg0",
-			listen:    []string{"wg0", "em0"},
-			ifaces:    ifaceList("em0", "wg0"),
-			route:     constRoute("", nil),
-			wantNames: []string{"em0"},
+			name:         "naming the wg interface itself is skipped",
+			exclude:      "wg0",
+			listen:       []string{"wg0", "em0"},
+			ifaces:       ifaceList("em0", "wg0"),
+			route:        constRoute("", nil),
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"}, // em0 is explicitly listed, so still required
 		},
 		{
 			name:         "default route interface is added (best effort, not required)",

--- a/internal/stun/stun_darwinbsd_test.go
+++ b/internal/stun/stun_darwinbsd_test.go
@@ -1,0 +1,223 @@
+//go:build darwin || freebsd
+
+package stun
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// ifaceList builds a fake net.Interfaces() returning the named interfaces, all
+// up and non-loopback unless the name is "lo0".
+func ifaceList(names ...string) func() ([]net.Interface, error) {
+	return func() ([]net.Interface, error) {
+		out := make([]net.Interface, 0, len(names))
+		for i, n := range names {
+			flags := net.FlagUp
+			if n == "lo0" {
+				flags = net.FlagUp | net.FlagLoopback
+			}
+			out = append(out, net.Interface{Index: i + 1, Name: n, Flags: flags})
+		}
+		return out, nil
+	}
+}
+
+func constRoute(name string, err error) func(string) (string, error) {
+	return func(string) (string, error) { return name, err }
+}
+
+func TestResolveListenInterfaces(t *testing.T) {
+	logger := zerolog.Nop()
+
+	tests := []struct {
+		name         string
+		protocol     string
+		exclude      string
+		listen       []string
+		defaultRoute bool
+		ifaces       func() ([]net.Interface, error)
+		route        func(string) (string, error)
+		wantNames    []string // order-insensitive
+		wantRequired []string
+		wantErr      bool
+	}{
+		{
+			name:      "no selector opens all eligible, minus loopback and wg",
+			exclude:   "wg0",
+			ifaces:    ifaceList("em0", "em1", "lo0", "wg0"),
+			route:     constRoute("", nil),
+			wantNames: []string{"em0", "em1"},
+		},
+		{
+			name:    "no selector, nothing eligible is an error",
+			exclude: "wg0",
+			ifaces:  ifaceList("lo0", "wg0"),
+			route:   constRoute("", nil),
+			wantErr: true,
+		},
+		{
+			name:         "explicit list selects only those, marked required",
+			exclude:      "wg0",
+			listen:       []string{"em0"},
+			ifaces:       ifaceList("em0", "em1", "wg0"),
+			route:        constRoute("", nil),
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"},
+		},
+		{
+			name:         "unknown interface name is skipped, not fatal",
+			exclude:      "wg0",
+			listen:       []string{"em0", "typo0"},
+			ifaces:       ifaceList("em0", "wg0"),
+			route:        constRoute("", nil),
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"},
+		},
+		{
+			name:    "explicit list of only unknowns resolves to none is an error",
+			exclude: "wg0",
+			listen:  []string{"typo0"},
+			ifaces:  ifaceList("em0", "wg0"),
+			route:   constRoute("", nil),
+			wantErr: true,
+		},
+		{
+			name:      "naming the wg interface itself is skipped",
+			exclude:   "wg0",
+			listen:    []string{"wg0", "em0"},
+			ifaces:    ifaceList("em0", "wg0"),
+			route:     constRoute("", nil),
+			wantNames: []string{"em0"},
+		},
+		{
+			name:         "default route interface is added (best effort, not required)",
+			exclude:      "wg0",
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "em1", "wg0"),
+			route:        constRoute("em1", nil),
+			wantNames:    []string{"em1"},
+			wantRequired: nil,
+		},
+		{
+			name:         "union of explicit list and default route, deduped",
+			exclude:      "wg0",
+			listen:       []string{"em0"},
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "em1", "wg0"),
+			route:        constRoute("em0", nil), // same as explicit -> dedup
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"},
+		},
+		{
+			name:         "union keeps both when default route differs",
+			exclude:      "wg0",
+			listen:       []string{"em0"},
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "em1", "wg0"),
+			route:        constRoute("em1", nil),
+			wantNames:    []string{"em0", "em1"},
+			wantRequired: []string{"em0"},
+		},
+		{
+			name:         "default route missing for protocol resolves to none is an error",
+			exclude:      "wg0",
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "wg0"),
+			route:        constRoute("", nil), // e.g. no IPv6 default route
+			wantErr:      true,
+		},
+		{
+			name:         "default route lookup error is skipped, not fatal, when list carries",
+			exclude:      "wg0",
+			listen:       []string{"em0"},
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "wg0"),
+			route:        constRoute("", errors.New("route table read failed")),
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"},
+		},
+		{
+			name:         "default route pointing at wg interface is skipped",
+			exclude:      "wg0",
+			listen:       []string{"em0"},
+			defaultRoute: true,
+			ifaces:       ifaceList("em0", "wg0"),
+			route:        constRoute("wg0", nil),
+			wantNames:    []string{"em0"},
+			wantRequired: []string{"em0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names, required, err := resolveListenInterfaces(&logger, tt.protocol, tt.exclude, tt.listen, tt.defaultRoute, tt.ifaces, tt.route)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got names=%v", names)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotNames := append([]string(nil), names...)
+			wantNames := append([]string(nil), tt.wantNames...)
+			sort.Strings(gotNames)
+			sort.Strings(wantNames)
+			if !reflect.DeepEqual(gotNames, wantNames) {
+				t.Errorf("names = %v, want %v", names, tt.wantNames)
+			}
+
+			var gotRequired []string
+			for k := range required {
+				gotRequired = append(gotRequired, k)
+			}
+			wantRequired := append([]string(nil), tt.wantRequired...)
+			sort.Strings(gotRequired)
+			sort.Strings(wantRequired)
+			if !reflect.DeepEqual(gotRequired, wantRequired) {
+				t.Errorf("required = %v, want %v", gotRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+// TestResolveListenInterfaces_InterfaceListError surfaces an enumeration
+// failure rather than treating it as "no interfaces".
+func TestResolveListenInterfaces_InterfaceListError(t *testing.T) {
+	logger := zerolog.Nop()
+	boom := errors.New("cannot list interfaces")
+	failing := func() ([]net.Interface, error) { return nil, boom }
+
+	_, _, err := resolveListenInterfaces(&logger, "ipv4", "wg0", []string{"em0"}, false, failing, constRoute("", nil))
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the enumeration error, got %v", err)
+	}
+}
+
+// TestDefaultRouteInterface_Smoke exercises the real x/net/route parsing path on
+// the platform it targets (it only runs where the build tag lets it compile).
+// It cannot assert a specific interface -- the CI VM's routing table is not
+// fixed -- but it pins that the RIB dump parses without error and that any name
+// returned is a real interface.
+func TestDefaultRouteInterface_Smoke(t *testing.T) {
+	for _, protocol := range []string{"ipv4", "ipv6"} {
+		name, err := defaultRouteInterface(protocol)
+		if err != nil {
+			t.Fatalf("defaultRouteInterface(%q): %v", protocol, err)
+		}
+		if name == "" {
+			continue // no default route for this family is legitimate
+		}
+		if _, err := net.InterfaceByName(name); err != nil {
+			t.Errorf("defaultRouteInterface(%q) returned %q which is not a real interface: %v", protocol, name, err)
+		}
+	}
+}

--- a/internal/stun/stun_linux.go
+++ b/internal/stun/stun_linux.go
@@ -85,8 +85,22 @@ func setPacketConn(s *Stun, c net.PacketConn, filter []bpf.RawInstruction) error
 	return nil
 }
 
-func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int) (*Stun, error) {
+// listenIgnoredOnce guards the one-time warning that Linux ignores the
+// per-interface listen restriction. New runs once per refresh cycle, so a
+// plain log would repeat every cycle; sync.Once fires it exactly once.
+var listenIgnoredOnce sync.Once
+
+func New(ctx context.Context, excludeInterface string, port uint16, protocol string, firewallMark int, listenInterfaces []string, listenDefaultRoute bool) (*Stun, error) {
 	logger := zerolog.Ctx(ctx)
+
+	// Linux discovers via a system-wide raw socket with a BPF filter, so there
+	// is no per-interface listen to restrict. Honor the config's spirit by
+	// telling the user it has no effect here rather than silently dropping it.
+	if len(listenInterfaces) > 0 || listenDefaultRoute {
+		listenIgnoredOnce.Do(func() {
+			logger.Warn().Msg("listen_interfaces/listen_default_route are ignored on Linux (system-wide raw socket); they apply to darwin/bsd only")
+		})
+	}
 
 	c, err := createRawSocket(ctx, protocol, firewallMark, *logger)
 	if err != nil {


### PR DESCRIPTION
## What

Adds two per-interface config options for the BSD (FreeBSD/macOS) STUN backend to narrow which underlay interfaces it pcap-captures on, instead of always opening every eligible interface.

```yaml
interfaces:
  wg0:
    protocol: "dualstack"
    listen_interfaces: ["em0", "em1"]   # only these
    listen_default_route: true          # also the default-route interface
```

## Semantics

- **Additive, not exclusive** — effective set is the union of `listen_interfaces` and (if `listen_default_route`) the default-route interface.
- **Zero-breaking** — "no selector active" (empty list + `false`) keeps the historical open-everything behavior. Refined the naive "empty = all" to "no selector active = all" so `listen_default_route: true` alone means *only* the default route rather than being a no-op.
- **Default route resolved per-protocol** via an `x/net/route` RIB dump (no exec, no `netstat` parsing); IPv4 and IPv6 default routes may sit on different interfaces.
- **Tolerant, with a loud backstop** — unknown names and interfaces that can't be opened right now are warned and skipped (the daemon retries every cycle); `New`'s existing `no usable interfaces` error fires when the selection is empty, and `dualstack` tolerates a single failed family.
- **Linux ignores both keys** (system-wide raw socket, no per-interface listen) and warns once.

## Design note

The selection is read in the resolver from static interface config and threaded to `stun.New`; it does **not** go through the `Device` entity, so the bootstrap/publish path is untouched (unlike fwmark, which is live wg-device state).

## Tests

- `resolveListenInterfaces` is a pure function with injected interface-lister and default-route resolver — table-tested for all selection cases (union, dedup, typo-skip, wg-exclude, empty-resolves-to-error, dualstack tolerance). Runs on the FreeBSD CI VM.
- `defaultRouteInterface` smoke test exercises the real `x/net/route` parse path on FreeBSD CI.
- Config layer: `GetListenConfig` parse + defaults + unknown-device tests (run on Linux).

Verified locally: `go build`/`go vet` across linux/darwin/freebsd (amd64+arm64, wgctrl+wgcli), `gofmt` clean, `wire .` no diff, full `go test ./...` green. The darwin/bsd-tagged tests run on CI's FreeBSD VM.