### PR TITLE
ci: raise e2e tunnel startup polls to 60s

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,9 @@
-name: Build
+name: CI
 on:
   pull_request:
   push:
     branches:
       - main
-  # A weekly run rebuilds and re-runs e2e with no code change, catching bit-rot
-  # and external regressions (a dhtproxy endpoint going away). workflow_dispatch
-  # allows the same on demand.
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -77,7 +77,7 @@ create_iface() {
 		# writes the chosen utunN to namefile once up.
 		$SUDO env WG_TUN_NAME_FILE="$namefile" WG_PROCESS_FOREGROUND=1 \
 			"$wgg" utun >"$WORK/wggo$slot.log" 2>&1 &
-		for _ in $(seq 1 30); do [ -s "$namefile" ] && break; sleep 0.5; done
+		for _ in $(seq 1 60); do [ -s "$namefile" ] && break; sleep 1; done
 		if ! $SUDO test -s "$namefile"; then
 			echo "wireguard-go never named a utun; its log:" >&2
 			$SUDO cat "$WORK/wggo$slot.log" >&2 || true
@@ -109,7 +109,7 @@ create_iface() {
 		up=""
 		for _ in $(seq 1 60); do
 			if wg show "$name" >/dev/null 2>&1; then up=1; break; fi
-			sleep 0.5
+			sleep 1
 		done
 		[ -n "$up" ] || { echo "tunnel $name never came up" >&2; exit 1; }
 		;;


### PR DESCRIPTION
The windows/arm64 e2e cell flaked with `tunnel stunmesh0 never came up` (run 30199474862) — the WGNT tunnel service occasionally needs more than the 30s poll on the arm64 runner; the rerun passed with no change. Raise both startup polls (darwin wireguard-go namefile 15s, windows tunnel service 30s) to 60s.


Also renames the main workflow from `Build` to `CI` — it runs codegen/lint/test/build/e2e/docker, and the required checks bind to job names, so branch protection is unaffected.
