### PR TITLE
feat(log): add json output format and validate the level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,17 @@ Environment variables cannot override config values (the former Viper `Automatic
 - Deprecated `stun.address` (single server) is still supported and takes highest priority: it is merged in front of `addresses` and the list is deduplicated preserving order
 - Defaults (refresh interval, STUN server, ping settings) live in the const block at the top of `internal/config/config.go`
 
+### Logging Configuration
+```yaml
+log:
+  level: info      # trace, debug, info, warn, error, fatal, panic, disabled
+  format: console  # console (human-readable) or json
+```
+- `format: json` emits zerolog's native JSON, one object per line; `console` reformats it for humans. There is no CLI flag for either — logging is config-file only, since the flags exist to locate the config file, not to replace its contents
+- `LogLevels` is derived from `zerolog.Level.String()` rather than hand-written, so it tracks whatever zerolog names; validation delegates to `zerolog.ParseLevel`, which is case-insensitive
+- Both default when absent **or explicitly empty** (`level: ""`): `info` and `console`. Unknown values are a startup error
+- An unset level used to fall through to zerolog's own default (trace), so configs that never set `log.level` silently ran at debug verbosity; they now run at `info`
+
 ## Key Implementation Details
 
 ### Wire Interface Bindings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -25,27 +27,64 @@ const (
 	DefaultPingInterval     = 1 * time.Second
 	DefaultPingTimeout      = 1 * time.Second
 	DefaultPingFixedRetries = 3
+	DefaultLogFormat        = LogFormatConsole
+	DefaultLogLevel         = "info"
 )
 
-// File, when non-empty, is the exact config file to read; it overrides Dir
-// and Paths and must be readable (no fallback to defaults).
-var File string
+// Log output formats accepted by log.format and --log-format.
+const (
+	LogFormatConsole = "console"
+	LogFormatJSON    = "json"
+)
 
-// Dir, when non-empty, is a directory searched for ConfigFileNames; it
-// overrides Paths and must contain a config file (no fallback to defaults).
-var Dir string
+// Accepted log settings, both the validation source and the list quoted in
+// the error messages.
+var (
+	LogFormats = []string{LogFormatConsole, LogFormatJSON}
+	LogLevels  = logLevels()
+)
 
-// ConfigFileNames lists candidate file names inside a directory; the first
-// one that exists wins.
-var ConfigFileNames = []string{"config.yaml", "config.yml"}
-
-// Paths lists directories (env-expanded) searched when neither File nor Dir is set.
-var Paths []string = []string{
-	"$STUNMESH_CONFIG_DIR",
-	"/etc/stunmesh",
-	"$HOME/.stunmesh",
-	".",
+// logLevels asks zerolog for its own level names, in increasing severity.
+// NoLevel is skipped: it stringifies to "" and is not a value to configure.
+func logLevels() []string {
+	var names []string
+	for level := zerolog.TraceLevel; level <= zerolog.Disabled; level++ {
+		if name := level.String(); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
+
+// Command-line overrides, set from main before Load runs. Each takes priority
+// over the corresponding config-file value or search path.
+var (
+	// ConfigFile, when non-empty, is the exact config file to read; it
+	// overrides ConfigDir and Paths and must be readable (no fallback to
+	// defaults).
+	ConfigFile string
+
+	// ConfigDir, when non-empty, is a directory searched for ConfigFileNames;
+	// it overrides Paths and must contain a config file (no fallback to
+	// defaults).
+	ConfigDir string
+)
+
+// Where Load looks for a config file when ConfigFile is unset.
+var (
+	// ConfigFileNames lists candidate file names inside a directory; the first
+	// one that exists wins.
+	ConfigFileNames = []string{"config.yaml", "config.yml"}
+
+	// Paths lists directories (env-expanded) searched when neither ConfigFile
+	// nor ConfigDir is set.
+	Paths = []string{
+		"$STUNMESH_CONFIG_DIR",
+		"/etc/stunmesh",
+		"$HOME/.stunmesh",
+		".",
+	}
+)
 
 var (
 	ErrReadConfig      = errors.New("failed to read config")
@@ -54,7 +93,8 @@ var (
 )
 
 type Logger struct {
-	Level string `mapstructure:"level"`
+	Level  string `mapstructure:"level"`
+	Format string `mapstructure:"format"`
 }
 
 type Stun struct {
@@ -101,22 +141,22 @@ type Config struct {
 	PingMonitor     PingMonitor                           `mapstructure:"ping_monitor"`
 }
 
-// findConfigFile resolves the config file path, honoring File and Dir before
+// findConfigFile resolves the config file path, honoring ConfigFile and ConfigDir before
 // the Paths search; "" with nil error means not found (proceed with defaults).
 func findConfigFile() (string, error) {
-	if File != "" {
-		return File, nil
+	if ConfigFile != "" {
+		return ConfigFile, nil
 	}
 
-	if Dir != "" {
+	if ConfigDir != "" {
 		for _, name := range ConfigFileNames {
-			candidate := filepath.Join(Dir, name)
+			candidate := filepath.Join(ConfigDir, name)
 			if _, err := os.Stat(candidate); err == nil {
 				return candidate, nil
 			}
 		}
-		// Explicit Dir override must succeed: return the primary name so the read fails hard.
-		return filepath.Join(Dir, ConfigFileNames[0]), nil
+		// Explicit ConfigDir override must succeed: return the primary name so the read fails hard.
+		return filepath.Join(ConfigDir, ConfigFileNames[0]), nil
 	}
 
 	for _, path := range Paths {
@@ -144,6 +184,8 @@ func Load() (*Config, error) {
 	cfg.PingMonitor.Interval = DefaultPingInterval
 	cfg.PingMonitor.Timeout = DefaultPingTimeout
 	cfg.PingMonitor.FixedRetries = DefaultPingFixedRetries
+	cfg.Log.Format = DefaultLogFormat
+	cfg.Log.Level = DefaultLogLevel
 
 	path, err := findConfigFile()
 	if err != nil {
@@ -210,6 +252,14 @@ func Load() (*Config, error) {
 	cfg.Stun.Addresses = cfg.Stun.GetServers()
 	cfg.Stun.Address = ""
 
+	// An explicit `format: ""` / `level: ""` means unset, not invalid.
+	if cfg.Log.Format == "" {
+		cfg.Log.Format = DefaultLogFormat
+	}
+	if cfg.Log.Level == "" {
+		cfg.Log.Level = DefaultLogLevel
+	}
+
 	// Validate protocol configurations
 	if err := validateConfig(&cfg); err != nil {
 		return nil, err
@@ -220,6 +270,20 @@ func Load() (*Config, error) {
 
 // validateConfig validates protocol configurations and returns error if invalid
 func validateConfig(cfg *Config) error {
+	// Empty means unset, as it does for the protocol fields below; Load has
+	// already replaced it with the default on the path that reads a file.
+	if cfg.Log.Format != "" && !slices.Contains(LogFormats, cfg.Log.Format) {
+		return errors.New("invalid log format '" + cfg.Log.Format + "', must be one of: " + strings.Join(LogFormats, ", "))
+	}
+
+	// ParseLevel is the authority on what it accepts, including case; LogLevels
+	// only supplies the list its own error message leaves out.
+	if cfg.Log.Level != "" {
+		if _, err := zerolog.ParseLevel(cfg.Log.Level); err != nil {
+			return errors.New("invalid log level '" + cfg.Log.Level + "', must be one of: " + strings.Join(LogLevels, ", "))
+		}
+	}
+
 	for ifaceName, iface := range cfg.Interfaces {
 		// Validate interface protocol
 		if iface.Protocol != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,20 +4,22 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 )
 
-// resetConfigGlobals saves File/Dir/Paths and restores them via t.Cleanup, then
-// clears File/Dir. These are shared globals: tests using it must not t.Parallel().
+// resetConfigGlobals saves ConfigFile/ConfigDir/Paths and restores them via t.Cleanup, then
+// clears ConfigFile/ConfigDir. These are shared globals: tests using it must not t.Parallel().
 func resetConfigGlobals(t *testing.T) {
 	t.Helper()
-	origFile, origDir, origPaths := File, Dir, Paths
+	origFile, origDir, origPaths := ConfigFile, ConfigDir, Paths
 	t.Cleanup(func() {
-		File, Dir, Paths = origFile, origDir, origPaths
+		ConfigFile, ConfigDir, Paths = origFile, origDir, origPaths
 	})
-	File = ""
-	Dir = ""
+	ConfigFile = ""
+	ConfigDir = ""
 }
 
 func TestLoad_Success(t *testing.T) {
@@ -427,7 +429,7 @@ func TestValidateConfig_ValidProtocols(t *testing.T) {
 	}
 }
 
-// --- File / Dir / Paths resolution ---
+// --- ConfigFile / ConfigDir / Paths resolution ---
 
 func TestLoad_File_Exists(t *testing.T) {
 	resetConfigGlobals(t)
@@ -438,9 +440,9 @@ func TestLoad_File_Exists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// File must win even though Paths would never find this file.
+	// ConfigFile must win even though Paths would never find this file.
 	Paths = []string{t.TempDir()}
-	File = path
+	ConfigFile = path
 
 	cfg, err := Load()
 	if err != nil {
@@ -455,11 +457,11 @@ func TestLoad_File_Exists(t *testing.T) {
 func TestLoad_File_NotExists_ErrorsWithoutFallback(t *testing.T) {
 	resetConfigGlobals(t)
 
-	File = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	ConfigFile = filepath.Join(t.TempDir(), "does-not-exist.yaml")
 
 	_, err := Load()
 	if err == nil {
-		t.Fatal("Load() with nonexistent File should return an error, not fall back to defaults")
+		t.Fatal("Load() with nonexistent ConfigFile should return an error, not fall back to defaults")
 	}
 
 	if !errors.Is(err, ErrReadConfig) {
@@ -475,7 +477,7 @@ func TestLoad_Dir_WithConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Dir = tmpDir
+	ConfigDir = tmpDir
 
 	cfg, err := Load()
 	if err != nil {
@@ -490,11 +492,11 @@ func TestLoad_Dir_WithConfig(t *testing.T) {
 func TestLoad_Dir_WithoutConfig_ErrorsWithoutFallback(t *testing.T) {
 	resetConfigGlobals(t)
 
-	Dir = t.TempDir()
+	ConfigDir = t.TempDir()
 
 	_, err := Load()
 	if err == nil {
-		t.Fatal("Load() with Dir lacking config.yaml should return an error, not fall back to defaults")
+		t.Fatal("Load() with ConfigDir lacking config.yaml should return an error, not fall back to defaults")
 	}
 
 	if !errors.Is(err, ErrReadConfig) {
@@ -516,8 +518,8 @@ func TestLoad_File_TakesPriorityOverDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	File = filePath
-	Dir = dirWithConfig
+	ConfigFile = filePath
+	ConfigDir = dirWithConfig
 
 	cfg, err := Load()
 	if err != nil {
@@ -525,7 +527,7 @@ func TestLoad_File_TakesPriorityOverDir(t *testing.T) {
 	}
 
 	if cfg.RefreshInterval != 21*time.Minute {
-		t.Errorf("RefreshInterval = %v, want 21m (File must win over Dir)", cfg.RefreshInterval)
+		t.Errorf("RefreshInterval = %v, want 21m (ConfigFile must win over ConfigDir)", cfg.RefreshInterval)
 	}
 }
 
@@ -949,5 +951,116 @@ func TestLoad_WeaklyTypedInput_EmptyStringAddresses(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNoStunServers) {
 		t.Errorf("Load() error = %v, want ErrNoStunServers", err)
+	}
+}
+
+func writeLogConfig(t *testing.T, logSection string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := logSection + `
+stun:
+  addresses:
+    - stun.example.com:19302
+interfaces:
+  wg0:
+    peers: {}
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return path
+}
+
+func TestLoad_LogDefaults(t *testing.T) {
+	resetConfigGlobals(t)
+	ConfigFile = writeLogConfig(t, "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Log.Format != DefaultLogFormat {
+		t.Errorf("Log.Format = %q, want %q", cfg.Log.Format, DefaultLogFormat)
+	}
+	if cfg.Log.Level != DefaultLogLevel {
+		t.Errorf("Log.Level = %q, want %q", cfg.Log.Level, DefaultLogLevel)
+	}
+}
+
+func TestLoad_LogFromFile(t *testing.T) {
+	resetConfigGlobals(t)
+	ConfigFile = writeLogConfig(t, "log:\n  format: json\n  level: debug\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Log.Format != LogFormatJSON {
+		t.Errorf("Log.Format = %q, want %q", cfg.Log.Format, LogFormatJSON)
+	}
+	if cfg.Log.Level != "debug" {
+		t.Errorf("Log.Level = %q, want debug", cfg.Log.Level)
+	}
+}
+
+// An explicit empty value means unset, not invalid.
+func TestLoad_EmptyLogValuesFallBackToDefaults(t *testing.T) {
+	resetConfigGlobals(t)
+	ConfigFile = writeLogConfig(t, "log:\n  format: \"\"\n  level: \"\"\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Log.Format != DefaultLogFormat {
+		t.Errorf("Log.Format = %q, want %q", cfg.Log.Format, DefaultLogFormat)
+	}
+	if cfg.Log.Level != DefaultLogLevel {
+		t.Errorf("Log.Level = %q, want %q", cfg.Log.Level, DefaultLogLevel)
+	}
+}
+
+func TestLoad_InvalidLogFormatRejected(t *testing.T) {
+	resetConfigGlobals(t)
+	ConfigFile = writeLogConfig(t, "log:\n  format: yaml\n")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want an invalid log format error")
+	}
+}
+
+func TestLoad_LogLevels(t *testing.T) {
+	// Every level zerolog names must load, in any case; nothing else may.
+	for _, level := range LogLevels {
+		for _, spelling := range []string{level, strings.ToUpper(level)} {
+			t.Run(spelling, func(t *testing.T) {
+				resetConfigGlobals(t)
+				ConfigFile = writeLogConfig(t, "log:\n  level: "+spelling+"\n")
+
+				if _, err := Load(); err != nil {
+					t.Errorf("Load() error = %v, want nil", err)
+				}
+			})
+		}
+	}
+
+	for _, level := range []string{"banana", "verbose"} {
+		t.Run("invalid/"+level, func(t *testing.T) {
+			resetConfigGlobals(t)
+			ConfigFile = writeLogConfig(t, "log:\n  level: "+level+"\n")
+
+			if _, err := Load(); err == nil {
+				t.Errorf("Load() error = nil, want an invalid log level error")
+			}
+		})
+	}
+}
+
+// LogLevels is derived from zerolog rather than hand-written, so pin the set
+// and its severity order.
+func TestLogLevels_FromZerolog(t *testing.T) {
+	want := []string{"trace", "debug", "info", "warn", "error", "fatal", "panic", "disabled"}
+	if !slices.Equal(LogLevels, want) {
+		t.Errorf("LogLevels = %v, want %v", LogLevels, want)
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 
 	"github.com/google/wire"
@@ -12,18 +13,23 @@ var DefaultSet = wire.NewSet(
 	NewLogger,
 )
 
-var LevelMap = map[string]zerolog.Level{
-	"debug": zerolog.DebugLevel,
-	"info":  zerolog.InfoLevel,
-	"warn":  zerolog.WarnLevel,
-	"error": zerolog.ErrorLevel,
-}
+func NewLogger(cfg *config.Config) *zerolog.Logger {
+	// zerolog writes JSON natively; ConsoleWriter reformats it for humans.
+	var writer io.Writer = zerolog.ConsoleWriter{Out: os.Stdout}
+	if cfg.Log.Format == config.LogFormatJSON {
+		writer = os.Stdout
+	}
 
-func NewLogger(config *config.Config) *zerolog.Logger {
-	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).With().Timestamp().Logger()
+	logger := zerolog.New(writer).With().Timestamp().Logger()
 
-	if level, ok := LevelMap[config.Log.Level]; ok {
-		logger = logger.Level(level)
+	// Empty is the unset case; ParseLevel would read it as NoLevel and silence
+	// everything, including errors. config.Load has already rejected the rest.
+	level := cfg.Log.Level
+	if level == "" {
+		level = config.DefaultLogLevel
+	}
+	if parsed, err := zerolog.ParseLevel(level); err == nil {
+		logger = logger.Level(parsed)
 	}
 
 	return &logger

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,138 @@
+package logger
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/tjjh89017/stunmesh-go/internal/config"
+)
+
+// captureStdout swaps os.Stdout for a pipe around fn. NewLogger reads
+// os.Stdout when it builds the writer, so it has to be called inside fn.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+	return string(out)
+}
+
+func TestNewLogger_JSONFormat(t *testing.T) {
+	out := captureStdout(t, func() {
+		l := NewLogger(&config.Config{Log: config.Logger{Format: config.LogFormatJSON, Level: "info"}})
+		l.Error().Str("device", "wg0").Msg("boom")
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &entry); err != nil {
+		t.Fatalf("output is not JSON: %v (got %q)", err, out)
+	}
+
+	if entry["level"] != "error" {
+		t.Errorf("level = %v, want error", entry["level"])
+	}
+	if entry["message"] != "boom" {
+		t.Errorf("message = %v, want boom", entry["message"])
+	}
+	if entry["device"] != "wg0" {
+		t.Errorf("device = %v, want wg0", entry["device"])
+	}
+}
+
+func TestNewLogger_ConsoleFormat(t *testing.T) {
+	out := captureStdout(t, func() {
+		l := NewLogger(&config.Config{Log: config.Logger{Format: config.LogFormatConsole, Level: "info"}})
+		l.Error().Msg("boom")
+	})
+
+	var entry map[string]any
+	if json.Unmarshal([]byte(strings.TrimSpace(out)), &entry) == nil {
+		t.Errorf("console output parsed as JSON, want the human-readable form (got %q)", out)
+	}
+	if !strings.Contains(out, "boom") {
+		t.Errorf("output = %q, want it to contain the message", out)
+	}
+}
+
+// A zero Config must log in the console format, and must still log at all:
+// an empty level reads as NoLevel, which would silence even errors.
+func TestNewLogger_ZeroConfig(t *testing.T) {
+	out := captureStdout(t, func() {
+		l := NewLogger(&config.Config{})
+		l.Error().Msg("boom")
+	})
+
+	if !strings.Contains(out, "boom") {
+		t.Fatalf("output = %q, want the error to be logged", out)
+	}
+
+	var entry map[string]any
+	if json.Unmarshal([]byte(strings.TrimSpace(out)), &entry) == nil {
+		t.Errorf("output parsed as JSON, want console (got %q)", out)
+	}
+}
+
+func TestNewLogger_Level(t *testing.T) {
+	tests := []struct {
+		level string
+		want  zerolog.Level
+	}{
+		{"trace", zerolog.TraceLevel},
+		{"debug", zerolog.DebugLevel},
+		{"info", zerolog.InfoLevel},
+		{"warn", zerolog.WarnLevel},
+		{"error", zerolog.ErrorLevel},
+		{"fatal", zerolog.FatalLevel},
+		{"panic", zerolog.PanicLevel},
+		{"disabled", zerolog.Disabled},
+		{"INFO", zerolog.InfoLevel},
+		{"", zerolog.InfoLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			l := NewLogger(&config.Config{Log: config.Logger{Level: tt.level}})
+			if got := l.GetLevel(); got != tt.want {
+				t.Errorf("GetLevel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Below the configured level nothing is written at all.
+func TestNewLogger_LevelFilters(t *testing.T) {
+	out := captureStdout(t, func() {
+		l := NewLogger(&config.Config{Log: config.Logger{Format: config.LogFormatJSON, Level: "warn"}})
+		l.Debug().Msg("hidden")
+		l.Info().Msg("hidden")
+		l.Warn().Msg("shown")
+	})
+
+	if strings.Contains(out, "hidden") {
+		t.Errorf("output = %q, want entries below warn dropped", out)
+	}
+	if !strings.Contains(out, "shown") {
+		t.Errorf("output = %q, want the warn entry", out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,30 +11,34 @@ import (
 func main() {
 	ctx := context.Background()
 
-	oneshot := flag.Bool("oneshot", false, "run in oneshot mode (publish and establish 3 times, then exit)")
+	var (
+		oneshot    bool
+		configFile string
+		configDir  string
+	)
 
+	// -c and --config are the same destination, so the usage text is shared.
 	const configFileUsage = "path to the config file (takes priority over --config-dir)"
-	var configFile string
+
+	flag.BoolVar(&oneshot, "oneshot", false, "run in oneshot mode (publish and establish 3 times, then exit)")
 	flag.StringVar(&configFile, "c", "", configFileUsage)
 	flag.StringVar(&configFile, "config", "", configFileUsage)
-
-	var configDir string
 	flag.StringVar(&configDir, "config-dir", "", "directory containing config.yaml (ignored if -c/--config is set)")
 
 	flag.Parse()
 
-	config.File = configFile
-	config.Dir = configDir
+	config.ConfigFile = configFile
+	config.ConfigDir = configDir
 
 	daemon, err := setup()
 	if err != nil {
 		panic(err)
 	}
 
-	if *oneshot {
+	if oneshot {
 		daemon.RunOneshot(ctx)
 		os.Exit(0)
-	} else {
-		daemon.Run(ctx)
 	}
+
+	daemon.Run(ctx)
 }


### PR DESCRIPTION
## log.format

Selects between zerolog's native JSON and the `ConsoleWriter` reformatting that
was previously hardcoded. JSON is one object per line — what log aggregation
wants, and what the planned e2e assertions need in order to key on `.level`
rather than grep message text.

```yaml
log:
  level: info      # trace, debug, info, warn, error, fatal, panic, disabled
  format: console  # console or json
```

## log.level

`LevelMap` only had `debug`/`info`/`warn`/`error`, so `trace`, `fatal`, `panic`
and `disabled` were missing. It is gone: `LogLevels` is now derived from
`zerolog.Level.String()` so it cannot drift, and validation delegates to
`zerolog.ParseLevel`, which is case-insensitive (`INFO` works).

## Behavior changes

Both come from the same root cause — an unmatched level left zerolog's own
default of `trace` in place:

| Config | Before | After |
| --- | --- | --- |
| `level: banana` | silently logged **everything** | startup error |
| `log.level` absent | silently logged **everything** | defaults to `info` |

The first is the more surprising one: a typo turned on full verbosity rather
than being rejected. Worth a line in the release notes, since anyone who never
set `log.level` will see less output than before.

## No CLI flag

Deliberate. The existing flags (`-c`, `--config`, `--config-dir`) all answer
"where is the config file" — bootstrap information that cannot live inside the
file. A flag overriding a value *in* the file is a different kind of thing, and
one for `format` but not `level` would be asymmetric.

`main()`'s flag declarations, registrations and assignments are grouped rather
than interleaved, as a drive-by.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` + `go vet ./...` | pass |
| `go test ./...` | pass |
| `golangci-lint run` | 0 issues |
| builtin tag matrix (none / cloudflare / opendht / both) | pass |

Also exercised against the real binary: JSON output parses, every named level
loads in any case, `banana` and the numeric form are rejected, an absent level
yields no debug lines.

One trap caught while testing: `NewLogger` on a hand-built `config.Config` with
an empty level parsed to `NoLevel`, which silences **even errors**. `NewLogger`
now falls back to the default itself rather than relying on `Load` having run.