### PR TITLE
ci: add embedca build and release cells for linux

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Tag to append to binary name'
     required: false
     default: ''
+  embedca:
+    description: 'Embed the Mozilla CA bundle when not 0 (passed to make as EMBED_CA)'
+    required: false
+    default: '0'
 
 outputs:
   binary-name:
@@ -32,15 +36,15 @@ runs:
       id: build-info
       shell: bash
       run: |
-        SUFFIX=""
-        if [ "${{ inputs.os }}" = "windows" ]; then
-          SUFFIX="${SUFFIX}.exe"
+        BINARY_NAME="${{ inputs.app-name }}-${{ inputs.os }}-${{ inputs.arch }}"
+        if [ "${{ inputs.embedca }}" != "0" ]; then
+          BINARY_NAME="${BINARY_NAME}-ca"
         fi
-
         if [ -n "${{ inputs.tag }}" ]; then
-          BINARY_NAME="${{ inputs.app-name }}-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.tag }}${SUFFIX}"
-        else
-          BINARY_NAME="${{ inputs.app-name }}-${{ inputs.os }}-${{ inputs.arch }}${SUFFIX}"
+          BINARY_NAME="${BINARY_NAME}-${{ inputs.tag }}"
+        fi
+        if [ "${{ inputs.os }}" = "windows" ]; then
+          BINARY_NAME="${BINARY_NAME}.exe"
         fi
         echo "binary-name=$BINARY_NAME" >> "$GITHUB_OUTPUT"
 
@@ -50,7 +54,7 @@ runs:
 
     - name: Build
       shell: bash
-      run: make APP=${{ steps.build-info.outputs.binary-name }}
+      run: make APP=${{ steps.build-info.outputs.binary-name }} EMBED_CA=${{ inputs.embedca }}
       env:
         GOARCH: ${{ inputs.arch }}
         GOOS: ${{ inputs.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,19 +93,26 @@ jobs:
       matrix:
         os: [linux, darwin, freebsd, windows]
         arch: [amd64, arm64, arm, mipsle]
+        embedca: [0, 1]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
             arch: mipsle
+          - os: darwin
+            embedca: 1
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
+          - os: freebsd
+            embedca: 1
           - os: windows
             arch: arm
           - os: windows
             arch: mipsle
+          - os: windows
+            embedca: 1
     steps:
       - uses: actions/checkout@v7
       - name: Build
@@ -116,6 +123,7 @@ jobs:
           arch: ${{ matrix.arch }}
           app-name: ${{ env.APP }}
           go-version: ${{ env.GO_VERSION }}
+          embedca: ${{ matrix.embedca }}
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.binary-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,19 +46,26 @@ jobs:
       matrix:
         os: [linux, darwin, freebsd, windows]
         arch: [amd64, arm64, arm, mipsle]
+        embedca: [0, 1]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
             arch: mipsle
+          - os: darwin
+            embedca: 1
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
+          - os: freebsd
+            embedca: 1
           - os: windows
             arch: arm
           - os: windows
             arch: mipsle
+          - os: windows
+            embedca: 1
     steps:
       - uses: actions/checkout@v7
       - name: tag
@@ -73,6 +80,7 @@ jobs:
           app-name: ${{ env.APP }}
           go-version: ${{ env.GO_VERSION }}
           tag: ${{ steps.tag.outputs.TAG }}
+          embedca: ${{ matrix.embedca }}
       # Windows ships as a zip of the .exe; the other platforms ship the raw
       # binary. package.outputs.file is empty when the step is skipped, so the
       # || falls back to the binary.


### PR DESCRIPTION
Adds an `embedca` matrix dimension (linux-only) that builds with `EMBED_CA=1` (the `embedca` tag from #225), published with a `-ca` suffix between arch and tag:

- CI artifact: `stunmesh-linux-<arch>-ca`
- Release asset: `stunmesh-linux-<arch>-ca-<tag>`

Design notes:
- The suffix sits before the tag so the version stays terminal (`v1.12.0-ca` would read as a semver pre-release) and artifact/release names differ only by the tag.
- `embedca` is its own 0/1 dimension rather than a `variant` enum, so it can combine with future build options; nonzero enables, and the value passes straight through to `make` as `EMBED_CA`, matching the Makefile's `ifneq (...,0)` convention.
- Linux-only: the CA-less images this exists for are embedded linux (OpenWrt-class). +4 cells in each matrix.
- Both workflows reuse the same build action, which derives the name by appending `-ca`, tag and `.exe` in order.
