### PR TITLE
feat(opendht): accept several endpoints and require an explicit scheme

### DIFF
--- a/contrib/opendht/README.md
+++ b/contrib/opendht/README.md
@@ -12,8 +12,8 @@ before deploying this.
 
 - `curl`
 - `jq`
-- **IPv6 connectivity**, if you use the default `dhtproxy.jami.net` endpoint —
-  it does not answer over IPv4 at all. See [Limitations](#limitations).
+- At least one OpenDHT proxy endpoint. There is no default; see
+  [Which proxies to use](#which-proxies-to-use).
 
 Tested on Linux and macOS.
 
@@ -24,7 +24,11 @@ plugins:
   opendht:
     type: exec
     command: /usr/local/bin/stunmesh-opendht
-    args: ["-endpoint", "https://dhtproxy.jami.net"]
+    args:
+      - "-endpoint"
+      - "https://dhtproxy2.jami.net"
+      - "-endpoint"
+      - "https://dhtproxy3.jami.net"
     dedup: false
 
 interfaces:
@@ -39,13 +43,56 @@ interfaces:
 
 | Option | Default | Description |
 |---|---|---|
-| `-endpoint` | `https://dhtproxy.jami.net` | OpenDHT proxy server base URL |
+| `-endpoint` | none, required | OpenDHT proxy base URL, with scheme. Repeat to add fallbacks |
 | `-magic` | `stunmesh-v1` | Envelope tag used to recognise our own values |
 | `-timeout` | `15` | Per-request timeout in seconds |
 
 Do not lower `-timeout` much. A DHT lookup that finds nothing legitimately
 takes ~6 seconds to converge; a short timeout turns a slow success into a
 false "not found".
+
+### Which proxies to use
+
+There is no built-in default. Which proxy you trust is a decision about whose
+infrastructure your mesh depends on, so the plugin makes you name one rather
+than inheriting a choice silently.
+
+Savoir-faire Linux runs several public proxies for Jami. Measured July 2026,
+in the order suggested above:
+
+| Endpoint | Notes |
+|---|---|
+| `https://dhtproxy2.jami.net` | Reachable over IPv4 and IPv6. Hosted in Europe |
+| `https://dhtproxy3.jami.net` | Reachable over IPv4 and IPv6. Hosted in Canada, so it is the better first choice from the Americas |
+| `https://dhtproxy.jami.net` | **Avoid.** See below |
+| `https://dhtproxy1.jami.net` | **Avoid.** IPv6 only in practice |
+
+Order them by whichever is closest to you; the plugin tries them in the order
+given and only moves on when a request fails. Listing two from different
+regions costs nothing until the first one breaks.
+
+### Why not `dhtproxy.jami.net`
+
+It is the name the Jami documentation points at, but it is a rotation over two
+addresses and one of them does not serve:
+
+| Address | TCP 80 | TCP 443 | Reverse DNS |
+|---|---|---|---|
+| `141.94.96.2` | answers | answers | `dhtproxy1.jami.net` |
+| `141.94.96.254` | refused | refused | none |
+
+`141.94.96.254` is what `dhtproxy1.jami.net` resolves to today, and it appeared
+in roughly nine of ten lookups across four resolvers. The AAAA record is
+healthy, so a dual-stack host prefers IPv6 and never notices. An IPv4-only host
+draws a single A record per query with nothing to fall back to, so it fails
+outright — intermittently, which is far more confusing than a clean failure:
+
+```
+exec plugin error: set request failed: curl: (7) Failed to connect to
+dhtproxy.jami.net port 443 after 299 ms: Couldn't connect to server
+```
+
+Naming `dhtproxy2` and `dhtproxy3` explicitly sidesteps the whole thing.
 
 ## `dedup` must stay false
 
@@ -96,30 +143,28 @@ peer would pick an arbitrary one of its own recent endpoints.
 
 ## Limitations
 
-**`dhtproxy.jami.net` is reachable over IPv6 only.** The name resolves to
-both an A record (`141.94.96.254`) and an AAAA record
-(`2001:41d0:403:4702::`), but nothing is listening on the IPv4 address — TCP
-80, 443 and 8080 are all closed there. An IPv4-only host therefore fails at
-connect:
+**Listing several endpoints does not make the DHT more available.** They are
+all entrances to the same DHT, so the fallbacks help when a proxy is down, not
+when a value has expired. If nothing published within the last 10 minutes, no
+endpoint will have it.
 
-```
-exec plugin error: set request failed: curl: (7) Failed to connect to
-dhtproxy.jami.net port 443 after 299 ms: Couldn't connect to server
-```
-
-There is no client-side fix, because the IPv4 endpoint does not exist. Hosts
-without IPv6 have to run their own proxy (see below). This is worth weighing
-before choosing this plugin: NAT traversal is an IPv4 problem, so the peers
-that most need stunmesh are also the ones most likely to lack the IPv6 that
-the default endpoint requires.
-
-**The endpoint is somebody else's infrastructure.** `dhtproxy.jami.net` is
-run by Savoir-faire Linux for the Jami messenger. It publishes no terms of
-service, no SLA and no rate limits for third-party use. It may start refusing
-or throttling stunmesh traffic at any time, with no recourse. The dead A
-record above is what that looks like in practice: a broken record nobody
-announces, fixes on your schedule, or answers questions about. If that
+**The endpoints are somebody else's infrastructure.** The `jami.net` proxies
+are run by Savoir-faire Linux for the Jami messenger. They publish no terms of
+service, no SLA and no rate limits for third-party use. They may start refusing
+or throttling stunmesh traffic at any time, with no recourse. The dead address
+behind `dhtproxy.jami.net` is what that looks like in practice: a broken record
+nobody announces, fixes on your schedule, or answers questions about. If that
 matters to you, run your own proxy (see below).
+
+**IPv4-only hosts should check their endpoints.** NAT traversal is an IPv4
+problem, so the peers that most need stunmesh are also the ones least likely to
+have IPv6 — and a proxy that is IPv6-only, as `dhtproxy1.jami.net` is today,
+looks fine to everyone testing from a dual-stack machine. Verify with `curl -4`
+before relying on one:
+
+```bash
+curl -4 -sS https://dhtproxy2.jami.net/node/info | jq '.ipv4.good'
+```
 
 **The network is small.** `GET /node/info` on the public proxy reports a
 `network_size_estimation` of roughly 4096 IPv4 nodes — this is essentially
@@ -143,9 +188,8 @@ at the cost of managing a second keypair; this plugin does not use it.
 
 ## Running your own proxy
 
-Hosts without IPv6 have to do this, since the default endpoint is
-unreachable for them. Run a node with the proxy interface enabled and point
-`-endpoint` at it:
+The surest way not to depend on somebody else's uptime. Run a node with the
+proxy interface enabled and point `-endpoint` at it:
 
 ```bash
 docker run -d -i --name dhtnode -p 8080:8080 \

--- a/contrib/opendht/opendht.sh
+++ b/contrib/opendht/opendht.sh
@@ -10,7 +10,8 @@
 #     opendht:
 #       type: exec
 #       command: /usr/local/bin/stunmesh-opendht
-#       args: ["-endpoint", "https://dhtproxy.jami.net"]
+#       args: ["-endpoint", "https://dhtproxy2.jami.net",
+#              "-endpoint", "https://dhtproxy3.jami.net"]
 #       dedup: false
 #
 # IMPORTANT: dedup must stay false. OpenDHT values expire after 10 minutes
@@ -21,13 +22,19 @@
 
 set -eu
 
-ENDPOINT="https://dhtproxy.jami.net"
+ENDPOINTS=""
 MAGIC="stunmesh-v1"
 TIMEOUT=15
 
 usage() {
 	cat >&2 <<'EOF'
-Usage: stunmesh-opendht [-endpoint URL] [-magic STRING] [-timeout SECONDS]
+Usage: stunmesh-opendht -endpoint URL [-endpoint URL]... [-magic STRING]
+                        [-timeout SECONDS]
+
+At least one -endpoint is required and each needs an http:// or https://
+scheme. Repeat it to add fallbacks: they are tried in the order given, and
+only a failed request moves on to the next. README.md suggests which
+proxies to use.
 
 Reads an exec-protocol JSON request on stdin and writes a JSON response
 on stdout. Not intended to be run interactively.
@@ -39,7 +46,9 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 	-endpoint)
 		[ $# -ge 2 ] || usage
-		ENDPOINT="$2"
+		# Repeatable. URLs contain no spaces, so a space-separated list
+		# survives the word splitting the loops below rely on.
+		ENDPOINTS="$ENDPOINTS $2"
 		shift 2
 		;;
 	-magic)
@@ -80,6 +89,27 @@ respond_error() {
 
 command -v curl >/dev/null 2>&1 || respond_error "curl not found in PATH"
 
+# No default: which proxy to trust is a decision for whoever runs the mesh,
+# not something to inherit silently. README.md suggests some.
+[ -n "$ENDPOINTS" ] || respond_error "no -endpoint given; see the plugin README for suggested proxies"
+
+# Validate every endpoint up front, so a typo in the third one is not
+# discovered only when the first two happen to be down. curl would read a
+# scheme-less "dhtproxy.jami.net" as http, silently downgrading from the https
+# the default uses, so ask for the scheme instead. Trailing slashes are
+# trimmed because the request URLs append "/key/...".
+checked=""
+for endpoint in $ENDPOINTS; do
+	case "$endpoint" in
+	http://* | https://*) ;;
+	*)
+		respond_error "-endpoint '$endpoint' must start with http:// or https://"
+		;;
+	esac
+	checked="$checked ${endpoint%/}"
+done
+ENDPOINTS="$checked"
+
 request=$(cat)
 
 action=$(printf '%s' "$request" | jq -r '.action // empty' 2>/dev/null) ||
@@ -104,9 +134,24 @@ esac
 
 case "$action" in
 get)
-	if ! body=$(curl -sS -f --max-time "$TIMEOUT" "$ENDPOINT/key/$key" 2>&1); then
-		respond_error "get request failed: $body"
-	fi
+	# Only a failed request moves on to the next endpoint. A request that
+	# succeeds but carries no value is an answer, not a failure, and every
+	# endpoint fronts the same DHT, so asking another would give the same one.
+	# A successful request may return an empty body -- a key with no value --
+	# so completion is tracked separately from what came back.
+	body=""
+	answered=""
+	errors=""
+	for endpoint in $ENDPOINTS; do
+		if body=$(curl -sS -f --max-time "$TIMEOUT" "$endpoint/key/$key" 2>&1); then
+			answered=1
+			break
+		fi
+		errors="$errors; $endpoint: $body"
+		body=""
+	done
+
+	[ -n "$answered" ] || respond_error "get request failed:${errors#;}"
 
 	# The proxy answers with newline-delimited JSON: one value object per
 	# line, since a key holds a set of values rather than a single slot.
@@ -134,13 +179,21 @@ set)
 		'{data: ({magic: $m, ts: $ts, data: $d} | tojson | @base64)}') ||
 		respond_error "failed to build request payload"
 
-	if ! out=$(curl -sS -f --max-time "$TIMEOUT" \
-		-X POST \
-		-H 'Content-Type: application/json' \
-		-d "$payload" \
-		"$ENDPOINT/key/$key" 2>&1); then
-		respond_error "set request failed: $out"
-	fi
+	stored=""
+	errors=""
+	for endpoint in $ENDPOINTS; do
+		if out=$(curl -sS -f --max-time "$TIMEOUT" \
+			-X POST \
+			-H 'Content-Type: application/json' \
+			-d "$payload" \
+			"$endpoint/key/$key" 2>&1); then
+			stored=1
+			break
+		fi
+		errors="$errors; $endpoint: $out"
+	done
+
+	[ -n "$stored" ] || respond_error "set request failed:${errors#;}"
 
 	respond_ok ""
 	;;

--- a/internal/plugin/builtin/opendht/opendht.go
+++ b/internal/plugin/builtin/opendht/opendht.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -23,14 +26,14 @@ func init() {
 }
 
 const (
-	defaultEndpoint = "https://dhtproxy.jami.net"
-	defaultMagic    = "stunmesh-v1"
-	defaultTimeout  = 15 * time.Second
+	defaultMagic   = "stunmesh-v1"
+	defaultTimeout = 15 * time.Second
 
 	// Configuration keys
-	configKeyEndpoint = "endpoint"
-	configKeyMagic    = "magic"
-	configKeyTimeout  = "timeout"
+	configKeyEndpoint  = "endpoint"
+	configKeyEndpoints = "endpoints"
+	configKeyMagic     = "magic"
+	configKeyTimeout   = "timeout"
 )
 
 // An OpenDHT key is an InfoHash: 160 bits, i.e. 40 hex characters. stunmesh
@@ -40,9 +43,9 @@ var keyPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 
 // OpenDHTPlugin implements the Store interface
 type OpenDHTPlugin struct {
-	endpoint string
-	magic    string
-	client   *http.Client
+	endpoints []string
+	magic     string
+	client    *http.Client
 }
 
 // envelope wraps the value stored under a key.
@@ -79,6 +82,32 @@ func (c *BuiltinConfig) GetString(key string) (string, bool) {
 	return str, ok
 }
 
+// GetStringSlice reads a list that YAML may deliver as []interface{}, or that
+// mapstructure's weak typing may have already turned into []string.
+func (c *BuiltinConfig) GetStringSlice(key string) ([]string, error) {
+	val, ok := c.config[key]
+	if !ok {
+		return nil, nil
+	}
+
+	switch v := val.(type) {
+	case []string:
+		return v, nil
+	case []interface{}:
+		items := make([]string, 0, len(v))
+		for _, item := range v {
+			str, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s must be a list of strings", key)
+			}
+			items = append(items, str)
+		}
+		return items, nil
+	default:
+		return nil, fmt.Errorf("%s must be a list of strings", key)
+	}
+}
+
 // GetDuration reads a timeout expressed either as a duration string such as
 // "20s" or as a plain number of seconds, since a YAML scalar may arrive as
 // either depending on how it was written.
@@ -104,13 +133,69 @@ func (c *BuiltinConfig) GetDuration(key string) (time.Duration, bool, error) {
 	}
 }
 
+// normalizeEndpoint requires an explicit http:// or https:// scheme. Go's http
+// client rejects a bare host with "unsupported protocol scheme", but only once
+// a request is made -- every refresh cycle, long after startup. curl would
+// instead assume http, which for a scheme-less "dhtproxy.jami.net" is a silent
+// downgrade from the https the default endpoint uses. Neither is a good answer
+// to a value that simply does not say what it means.
+func normalizeEndpoint(endpoint string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("opendht endpoint %q must start with http:// or https://", endpoint)
+	}
+
+	// doRequest joins with "/key/...", so a trailing slash would double it.
+	return strings.TrimRight(endpoint, "/"), nil
+}
+
+// resolveEndpoints merges the singular endpoint in front of the endpoints list
+// and deduplicates preserving order, the same shape as stun.address feeding
+// stun.addresses. Every entry is validated here so a typo in the third one is
+// not discovered only when the first two happen to be down.
+func resolveEndpoints(cfg *BuiltinConfig) ([]string, error) {
+	list, err := cfg.GetStringSlice(configKeyEndpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	single, _ := cfg.GetString(configKeyEndpoint)
+
+	seen := make(map[string]struct{})
+	endpoints := make([]string, 0, len(list)+1)
+	for _, endpoint := range append([]string{single}, list...) {
+		if endpoint == "" {
+			continue
+		}
+
+		normalized, err := normalizeEndpoint(endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		endpoints = append(endpoints, normalized)
+	}
+
+	// No default: which proxy to trust is a decision for whoever runs the
+	// mesh, not something to inherit silently. The plugin README suggests some.
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("opendht needs %s or %s; see the plugin README for suggested proxies", configKeyEndpoint, configKeyEndpoints)
+	}
+
+	return endpoints, nil
+}
+
 // NewOpenDHTPlugin creates a new OpenDHT plugin instance
 func NewOpenDHTPlugin(config pluginapi.PluginConfig) (pluginapi.Store, error) {
 	cfg := &BuiltinConfig{config: config}
 
-	endpoint, ok := cfg.GetString(configKeyEndpoint)
-	if !ok || endpoint == "" {
-		endpoint = defaultEndpoint
+	endpoints, err := resolveEndpoints(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	magic, ok := cfg.GetString(configKeyMagic)
@@ -139,14 +224,35 @@ func NewOpenDHTPlugin(config pluginapi.PluginConfig) (pluginapi.Store, error) {
 	}
 
 	return &OpenDHTPlugin{
-		endpoint: endpoint,
-		magic:    magic,
-		client:   client,
+		endpoints: endpoints,
+		magic:     magic,
+		client:    client,
 	}, nil
 }
 
+// doRequest tries each endpoint in order and returns the first success. Only a
+// failed request moves on to the next: a request that succeeds but carries no
+// value for the key is an answer, not a failure, and every endpoint fronts the
+// same DHT so asking another would give the same one.
 func (p *OpenDHTPlugin) doRequest(ctx context.Context, method, key string, body []byte) ([]byte, error) {
-	url := fmt.Sprintf("%s/key/%s", p.endpoint, key)
+	logger := zerolog.Ctx(ctx)
+
+	var errs []error
+	for _, endpoint := range p.endpoints {
+		data, err := p.doRequestTo(ctx, endpoint, method, key, body)
+		if err == nil {
+			return data, nil
+		}
+
+		logger.Warn().Err(err).Str("endpoint", endpoint).Msg("opendht endpoint failed, trying next")
+		errs = append(errs, fmt.Errorf("%s: %w", endpoint, err))
+	}
+
+	return nil, errors.Join(errs...)
+}
+
+func (p *OpenDHTPlugin) doRequestTo(ctx context.Context, endpoint, method, key string, body []byte) ([]byte, error) {
+	url := fmt.Sprintf("%s/key/%s", endpoint, key)
 
 	var bodyReader io.Reader
 	if body != nil {

--- a/internal/plugin/builtin/opendht/opendht_test.go
+++ b/internal/plugin/builtin/opendht/opendht_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -304,7 +305,7 @@ func TestKeyMustBeInfoHash(t *testing.T) {
 }
 
 func TestDefaults(t *testing.T) {
-	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{})
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoint: "https://a.example"})
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -312,10 +313,6 @@ func TestDefaults(t *testing.T) {
 	plugin, ok := p.(*OpenDHTPlugin)
 	if !ok {
 		t.Fatal("expected an *OpenDHTPlugin")
-	}
-
-	if plugin.endpoint != defaultEndpoint {
-		t.Errorf("expected endpoint %s, got %s", defaultEndpoint, plugin.endpoint)
 	}
 
 	if plugin.magic != defaultMagic {
@@ -340,7 +337,10 @@ func TestTimeoutConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyTimeout: tt.value})
+			p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+				configKeyEndpoint: "https://a.example",
+				configKeyTimeout:  tt.value,
+			})
 			if err != nil {
 				t.Fatalf("failed to create plugin: %v", err)
 			}
@@ -354,8 +354,288 @@ func TestTimeoutConfig(t *testing.T) {
 
 func TestInvalidTimeoutConfig(t *testing.T) {
 	for _, value := range []interface{}{"not-a-duration", true} {
-		if _, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyTimeout: value}); err == nil {
+		config := pluginapi.PluginConfig{
+			configKeyEndpoint: "https://a.example",
+			configKeyTimeout:  value,
+		}
+		if _, err := NewOpenDHTPlugin(config); err == nil {
 			t.Errorf("expected an error for timeout %v", value)
+		}
+	}
+}
+
+// A scheme-less endpoint used to be accepted and then fail on every request
+// with net/http's "unsupported protocol scheme", long after startup.
+func TestEndpointRequiresScheme(t *testing.T) {
+	rejected := []string{
+		"dhtproxy.jami.net",
+		"dhtproxy.jami.net:80",
+		"//dhtproxy.jami.net",
+		"ftp://dhtproxy.jami.net",
+		"https://",
+		"   ",
+	}
+
+	for _, endpoint := range rejected {
+		t.Run(endpoint, func(t *testing.T) {
+			_, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoint: endpoint})
+			if err == nil {
+				t.Fatalf("expected %q to be rejected", endpoint)
+			}
+			if !strings.Contains(err.Error(), "http:// or https://") {
+				t.Errorf("error should say what is required, got: %v", err)
+			}
+		})
+	}
+
+	accepted := []string{
+		"http://127.0.0.1:8080",
+		"https://dhtproxy.jami.net",
+		"https://dhtproxy.jami.net:443",
+	}
+
+	for _, endpoint := range accepted {
+		t.Run(endpoint, func(t *testing.T) {
+			p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoint: endpoint})
+			if err != nil {
+				t.Fatalf("expected %q to be accepted, got: %v", endpoint, err)
+			}
+			if got := p.(*OpenDHTPlugin).endpoints; len(got) != 1 || got[0] != endpoint {
+				t.Errorf("endpoints = %v, want [%q]", got, endpoint)
+			}
+		})
+	}
+}
+
+// A trailing slash would make the request path "//key/...".
+func TestEndpointTrailingSlashTrimmed(t *testing.T) {
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoint: "http://127.0.0.1:8080/"})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	if got := p.(*OpenDHTPlugin).endpoints; len(got) != 1 || got[0] != "http://127.0.0.1:8080" {
+		t.Errorf("endpoints = %v, want the trailing slash removed", got)
+	}
+}
+
+func TestResolveEndpointsMergesAndDeduplicates(t *testing.T) {
+	tests := []struct {
+		name   string
+		config pluginapi.PluginConfig
+		want   []string
+	}{
+		{
+			name:   "singular only",
+			config: pluginapi.PluginConfig{configKeyEndpoint: "https://a.example"},
+			want:   []string{"https://a.example"},
+		},
+		{
+			name:   "list only, order preserved",
+			config: pluginapi.PluginConfig{configKeyEndpoints: []interface{}{"https://a.example", "https://b.example"}},
+			want:   []string{"https://a.example", "https://b.example"},
+		},
+		{
+			name: "singular comes first",
+			config: pluginapi.PluginConfig{
+				configKeyEndpoint:  "https://first.example",
+				configKeyEndpoints: []interface{}{"https://b.example"},
+			},
+			want: []string{"https://first.example", "https://b.example"},
+		},
+		{
+			name: "duplicates collapse, first position wins",
+			config: pluginapi.PluginConfig{
+				configKeyEndpoint:  "https://a.example",
+				configKeyEndpoints: []interface{}{"https://b.example", "https://a.example/"},
+			},
+			want: []string{"https://a.example", "https://b.example"},
+		},
+		{
+			name:   "already []string",
+			config: pluginapi.PluginConfig{configKeyEndpoints: []string{"https://a.example"}},
+			want:   []string{"https://a.example"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewOpenDHTPlugin(tt.config)
+			if err != nil {
+				t.Fatalf("failed to create plugin: %v", err)
+			}
+
+			got := p.(*OpenDHTPlugin).endpoints
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("endpoints = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A bad entry anywhere in the list must fail at startup, not when the earlier
+// endpoints happen to go down.
+func TestResolveEndpointsValidatesEveryEntry(t *testing.T) {
+	_, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoints: []interface{}{"https://good.example", "bad.example"},
+	})
+	if err == nil {
+		t.Fatal("expected the scheme-less second entry to be rejected")
+	}
+	if !strings.Contains(err.Error(), "bad.example") {
+		t.Errorf("error should name the offending entry, got: %v", err)
+	}
+}
+
+// There is no built-in default: an unconfigured plugin must say so rather
+// than silently adopt somebody else's proxy.
+func TestNoEndpointConfigured(t *testing.T) {
+	_, err := NewOpenDHTPlugin(pluginapi.PluginConfig{})
+	if err == nil {
+		t.Fatal("expected an error when neither endpoint nor endpoints is set")
+	}
+	if !strings.Contains(err.Error(), configKeyEndpoints) {
+		t.Errorf("error should name the config key, got: %v", err)
+	}
+}
+
+func TestResolveEndpointsRejectsNonList(t *testing.T) {
+	_, err := NewOpenDHTPlugin(pluginapi.PluginConfig{configKeyEndpoints: 42})
+	if err == nil {
+		t.Fatal("expected a non-list endpoints value to be rejected")
+	}
+}
+
+// Both Get and Set skip a failing endpoint and keep the first that answers.
+func TestFailsOverToNextEndpoint(t *testing.T) {
+	for _, action := range []string{"get", "set"} {
+		t.Run(action, func(t *testing.T) {
+			dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			}))
+			defer dead.Close()
+
+			var liveHits int
+			live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				liveHits++
+				if r.Method == http.MethodGet {
+					fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer live.Close()
+
+			p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+				configKeyEndpoints: []interface{}{dead.URL, live.URL},
+			})
+			if err != nil {
+				t.Fatalf("failed to create plugin: %v", err)
+			}
+
+			if action == "get" {
+				got, err := p.Get(context.Background(), testKey)
+				if err != nil {
+					t.Fatalf("Get() error = %v, want the second endpoint to answer", err)
+				}
+				if got != "payload" {
+					t.Errorf("Get() = %q, want payload", got)
+				}
+			} else if err := p.Set(context.Background(), testKey, "payload"); err != nil {
+				t.Fatalf("Set() error = %v, want the second endpoint to accept", err)
+			}
+
+			if liveHits != 1 {
+				t.Errorf("live endpoint hit %d times, want 1", liveHits)
+			}
+		})
+	}
+}
+
+// The first endpoint that answers ends the walk.
+func TestDoesNotTryLaterEndpointsOnSuccess(t *testing.T) {
+	var secondHits int
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondHits++
+	}))
+	defer second.Close()
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
+	}))
+	defer first.Close()
+
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoints: []interface{}{first.URL, second.URL},
+	})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	if _, err := p.Get(context.Background(), testKey); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if secondHits != 0 {
+		t.Errorf("second endpoint hit %d times, want 0", secondHits)
+	}
+}
+
+// A key with no value is an answer, not a failure: the walk stops there.
+func TestNoValueDoesNotFailOver(t *testing.T) {
+	var secondHits int
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondHits++
+	}))
+	defer second.Close()
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer first.Close()
+
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoints: []interface{}{first.URL, second.URL},
+	})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	if _, err := p.Get(context.Background(), testKey); err == nil {
+		t.Fatal("Get() error = nil, want no value found")
+	}
+
+	if secondHits != 0 {
+		t.Errorf("second endpoint hit %d times, want 0", secondHits)
+	}
+}
+
+// When every endpoint fails the error has to name them all, or a mesh that is
+// down for two different reasons looks like it is down for one.
+func TestAllEndpointsFailingReportsEach(t *testing.T) {
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "first is unhappy", http.StatusInternalServerError)
+	}))
+	defer first.Close()
+
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "second is unhappy", http.StatusBadGateway)
+	}))
+	defer second.Close()
+
+	p, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoints: []interface{}{first.URL, second.URL},
+	})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	err = p.Set(context.Background(), testKey, "payload")
+	if err == nil {
+		t.Fatal("Set() error = nil, want both endpoints reported")
+	}
+
+	for _, want := range []string{first.URL, second.URL, "first is unhappy", "second is unhappy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
 		}
 	}
 }


### PR DESCRIPTION
Three changes to how the OpenDHT plugins reach a proxy, applied to both the
built-in and the contrib shell implementation.

## Several endpoints

`endpoints` takes a list, `-endpoint` repeats. The singular `endpoint` is merged
in front and the result deduplicated — the same shape `stun.address` and
`stun.addresses` already use.

```yaml
plugins:
  dht:
    type: builtin
    name: opendht
    endpoints:
      - https://dhtproxy2.jami.net
      - https://dhtproxy3.jami.net
```

Get and Set walk the list and stop at the first success. **Only a failed request
moves on**: a request that succeeds but carries no value is an answer, not a
failure, and every endpoint fronts the same DHT, so asking another would return
the same one. When all fail, the error names each.

## An explicit scheme is required

A bare `dhtproxy.jami.net` was accepted, then failed on every publish with:

```
Post "dhtproxy2.jami.net/key/...": unsupported protocol scheme ""
```

which says nothing about the config that caused it. curl instead reads it as
`http`, silently downgrading from the `https` the docs use. Both implementations
now reject it at startup. Trailing slashes are trimmed rather than left to
produce `//key/...`.

## No default endpoint (breaking)

The default was `https://dhtproxy.jami.net`. Measured July 2026, that name
round-robins over two addresses:

| Address | TCP 80 | TCP 443 | Reverse DNS |
| --- | --- | --- | --- |
| `141.94.96.2` | answers | answers | `dhtproxy1.jami.net` |
| `141.94.96.254` | refused | refused | none |

`.254` came back in roughly nine of ten lookups across four resolvers. The AAAA
record is healthy, so dual-stack hosts prefer IPv6 and never notice; an
IPv4-only host draws one A record per query with nothing to fall back to and
fails **intermittently**, which is far more confusing than a clean failure.

Rather than bake in a different name, the plugins now require one to be
configured — which proxy a mesh depends on is a decision to make, not to
inherit. The README explains the failure, suggests `dhtproxy2` and `dhtproxy3`,
and says how to order them.

**Configs relying on the default will now fail to start** with a message naming
the config key.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | pass |
| `go test -tags builtin_opendht ./internal/plugin/...` | pass |
| builtin tag matrix (none / cloudflare / opendht / both) | pass |
| `golangci-lint run` | 0 issues |
| `shellcheck contrib/opendht/opendht.sh` | clean |

13 new tests cover the merge/dedup order, per-entry validation, failover on
failure, *no* failover on success or on an empty result, and the combined error.

Also exercised against the live proxies: a `set` through a dead-then-live
endpoint pair, read back through a *different* endpoint pair, returning the
stored value — which also re-confirms values propagate between proxies.

## Note

`.github/actions/lint/action.yml` passes no build tags, so files behind
`//go:build builtin_opendht` are not linted in CI at all. Pre-existing errcheck
findings in this package survive for that reason. Left alone here; worth a
separate look.