### PR TITLE
docs: point contrib plugin protocol links at docs.stunmesh.dev

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -123,7 +123,7 @@ Use this protocol for complex plugins.
 }
 ```
 
-See the [exec plugin documentation](../README.md#exec-plugin-protocol) for more details.
+See the [exec plugin documentation](https://docs.stunmesh.dev/plugins/exec-protocol) for more details.
 
 ### Shell Plugin Protocol (Shell Variables)
 
@@ -163,7 +163,7 @@ esac
 - No special characters - safe to use without quoting or escaping
 - Can safely use `source /dev/stdin` or `eval`
 
-See the [shell plugin documentation](../README.md#shell-plugin-protocol) and [cloudflare-shell/](cloudflare-shell/) for complete examples.
+See the [shell plugin documentation](https://docs.stunmesh.dev/plugins/shell-protocol) and [cloudflare-shell/](cloudflare-shell/) for complete examples.
 
 ## Contributing
 

--- a/contrib/cloudflare-shell/README.md
+++ b/contrib/cloudflare-shell/README.md
@@ -142,6 +142,6 @@ echo -e "STUNMESH_ACTION=set\nSTUNMESH_KEY=testkey123\nSTUNMESH_VALUE=testvalue4
 
 ## See Also
 
-- [Shell Plugin Protocol](../../README.md#shell-plugin-protocol)
+- [Shell Plugin Protocol](https://docs.stunmesh.dev/plugins/shell-protocol)
 - [Go-based Cloudflare Plugin](../cloudflare/)
 - [Contrib Plugin Development Guide](../README.md)


### PR DESCRIPTION
Follow-up to #207: three links in contrib READMEs still pointed at the exec/shell protocol anchors that were removed from the main README. They now point at https://docs.stunmesh.dev/plugins/exec-protocol and https://docs.stunmesh.dev/plugins/shell-protocol.