### PR TITLE
docs: add Contributor License Agreement (CLA) v1.0

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,44 @@
+# stunmesh Individual Contributor License Agreement (v1.0)
+
+Thank you for your interest in contributing to stunmesh ("the Project", currently the repositories under https://github.com/tjjh89017 named stunmesh-go and related stunmesh repositories).
+
+By signing this agreement, You accept the following terms for Your past and future Contributions submitted to the Project.
+
+**1. Definitions.**
+"You" means the individual who signs this agreement. "Contribution" means any original work of authorship, including any modifications or additions to an existing work, that You intentionally submit to the Project, both before and after the date You sign this agreement.
+
+**2. Copyright license.**
+You grant Date Huang, as the Project maintainer, a perpetual, worldwide, non-exclusive, irrevocable, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute, and sublicense Your Contributions and derivative works of Your Contributions.
+
+**3. Relicensing.**
+You grant the Project maintainer the right to license Your Contributions, and derivative works of Your Contributions, under the terms of any license approved by the Open Source Initiative (OSI), and to add additional permissions or license exceptions to such licenses (for example, an exception that permits distribution through the Apple App Store).
+
+**4. Open-source commitment.**
+The rights in Section 3 are limited to OSI-approved open source licenses. This agreement does not permit the Project maintainer to distribute Your Contributions solely under a proprietary license.
+
+**5. Patent license.**
+You grant the Project maintainer and all recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, irrevocable, royalty-free patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contributions, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Project.
+
+**6. Your representations.**
+You represent that You are legally entitled to grant the above licenses. If Your employer has rights to intellectual property that You create, You represent that You have received permission to make the Contributions on behalf of that employer, or that Your employer has waived such rights for Your Contributions to the Project.
+
+**6a. AI-assisted contributions.**
+You may use AI or other automated tools as development aids. For any Contribution created with such assistance, You represent that: (a) You have reviewed the output and adopt it as Your own work, and You take the same responsibility for it as for code You wrote directly; (b) to Your knowledge, it does not include material that is subject to a license incompatible with the Project's license; and (c) the rights granted in this agreement apply to it in full. Contributions generated entirely without human review are not acceptable.
+
+**7. No warranty.**
+You provide Your Contributions "AS IS", without warranties or conditions of any kind.
+
+**8. You keep Your rights.**
+This agreement is a license, not a transfer of ownership. You keep the copyright in Your Contributions and remain free to use them for any other purpose.
+
+---
+
+## How to sign
+
+Reply with the following statement in the place where you are asked to sign (a pull request comment or a dedicated issue):
+
+> I have read the stunmesh Individual Contributor License Agreement v1.0 and I agree to it for all my past and future contributions to the Project.
+> I confirm that the following commit email addresses are mine and that this agreement covers all my contributions made under them: \<list every email address you have committed with\>.
+> — \<your name\> (GitHub: @\<your handle\>)
+
+This agreement is separate from the DCO `Signed-off-by` line, which remains required on every commit.


### PR DESCRIPTION
Adds `CLA.md`: a lightweight individual CLA whose relicensing scope is limited to OSI-approved open source licenses plus license exceptions (e.g. an Apple App Store exception). Key properties:

- Contributors keep their copyright; this is a license, not a transfer (§8)
- Relicensing power is explicitly restricted to open source licenses — the project cannot be taken proprietary with contributed code (§3–4)
- Standard Apache-style patent grant (§5)
- AI-assisted contributions are allowed with the contributor taking full responsibility, matching the existing project policy (§6a)
- The DCO `Signed-off-by` requirement is unchanged

This is the prerequisite for the upcoming relicensing consent issue (GPL-2.0-or-later → LGPL-3.0-or-later for the mobile library boundary).