### PR TITLE
ci: run tests per-OS and drop the standalone FreeBSD job

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,7 +1,11 @@
 name: 'Run Tests'
-description: 'Run Go tests with coverage'
+description: 'Run Go tests with coverage on the given OS'
 
 inputs:
+  os:
+    description: 'Target OS (linux, darwin, freebsd)'
+    required: true
+    default: 'linux'
   go-version:
     description: 'Go version to use'
     required: true
@@ -10,14 +14,29 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # os is an input, not runner.os: freebsd runs in a VM on a Linux host.
     - uses: actions/setup-go@v7
+      if: inputs.os == 'linux' || inputs.os == 'darwin'
       with:
         go-version: ${{ inputs.go-version }}
 
-    # Run as root so the tests that need CAP_NET_RAW / CAP_NET_ADMIN actually
-    # execute instead of skipping themselves. `sudo -E env "PATH=$PATH"` rather
-    # than a bare `sudo`, because sudo's secure_path drops the Go that
-    # setup-go put on PATH.
+    # Run as root so the tests that need CAP_NET_RAW / raw sockets execute
+    # instead of skipping. sudo -E env "PATH=$PATH" because sudo's secure_path
+    # drops the Go that setup-go put on PATH.
     - name: Test
+      if: inputs.os == 'linux' || inputs.os == 'darwin'
       shell: bash
       run: sudo -E env "PATH=$PATH" make test
+
+    # FreeBSD runs the tests in the guest, where the process is already root.
+    - name: Test (FreeBSD VM)
+      if: inputs.os == 'freebsd'
+      uses: vmactions/freebsd-vm@v1
+      with:
+        arch: amd64
+        sync: sshfs
+        prepare: |
+          pkg install -y gmake go
+        run: |
+          cd $GITHUB_WORKSPACE
+          gmake test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,20 +59,38 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: linux, runner: ubuntu-latest }
+          - { os: darwin, runner: macos-15 }
+          - { os: freebsd, runner: ubuntu-latest }  # host; tests run in a VM
     steps:
       - uses: actions/checkout@v7
       - name: Test
         uses: ./.github/actions/test
         with:
+          os: ${{ matrix.os }}
           go-version: ${{ env.GO_VERSION }}
+
+  # One stable check the ruleset can require in place of every Test (<os>) cell.
+  test-required:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: All test platforms passed
+        run: '[ "${{ needs.test.result }}" = "success" ]'
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs:
       - lint-required
-      - test
+      - test-required
     strategy:
       matrix:
         os: [linux, darwin, freebsd]
@@ -118,37 +136,12 @@ jobs:
       - name: All build cells passed
         run: '[ "${{ needs.build.result }}" = "success" ]'
 
-  # The only job running on real FreeBSD. It covers the two things the
-  # cross-compiled matrix cannot: the wgcli tests on the platform where wgcli is
-  # the default, and a compile check of wgctrl, which needs CGO and so cannot be
-  # cross-compiled. amd64 only — arm64 runs emulated and is far too slow.
-  freebsd:
-    name: FreeBSD (test + wgctrl build)
-    runs-on: ubuntu-latest
-    needs:
-      - lint-required
-      - test
-    steps:
-      - uses: actions/checkout@v7
-      - name: Test and build
-        uses: vmactions/freebsd-vm@v1
-        with:
-          arch: amd64
-          sync: sshfs
-          prepare: |
-            pkg update -f
-            pkg install -y gmake go
-          run: |
-            cd $GITHUB_WORKSPACE
-            gmake test
-            gmake build BACKEND=wgctrl
-
   build-plugins:
     name: Build Plugins
     runs-on: ubuntu-latest
     needs:
       - lint-required
-      - test
+      - test-required
     strategy:
       matrix:
         os: [linux, darwin, freebsd]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: '[ "${{ needs.lint.result }}" = "success" ]'
 
   test:
-    name: Test
+    name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Makes **Test** a matrix so it runs on each OS, and folds the standalone
`FreeBSD (test + wgctrl build)` job into it.

## Test matrix

The `test` action now branches on an `os` input (like the e2e action) — host
runners for linux/darwin, a FreeBSD VM for freebsd:

| cell | runs |
| --- | --- |
| `Test (linux)` | `make test` on ubuntu |
| `Test (darwin)` | `make test` on macos — **new**, darwin unit tests ran nowhere before |
| `Test (freebsd)` | `gmake test` in a FreeBSD VM — folded in from the old job |

A `test-required` summary gives the single stable `Test` check (mirroring
Lint/Build/Build Plugins), and build/build-plugins now depend on it.

Unit tests are single-arch per OS — they aren't arch-sensitive; runtime across
both arches is covered by e2e.

## Standalone FreeBSD job removed

Its `gmake test` is now the `Test (freebsd)` cell. Its **wgctrl compile check is
dropped** — the one thing not carried over, so `BACKEND=wgctrl` on FreeBSD is no
longer built in CI.

## Ruleset note

`Test` is now a summary of a matrix (as `Lint`/`Build` already are). The ruleset
already requires `Test` by that name, so nothing to change there — but the cells
`Test (linux/darwin/freebsd)` are new informational checks.