### PR TITLE
refactor(build): add builtin_all meta-tag, drop the hand-kept list

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,8 @@
 version: "2"
 run:
+  # builtin_all lints every built-in at once; GOOS is swept by `make lint`.
   build-tags:
-    - builtin_cloudflare
-    - builtin_opendht
+    - builtin_all
 linters:
   enable:
     - protogetter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,10 @@ make lint                        # Lint for linux, darwin and freebsd
 make lint LINT_PLATFORMS=linux   # Just the host, for a faster loop
 ```
 
-Build tags live in `.golangci.yaml` (`run.build-tags`), not in the Makefile, so
-a bare `golangci-lint run` checks the same files CI does. The `GOOS` sweep
-cannot come from the config, which is why `make lint` loops: golangci-lint only
-sees the files its `GOOS` selects, and `internal/stun/stun_darwinbsd.go` is the
-most platform-specific code in the tree. CI runs the same three as a matrix.
+`.golangci.yaml` sets `build-tags: [builtin_all]`, so a bare `golangci-lint run`
+and CI check the same files — the built-ins included, and no list to update when
+one is added. `GOOS` can't come from the config, so `make lint` loops over the
+three platforms and CI runs them as a matrix.
 
 ### Dependency Management
 ```bash
@@ -422,20 +421,21 @@ Common parameters to remember:
 5. See `contrib/README.md` for detailed plugin development guide
 
 ### Adding New Built-in Plugins
-1. Create `internal/plugin/builtin/<name>/<name>.go`, guarded by `//go:build builtin_<name>`
+1. Create `internal/plugin/builtin/<name>/<name>.go`, guarded by `//go:build builtin_<name> || builtin_all`
    - Implement `Store`, plus a constructor matching `registry.Factory`
    - Register it from `init()`: `registry.Register("<name>", New<Name>Plugin)`
-2. Create `internal/plugin/builtin/<name>/stub.go`, guarded by `//go:build !builtin_<name>`, declaring nothing but `package <name>`
+   - The `|| builtin_all` is what enrolls it in the `builtin_all` meta-tag, so nothing else (Makefile, `.golangci.yaml`) needs a list entry
+2. Create `internal/plugin/builtin/<name>/stub.go`, guarded by `//go:build !builtin_<name> && !builtin_all`, declaring nothing but `package <name>`
    - **Required, not optional.** `internal/plugin/imports.go` imports every built-in unconditionally, so without a stub a build that omits the tag fails with `build constraints exclude all Go files`
+   - The `&& !builtin_all` is the mirror of step 1: the stub applies only when this plugin is compiled in via neither its own tag nor `builtin_all`
 3. Add a blank import to `internal/plugin/imports.go`
    - That file carries no build tag, and must not: a blank import names no symbol, so importing a built-in that is tagged out (leaving only its stub) is fine. The tag belongs on the implementation, once
-4. Add `builtin_<name>` to `ALL_BUILTINS` in the `Makefile`
-5. Update the built-in plugin list and configuration example in the docs site ([tjjh89017/stunmesh-docs](https://github.com/tjjh89017/stunmesh-docs), published at docs.stunmesh.dev), and the `BUILTIN` examples in README.md if affected
+4. Update the built-in plugin list and configuration example in the docs site ([tjjh89017/stunmesh-docs](https://github.com/tjjh89017/stunmesh-docs), published at docs.stunmesh.dev), and the `BUILTIN` examples in README.md if affected
 
-Verify every tag combination, since a built-in must be able to compile
-both alone and alongside the others:
+Verify every tag combination, since a built-in must compile alone, under
+`builtin_all`, and alongside the others:
 ```bash
-for t in "" builtin_cloudflare builtin_<name> "builtin_cloudflare builtin_<name>"; do
+for t in "" builtin_all builtin_cloudflare builtin_<name> "builtin_cloudflare builtin_<name>"; do
   go build -tags "$t" -o /dev/null . || echo "FAILED: '$t'"
 done
 ```

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ TRIMPATH ?= 0
 UPX ?= 0
 EXTRA_MIN ?= 0
 BUILTIN ?= all
-ALL_BUILTINS := builtin_cloudflare builtin_opendht
 # Empty selects the per-platform default from the internal/wg build constraints:
 # wgcli on freebsd, wgctrl elsewhere. Set to override.
 BACKEND ?=
@@ -44,9 +43,10 @@ ifneq ($(TRIMPATH),0)
 	TRIMPATH_FLAGS := -trimpath
 endif
 
-# Expand BUILTIN=all to all available built-in plugins
+# builtin_all: every built-in opts in via `|| builtin_all`, no list to maintain.
+# BUILTIN=builtin_<name> picks one, BUILTIN= none.
 ifeq ($(BUILTIN),all)
-	override BUILTIN := $(ALL_BUILTINS)
+	override BUILTIN := builtin_all
 endif
 
 # Combine BUILTIN and BACKEND tags. An empty BACKEND adds no tag, leaving the
@@ -102,10 +102,8 @@ fmt:
 vet:
 	go vet ${TAGS_FLAGS} ./...
 
-# Platforms to lint. golangci-lint only sees the files its GOOS selects, and
-# the darwin/bsd STUN implementation is the most platform-specific code here,
-# so linting the host alone leaves it unchecked. Build tags come from
-# .golangci.yaml so that a bare golangci-lint run agrees with this.
+# golangci-lint only sees the files its GOOS selects, so lint each platform;
+# the darwin/bsd STUN code is the most platform-specific in the tree.
 LINT_PLATFORMS ?= linux darwin freebsd
 
 .PHONY: lint

--- a/internal/plugin/builtin/cloudflare/cloudflare.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare.go
@@ -1,4 +1,4 @@
-//go:build builtin_cloudflare
+//go:build builtin_cloudflare || builtin_all
 
 package cloudflare
 

--- a/internal/plugin/builtin/cloudflare/cloudflare_test.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare_test.go
@@ -1,4 +1,4 @@
-//go:build builtin_cloudflare
+//go:build builtin_cloudflare || builtin_all
 
 package cloudflare
 

--- a/internal/plugin/builtin/cloudflare/stub.go
+++ b/internal/plugin/builtin/cloudflare/stub.go
@@ -1,4 +1,4 @@
-//go:build !builtin_cloudflare
+//go:build !builtin_cloudflare && !builtin_all
 
 package cloudflare
 

--- a/internal/plugin/builtin/opendht/opendht.go
+++ b/internal/plugin/builtin/opendht/opendht.go
@@ -1,4 +1,4 @@
-//go:build builtin_opendht
+//go:build builtin_opendht || builtin_all
 
 package opendht
 

--- a/internal/plugin/builtin/opendht/opendht_test.go
+++ b/internal/plugin/builtin/opendht/opendht_test.go
@@ -1,4 +1,4 @@
-//go:build builtin_opendht
+//go:build builtin_opendht || builtin_all
 
 package opendht
 

--- a/internal/plugin/builtin/opendht/stub.go
+++ b/internal/plugin/builtin/opendht/stub.go
@@ -1,4 +1,4 @@
-//go:build !builtin_opendht
+//go:build !builtin_opendht && !builtin_all
 
 package opendht
 


### PR DESCRIPTION
Follow-up to #215. That PR fixed a lint gap by adding a build-tag list to
`.golangci.yaml` — but that list duplicated `ALL_BUILTINS` in the Makefile, so
adding a plugin still meant editing two lists. This removes the class of problem
instead.

## The change

Each built-in is guarded by `builtin_<name> || builtin_all`, each stub by
`!builtin_<name> && !builtin_all`:

```go
//go:build builtin_opendht || builtin_all      // opendht.go
//go:build !builtin_opendht && !builtin_all     // stub.go
```

`builtin_all` now compiles every built-in at once, and a new plugin joins the
meta-tag simply by declaring it in its own constraint. **There is no list
anywhere to keep in sync.**

| | Before | After |
| --- | --- | --- |
| `.golangci.yaml` | `[builtin_cloudflare, builtin_opendht]` | `[builtin_all]` — static, never edited again |
| Makefile | `ALL_BUILTINS := builtin_cloudflare builtin_opendht` | gone; `BUILTIN=all` → `builtin_all` |
| Add a plugin | edit both lists + the file | edit only the file's build tag |

`BUILTIN=builtin_<name>` still selects one; `BUILTIN=` still selects none.

## Why not go generate

A tag list is computable at build time — `go generate` would produce a file to
commit plus a drift check to enforce it (like `wire`), more machinery than a
build-constraint OR. The `|| builtin_all` keeps each plugin self-contained: the
one place that knows about a plugin is the plugin.

## Verification

Tag combinations — each built-in must compile alone, under `builtin_all`, and
together:

```console
$ for t in "" builtin_all builtin_cloudflare builtin_opendht "builtin_cloudflare builtin_opendht"; do
    go build -tags "$t" -o /dev/null . || echo "FAIL: $t"; done
# all pass
```

Both halves of the constraint are exercised — `|| builtin_all` (everything in)
and `&& !builtin_all` (the no-tag build, stubs only):

| Check | `BUILTIN=all` (→ builtin_all) | `BUILTIN=` (none) |
| --- | --- | --- |
| `make build` | both plugins compiled in | **0 builtin symbols in the binary** |
| `make test` | both suites run, all pass | `internal/plugin` + `registry` pass (stubs compile, `imports.go` still builds) |
| `make vet` | clean | clean |

`make lint` (linux/darwin/freebsd): 0 issues.

The `BUILTIN=` column matters most: it confirms the stub side of the new
constraint. With no tag, both plugins fall back to their stubs, `imports.go`'s
unconditional blank imports still compile against those empty packages, and the
resulting binary contains neither plugin.

CI needs no change: the lint action already runs a bare `golangci-lint run`,
which now reads `builtin_all` from the config, and the `GOOS` matrix from #215
stays.