### PR TITLE
ci: lint the build-tagged and non-linux files too

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Go version to use'
     required: true
     default: 'stable'
+  goos:
+    description: 'GOOS to lint for; golangci-lint only sees the files its GOOS selects'
+    required: false
+    default: 'linux'
 
 runs:
   using: 'composite'
@@ -15,7 +19,11 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: false
 
+    # Build tags come from .golangci.yaml, so a bare golangci-lint run locally
+    # checks the same files this does.
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
         version: latest
+      env:
+        GOOS: ${{ inputs.goos }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, freebsd]
     steps:
       - uses: actions/checkout@v7
       - name: Lint
         uses: ./.github/actions/lint
         with:
           go-version: ${{ env.GO_VERSION }}
+          goos: ${{ matrix.goos }}
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, freebsd]
     steps:
       - uses: actions/checkout@v7
       - name: Lint
         uses: ./.github/actions/lint
         with:
           go-version: ${{ env.GO_VERSION }}
+          goos: ${{ matrix.goos }}
 
   test:
     name: Test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,8 @@
 version: "2"
+run:
+  build-tags:
+    - builtin_cloudflare
+    - builtin_opendht
 linters:
   enable:
     - protogetter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,18 @@ go test ./internal/entity -v     # Run entity tests
 go test ./internal/repo -v       # Run repository tests
 ```
 
+### Linting
+```bash
+make lint                        # Lint for linux, darwin and freebsd
+make lint LINT_PLATFORMS=linux   # Just the host, for a faster loop
+```
+
+Build tags live in `.golangci.yaml` (`run.build-tags`), not in the Makefile, so
+a bare `golangci-lint run` checks the same files CI does. The `GOOS` sweep
+cannot come from the config, which is why `make lint` loops: golangci-lint only
+sees the files its `GOOS` selects, and `internal/stun/stun_darwinbsd.go` is the
+most platform-specific code in the tree. CI runs the same three as a matrix.
+
 ### Dependency Management
 ```bash
 go mod tidy                      # Clean up dependencies

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,19 @@ fmt:
 vet:
 	go vet ${TAGS_FLAGS} ./...
 
+# Platforms to lint. golangci-lint only sees the files its GOOS selects, and
+# the darwin/bsd STUN implementation is the most platform-specific code here,
+# so linting the host alone leaves it unchecked. Build tags come from
+# .golangci.yaml so that a bare golangci-lint run agrees with this.
+LINT_PLATFORMS ?= linux darwin freebsd
+
+.PHONY: lint
+lint:
+	@for os in $(LINT_PLATFORMS); do \
+		echo "Linting GOOS=$$os..."; \
+		GOOS=$$os golangci-lint run || exit 1; \
+	done
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/internal/plugin/builtin/cloudflare/cloudflare.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare.go
@@ -135,7 +135,7 @@ func (p *CloudflarePlugin) doRequest(ctx context.Context, method, path string, b
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/plugin/builtin/opendht/opendht.go
+++ b/internal/plugin/builtin/opendht/opendht.go
@@ -270,7 +270,7 @@ func (p *OpenDHTPlugin) doRequestTo(ctx context.Context, endpoint, method, key s
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/plugin/builtin/opendht/opendht_test.go
+++ b/internal/plugin/builtin/opendht/opendht_test.go
@@ -71,9 +71,9 @@ func TestGetReturnsMostRecentValue(t *testing.T) {
 	// 10-minute expiry leaves several of our own under it at once. The proxy
 	// does not order them, so the newest must be selected by ts.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, line(t, defaultMagic, 200, "newest"))
-		fmt.Fprintln(w, line(t, defaultMagic, 100, "oldest"))
-		fmt.Fprintln(w, line(t, defaultMagic, 150, "middle"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 200, "newest"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 100, "oldest"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 150, "middle"))
 	}))
 	defer server.Close()
 
@@ -91,9 +91,9 @@ func TestGetIgnoresForeignValues(t *testing.T) {
 	// Anyone may publish under a known key. Values that are not our envelope
 	// must not be returned -- not even one whose ts would otherwise win.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, rawLine(t, "total garbage not json"))
-		fmt.Fprintln(w, line(t, "someone-else", 1<<40, "hijacked"))
-		fmt.Fprintln(w, line(t, defaultMagic, 100, "ours"))
+		_, _ = fmt.Fprintln(w, rawLine(t, "total garbage not json"))
+		_, _ = fmt.Fprintln(w, line(t, "someone-else", 1<<40, "hijacked"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 100, "ours"))
 	}))
 	defer server.Close()
 
@@ -120,7 +120,7 @@ func TestGetEmptyKey(t *testing.T) {
 
 func TestGetOnlyForeignValues(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, line(t, "someone-else", 100, "theirs"))
+		_, _ = fmt.Fprintln(w, line(t, "someone-else", 100, "theirs"))
 	}))
 	defer server.Close()
 
@@ -132,8 +132,8 @@ func TestGetOnlyForeignValues(t *testing.T) {
 
 func TestGetRespectsConfiguredMagic(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, line(t, defaultMagic, 200, "default-magic"))
-		fmt.Fprintln(w, line(t, "custom", 100, "custom-magic"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 200, "default-magic"))
+		_, _ = fmt.Fprintln(w, line(t, "custom", 100, "custom-magic"))
 	}))
 	defer server.Close()
 
@@ -252,7 +252,7 @@ func TestRoundTrip(t *testing.T) {
 			stored = string(body)
 			return
 		}
-		fmt.Fprintln(w, stored)
+		_, _ = fmt.Fprintln(w, stored)
 	}))
 	defer server.Close()
 
@@ -519,7 +519,7 @@ func TestFailsOverToNextEndpoint(t *testing.T) {
 			live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				liveHits++
 				if r.Method == http.MethodGet {
-					fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
+					_, _ = fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
 					return
 				}
 				w.WriteHeader(http.StatusOK)
@@ -561,7 +561,7 @@ func TestDoesNotTryLaterEndpointsOnSuccess(t *testing.T) {
 	defer second.Close()
 
 	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
+		_, _ = fmt.Fprintln(w, line(t, defaultMagic, 1, "payload"))
 	}))
 	defer first.Close()
 


### PR DESCRIPTION
Closes #214.

golangci-lint only sees the files its build tags and `GOOS` select, and CI
passed neither. `make test` never had this gap — its `TAGS_FLAGS` come from
`BUILTIN`, which defaults to `all` — so the built-in plugins were tested but
never linted.

```console
$ golangci-lint run          # before: what CI ran
0 issues.

$ make lint                  # after
Linting GOOS=linux...   0 issues.
Linting GOOS=darwin...  0 issues.
Linting GOOS=freebsd... 0 issues.
```

Turning the tags on surfaced **14 errcheck findings** that had accumulated
unseen (`defer resp.Body.Close()` in both built-in plugins, `fmt.Fprintln` to an
`httptest` recorder throughout the opendht tests). All fixed here, or the new
job would go red on its first run.

## Where the tags live

In `.golangci.yaml` (`run.build-tags`), not the Makefile, so a bare
`golangci-lint run` checks the same files CI does — no flag to remember, and
the CI action picks it up with no change to how it is invoked.

A static list is right here even though `build` and `test` compute theirs from
`BUILTIN`: lint always wants *every* built-in, not whichever the current build
selects.

## The GOOS dimension

That part cannot come from the config, so `make lint` loops and both workflows
run a matrix:

| | Covers |
| --- | --- |
| `linux` | the default build |
| `darwin` | `stun_darwinbsd.go`, `ping_monitor_darwinbsd.go`, `update_only_darwin.go` |
| `freebsd` | `update_only_freebsd.go`, and `client_cli.go` via `freebsd && !wgctrl` |

The darwin/bsd STUN implementation carries the most platform-specific logic in
the tree — pcap handles, BPF offsets that differ per link type — and was exactly
what the linter never saw.

`make lint LINT_PLATFORMS=linux` for a faster local loop.

`release.yml` gets the matrix too: its lint job gates `create-release`, and a
tag can be pushed at any commit, so it cannot be assumed to have passed `main`'s
checks first. A release gate weaker than the pull request gate would be the
wrong way round.

## Verification

| Check | Result |
| --- | --- |
| `make lint` (all three platforms) | 0 issues |
| `go test -tags "builtin_cloudflare builtin_opendht" ./...` | pass |
| builtin tag matrix build | pass |