### PR TITLE
refactor(config): drop duplicate plugin definition types

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/wire"
 	"github.com/rs/zerolog"
+	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -91,20 +92,13 @@ type PingMonitor struct {
 	FixedRetries int           `mapstructure:"fixed_retries"`
 }
 
-type PluginConfig map[string]interface{}
-
-type PluginDefinition struct {
-	Type   string       `mapstructure:"type"`
-	Config PluginConfig `mapstructure:",remain"`
-}
-
 type Config struct {
-	Interfaces      Interfaces                  `mapstructure:"interfaces"`
-	Plugins         map[string]PluginDefinition `mapstructure:"plugins"`
-	RefreshInterval time.Duration               `mapstructure:"refresh_interval"`
-	Log             Logger                      `mapstructure:"log"`
-	Stun            Stun                        `mapstructure:"stun"`
-	PingMonitor     PingMonitor                 `mapstructure:"ping_monitor"`
+	Interfaces      Interfaces                            `mapstructure:"interfaces"`
+	Plugins         map[string]pluginapi.PluginDefinition `mapstructure:"plugins"`
+	RefreshInterval time.Duration                         `mapstructure:"refresh_interval"`
+	Log             Logger                                `mapstructure:"log"`
+	Stun            Stun                                  `mapstructure:"stun"`
+	PingMonitor     PingMonitor                           `mapstructure:"ping_monitor"`
 }
 
 // findConfigFile resolves the config file path, honoring File and Dir before

--- a/wire.go
+++ b/wire.go
@@ -16,7 +16,6 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/repo"
 	"github.com/tjjh89017/stunmesh-go/internal/stun"
 	"github.com/tjjh89017/stunmesh-go/internal/wg"
-	"github.com/tjjh89017/stunmesh-go/pluginapi"
 )
 
 func setup() (*daemon.Daemon, error) {
@@ -46,16 +45,7 @@ func providePluginManager(config *config.Config) (*plugin.Manager, error) {
 	manager := plugin.NewManager()
 	ctx := context.Background()
 
-	// Convert config.PluginDefinition to pluginapi.PluginDefinition
-	pluginsMap := make(map[string]pluginapi.PluginDefinition)
-	for name, def := range config.Plugins {
-		pluginsMap[name] = pluginapi.PluginDefinition{
-			Type:   def.Type,
-			Config: pluginapi.PluginConfig(def.Config),
-		}
-	}
-
-	if err := manager.LoadPlugins(ctx, pluginsMap); err != nil {
+	if err := manager.LoadPlugins(ctx, config.Plugins); err != nil {
 		return nil, err
 	}
 

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -18,7 +18,6 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/repo"
 	"github.com/tjjh89017/stunmesh-go/internal/stun"
 	"github.com/tjjh89017/stunmesh-go/internal/wg"
-	"github.com/tjjh89017/stunmesh-go/pluginapi"
 )
 
 // Injectors from wire.go:
@@ -57,15 +56,7 @@ func providePluginManager(config2 *config.Config) (*plugin.Manager, error) {
 	manager := plugin.NewManager()
 	ctx := context.Background()
 
-	pluginsMap := make(map[string]pluginapi.PluginDefinition)
-	for name, def := range config2.Plugins {
-		pluginsMap[name] = pluginapi.PluginDefinition{
-			Type:   def.Type,
-			Config: pluginapi.PluginConfig(def.Config),
-		}
-	}
-
-	if err := manager.LoadPlugins(ctx, pluginsMap); err != nil {
+	if err := manager.LoadPlugins(ctx, config2.Plugins); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
`internal/config` declared its own `PluginConfig` and `PluginDefinition` with
the same fields and the same mapstructure tags as the `pluginapi` pair, and
`providePluginManager` converted between them field by field on every startup.

This decodes straight into the `pluginapi` types and passes `Config.Plugins` to
`LoadPlugins` unchanged.

## Direction of the dependency

`config` depends on `pluginapi`, not the reverse. `pluginapi` only imports
`context`, so it stays a leaf; the other direction would put the config loader
below `internal/plugin`.

## Notes

- `wire_gen.go` is regenerated with `wire .`, not hand-edited.
- The `pluginapi` import in `wire.go` is removed because the conversion loop was
  its only user — leaving it would fail codegen.
- `,remain` behavior is unchanged: both structs carried identical tags, and
  `TestLoad_PluginDefinition_RemainCapturesExtraKeys` still pins it.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` + `go vet ./...` | pass |
| `go test ./...` | pass |
| `golangci-lint run` | 0 issues |
| builtin tag matrix (none / cloudflare / opendht / both) | pass |

No user-facing or config-format change.