### PR TITLE
docs: drop the Windows firewall rule step

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,9 @@ tunnel.
 2. Activate the tunnel **before** starting stunmesh-go.
 3. Run stunmesh-go from an **Administrator** console. The WireGuard service requires the same privilege;
    without it stunmesh-go fails at the first device access with a "run stunmesh as Administrator" error.
-4. Allow inbound UDP for the executable. The rule must be per-program, not per-port — the public port is
-   ephemeral by design and changes on every restart:
 
-```powershell
-netsh advfirewall firewall add rule name="stunmesh" dir=in action=allow protocol=UDP program="C:\stunmesh\stunmesh.exe" enable=yes
-```
+No firewall rule is needed: the proxy always initiates outbound first (STUN, then the WireGuard
+handshake), so Windows Firewall admits the return traffic on its own.
 
 The configuration file is unchanged from the other platforms and the proxy needs no configuration of its
 own; set `interfaces.<name>.proxy.listen` only if you need a fixed outer port for port forwarding or a


### PR DESCRIPTION
The netsh inbound rule in the Windows quickstart is unnecessary: the proxy always initiates outbound first (STUN, then the WireGuard handshake once the endpoint is set), so Windows Firewall's stateful UDP handling admits the return traffic on its own. Verified in the two-node manual test — no rule was added and the tunnel came up and passed traffic. Replaced the step with a sentence explaining why no rule is needed.