### PR TITLE
ci: drop lint and test from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,29 +9,7 @@ env:
   APP: "stunmesh"
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, darwin, freebsd]
-    steps:
-      - uses: actions/checkout@v7
-      - name: Lint
-        uses: ./.github/actions/lint
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          goos: ${{ matrix.goos }}
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Test
-        uses: ./.github/actions/test
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  # No lint/test: the tagged main commit already passed the full Build workflow.
 
   # Creates the draft up front so the upload jobs below only ever find it.
   # A draft is invisible to the get-release-by-tag API, so every uploader falls
@@ -40,9 +18,6 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs:
-      - lint
-      - test
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
A tag is cut from a main commit that already passed the full **Build** workflow
— lint, test, build and e2e — so rerunning lint and test on the tag is pure
duplication.

- **Lint** checks style and static analysis that don't affect the shipped binary
  at all — pointless as a release gate.
- **Test** was already green on the same commit when it merged to main.
- A **compile error still fails** the `release` / `release-plugins` build jobs,
  so a broken commit can't produce artifacts.

`create-release` now runs straight off the tag; `release` / `release-plugins` /
`docker` still gate on it.

## Caveat

This assumes a tag sits on a main commit that passed CI — the normal flow.
That's a release-discipline matter, better enforced by tag protection than by
re-verifying lint/test on every tag.

Also resolves the asymmetry left after the test-matrix change (release had a
matrixed `lint` but a single-platform `test`): both are simply gone.