### PR TITLE
feat: add two-VM real-network e2e harness

### DIFF
--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -75,6 +75,9 @@ runs:
           go build -o "$out/canary" ./test/e2e/realnet/canary
         fi
 
+    # The anchor gets a done-probe for its pair's subject job, so its hold
+    # window becomes a cap rather than a fixed sleep; gh needs only
+    # actions:read on the job token for that.
     - name: Run peer
       if: inputs.os == 'linux' || inputs.os == 'darwin'
       shell: bash
@@ -84,6 +87,8 @@ runs:
         PEER_PUBLIC_KEY: ${{ inputs.peer-public-key }}
         RESULT_DIR: ${{ runner.temp }}/realnet
         CANARY_BIN: ${{ runner.temp }}/canary
+        GH_TOKEN: ${{ github.token }}
+        SUBJECT_DONE_CMD: ${{ inputs.role == 'anchor' && format('sh test/e2e/realnet/subject-done.sh {0}', inputs.pair) || '' }}
       run: |
         mkdir -p "$RESULT_DIR"
         sh test/e2e/realnet/run-peer.sh "$RUNNER_TEMP/stunmesh"

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -1,5 +1,5 @@
 name: 'E2E realnet peer'
-description: 'Run one side of the two-VM real-network stunmesh e2e and upload its conclusions'
+description: 'Run one side of the two-VM real-network stunmesh e2e against a build-stage artifact and upload its conclusions'
 
 inputs:
   role:
@@ -8,11 +8,17 @@ inputs:
   os:
     description: 'Target OS (linux, darwin, freebsd, windows); the anchor is always linux'
     required: true
+  arch:
+    description: 'Target architecture of this runner (amd64, arm64)'
+    required: true
+  app-name:
+    description: 'Application name; the artifact is <app-name>-<os>-<arch>'
+    required: true
   pair:
     description: 'Pair name, used to keep each anchor/subject couple''s artifacts apart'
     required: true
   go-version:
-    description: 'Go toolchain version'
+    description: 'Go toolchain version (anchor only, for the canary helper)'
     required: true
   wg-private-key:
     description: 'This side''s WireGuard private key (ephemeral, per run)'
@@ -52,28 +58,23 @@ runs:
         if (-not (Test-Path $wg)) { throw 'WireGuard install did not complete' }
         Add-Content $env:GITHUB_PATH 'C:\Program Files\WireGuard'
 
+    # The binary under test is the build stage's artifact -- the exact bytes
+    # a release would ship -- mirroring the same-host e2e. Only the canary
+    # helper is built here: it is test tooling, not the thing under test,
+    # and only the anchor (always Linux) runs it.
+    - uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.app-name }}-${{ inputs.os }}-${{ inputs.arch }}${{ inputs.os == 'windows' && '.exe' || '' }}
+
     - uses: actions/setup-go@v7
+      if: inputs.role == 'anchor'
       with:
         go-version: ${{ inputs.go-version }}
 
-    # Built from source rather than taken from the build stage: this harness
-    # needs no cross-compiled release artifact, and building here keeps it
-    # independent of the build matrix's naming. The canary server is only
-    # ever run by the anchor, which is always Linux.
-    - name: Build
+    - name: Build canary helper
+      if: inputs.role == 'anchor'
       shell: bash
-      env:
-        GOOS: ${{ inputs.os == 'freebsd' && 'freebsd' || '' }}
-      run: |
-        set -eu
-        out=$RUNNER_TEMP ext=
-        [ "${{ inputs.os }}" = windows ] && { out=$(cygpath -u "$RUNNER_TEMP"); ext=.exe; }
-        [ "${{ inputs.os }}" = freebsd ] && out=$GITHUB_WORKSPACE/realnet-out
-        mkdir -p "$out"
-        go build -tags builtin_all -o "$out/stunmesh$ext" .
-        if [ "${{ inputs.role }}" = anchor ]; then
-          go build -o "$out/canary" ./test/e2e/realnet/canary
-        fi
+      run: go build -o "$RUNNER_TEMP/canary" ./test/e2e/realnet/canary
 
     # The subject's fixed handshake window must not start ticking against an
     # anchor that is still queued; runs on the host for every subject OS
@@ -100,8 +101,10 @@ runs:
         GH_TOKEN: ${{ github.token }}
         SUBJECT_DONE_CMD: ${{ inputs.role == 'anchor' && format('sh test/e2e/realnet/subject-done.sh {0}', inputs.pair) || '' }}
       run: |
+        bin=$GITHUB_WORKSPACE/${{ inputs.app-name }}-${{ inputs.os }}-${{ inputs.arch }}
+        chmod +x "$bin"
         mkdir -p "$RESULT_DIR"
-        sh test/e2e/realnet/run-peer.sh "$RUNNER_TEMP/stunmesh"
+        sh test/e2e/realnet/run-peer.sh "$bin"
 
     # Git Bash: run-peer.sh folds MINGW* to Windows and drives
     # wireguard.exe /installtunnelservice. RUNNER_TEMP is a Windows path, so
@@ -117,7 +120,8 @@ runs:
         tmp=$(cygpath -u "$RUNNER_TEMP")
         RESULT_DIR="$tmp/realnet" && export RESULT_DIR
         mkdir -p "$RESULT_DIR"
-        sh test/e2e/realnet/run-peer.sh "$tmp/stunmesh.exe"
+        sh test/e2e/realnet/run-peer.sh \
+          "$(cygpath -u "$GITHUB_WORKSPACE")/${{ inputs.app-name }}-windows-${{ inputs.arch }}.exe"
 
     # FreeBSD runs everything inside the guest, which has no access to the
     # host's step files, so the scripts fall back to stdout there and the
@@ -134,9 +138,11 @@ runs:
           kldload if_wg
         run: |
           cd $GITHUB_WORKSPACE
+          bin=$GITHUB_WORKSPACE/${{ inputs.app-name }}-freebsd-${{ inputs.arch }}
+          chmod +x "$bin"
           export RESULT_DIR=$GITHUB_WORKSPACE/realnet-out/realnet
           mkdir -p "$RESULT_DIR"
-          sh test/e2e/realnet/run-peer.sh "$GITHUB_WORKSPACE/realnet-out/stunmesh"
+          sh test/e2e/realnet/run-peer.sh "$bin"
       env:
         ROLE: ${{ inputs.role }}
         WG_PRIVATE_KEY: ${{ inputs.wg-private-key }}

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -1,9 +1,15 @@
 name: 'E2E realnet peer'
-description: 'Run one side of the two-VM real-network stunmesh e2e and return its conclusions as JSON'
+description: 'Run one side of the two-VM real-network stunmesh e2e and upload its conclusions'
 
 inputs:
   role:
-    description: 'anchor (fixed far end) or subject (the side under test)'
+    description: 'anchor (fixed Linux far end) or subject (the side under test)'
+    required: true
+  os:
+    description: 'Target OS (linux, darwin, freebsd, windows); the anchor is always linux'
+    required: true
+  pair:
+    description: 'Pair name, used to keep each anchor/subject couple''s artifacts apart'
     required: true
   go-version:
     description: 'Go toolchain version'
@@ -15,33 +21,62 @@ inputs:
     description: 'The other side''s WireGuard public key'
     required: true
 
-outputs:
-  results:
-    description: 'Recorded conclusions as a compact JSON object'
-    value: ${{ steps.run.outputs.results }}
-
 runs:
   using: 'composite'
   steps:
-    # Built from source rather than downloaded from the build stage: this
-    # harness needs no cross-compiled artifact, and building here keeps it
-    # independent of the build matrix's naming.
-    - name: Install tools
+    # os is an input, not runner.os: freebsd runs in a VM on a Linux host, so
+    # runner.os is Linux for both the linux and freebsd targets.
+    - name: Install tools (Linux)
+      if: inputs.os == 'linux' || inputs.os == 'freebsd'
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y wireguard-tools jq iperf3 tcpdump
+
+    - name: Install tools (macOS)
+      if: inputs.os == 'darwin'
+      shell: bash
+      run: brew install wireguard-tools wireguard-go jq iperf3
+
+    # Mirrors the same-host e2e: the official installer always takes the
+    # latest client and picks the arch itself, so a scheduled run doubles as
+    # an early warning when a new WireGuard release breaks us. It hands off
+    # to a child MSI process, so poll for the binary rather than trust -Wait.
+    - name: Install tools (Windows)
+      if: inputs.os == 'windows'
+      shell: pwsh
+      run: |
+        $installer = Join-Path $env:RUNNER_TEMP 'wireguard-installer.exe'
+        Invoke-WebRequest -Uri 'https://download.wireguard.com/windows-client/wireguard-installer.exe' -OutFile $installer
+        Start-Process $installer -ArgumentList '/install','/quiet' -Wait
+        $wg = 'C:\Program Files\WireGuard\wireguard.exe'
+        for ($i = 0; $i -lt 60 -and -not (Test-Path $wg); $i++) { Start-Sleep 2 }
+        if (-not (Test-Path $wg)) { throw 'WireGuard install did not complete' }
+        Add-Content $env:GITHUB_PATH 'C:\Program Files\WireGuard'
 
     - uses: actions/setup-go@v7
       with:
         go-version: ${{ inputs.go-version }}
 
+    # Built from source rather than taken from the build stage: this harness
+    # needs no cross-compiled release artifact, and building here keeps it
+    # independent of the build matrix's naming. The canary server is only
+    # ever run by the anchor, which is always Linux.
     - name: Build
       shell: bash
+      env:
+        GOOS: ${{ inputs.os == 'freebsd' && 'freebsd' || '' }}
       run: |
-        go build -tags builtin_all -o "$RUNNER_TEMP/stunmesh" .
-        go build -o "$RUNNER_TEMP/canary" ./test/e2e/realnet/canary
+        set -eu
+        out=$RUNNER_TEMP ext=
+        [ "${{ inputs.os }}" = windows ] && { out=$(cygpath -u "$RUNNER_TEMP"); ext=.exe; }
+        [ "${{ inputs.os }}" = freebsd ] && out=$GITHUB_WORKSPACE/realnet-out
+        mkdir -p "$out"
+        go build -tags builtin_all -o "$out/stunmesh$ext" .
+        if [ "${{ inputs.role }}" = anchor ]; then
+          go build -o "$out/canary" ./test/e2e/realnet/canary
+        fi
 
     - name: Run peer
-      id: run
+      if: inputs.os == 'linux' || inputs.os == 'darwin'
       shell: bash
       env:
         ROLE: ${{ inputs.role }}
@@ -53,15 +88,75 @@ runs:
         mkdir -p "$RESULT_DIR"
         sh test/e2e/realnet/run-peer.sh "$RUNNER_TEMP/stunmesh"
 
+    # Git Bash: run-peer.sh folds MINGW* to Windows and drives
+    # wireguard.exe /installtunnelservice. RUNNER_TEMP is a Windows path, so
+    # convert it before any shell use.
+    - name: Run peer (Windows)
+      if: inputs.os == 'windows'
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        WG_PRIVATE_KEY: ${{ inputs.wg-private-key }}
+        PEER_PUBLIC_KEY: ${{ inputs.peer-public-key }}
+      run: |
+        tmp=$(cygpath -u "$RUNNER_TEMP")
+        RESULT_DIR="$tmp/realnet" && export RESULT_DIR
+        mkdir -p "$RESULT_DIR"
+        sh test/e2e/realnet/run-peer.sh "$tmp/stunmesh.exe"
+
+    # FreeBSD runs everything inside the guest, which has no access to the
+    # host's step files, so the scripts fall back to stdout there and the
+    # results ride back to the host through the synced workspace.
+    - name: Run peer (FreeBSD VM)
+      if: inputs.os == 'freebsd'
+      uses: vmactions/freebsd-vm@v1
+      with:
+        arch: x86-64
+        sync: sshfs
+        envs: 'ROLE WG_PRIVATE_KEY PEER_PUBLIC_KEY'
+        prepare: |
+          pkg install -y wireguard-tools jq curl iperf3
+          kldload if_wg
+        run: |
+          cd $GITHUB_WORKSPACE
+          export RESULT_DIR=$GITHUB_WORKSPACE/realnet-out/realnet
+          mkdir -p "$RESULT_DIR"
+          sh test/e2e/realnet/run-peer.sh "$GITHUB_WORKSPACE/realnet-out/stunmesh"
+      env:
+        ROLE: ${{ inputs.role }}
+        WG_PRIVATE_KEY: ${{ inputs.wg-private-key }}
+        PEER_PUBLIC_KEY: ${{ inputs.peer-public-key }}
+
+    - name: Resolve result dir
+      id: dir
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ inputs.os }}" = freebsd ]; then
+          echo "path=realnet-out/realnet" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=${RUNNER_TEMP//\\//}/realnet" >> "$GITHUB_OUTPUT"
+        fi
+
     # Collapsible inline logs, so a first look needs no artifact download.
     - name: Logs
       if: always()
       shell: bash
       run: |
-        for f in "$RUNNER_TEMP"/realnet/*.log "$RUNNER_TEMP"/realnet/results.env; do
+        d='${{ steps.dir.outputs.path }}'
+        for f in "$d"/*.log "$d"/results.env; do
           [ -f "$f" ] || continue
           echo "::group::${f##*/}"; cat "$f"; echo "::endgroup::"
         done
+
+    # Two artifacts on purpose: the report job downloads only the small
+    # results set, so it never pulls the packet captures with it.
+    - uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: realnet-results-${{ inputs.pair }}-${{ inputs.role }}
+        path: ${{ steps.dir.outputs.path }}/results.json
+        if-no-files-found: warn
 
     # Evidence for post-mortem only. The captures are header-only (the
     # payload is encrypted and useless) and ring-buffered, so the upload
@@ -69,6 +164,7 @@ runs:
     - uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: realnet-${{ inputs.role }}
-        path: ${{ runner.temp }}/realnet
+        name: realnet-${{ inputs.pair }}-${{ inputs.role }}
+        path: ${{ steps.dir.outputs.path }}
         retention-days: 7
+        if-no-files-found: warn

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -111,7 +111,7 @@ runs:
       if: inputs.os == 'freebsd'
       uses: vmactions/freebsd-vm@v1
       with:
-        arch: x86-64
+        arch: amd64
         sync: sshfs
         envs: 'ROLE WG_PRIVATE_KEY PEER_PUBLIC_KEY'
         prepare: |

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -46,6 +46,15 @@ runs:
     # latest client and picks the arch itself, so a scheduled run doubles as
     # an early warning when a new WireGuard release breaks us. It hands off
     # to a child MSI process, so poll for the binary rather than trust -Wait.
+    # iperf3 via the preinstalled Chocolatey (winget is absent on the Server
+    # images): the windows subject is the only proxy-mode pair, and the
+    # sustained-stream check is the one signal that loads the relay over a
+    # real NAT -- without iperf3 phases.sh records it as skipped.
+    - name: Install iperf3 (Windows)
+      if: inputs.os == 'windows'
+      shell: pwsh
+      run: choco install iperf3 -y --no-progress
+
     - name: Install tools (Windows)
       if: inputs.os == 'windows'
       shell: pwsh

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -75,6 +75,16 @@ runs:
           go build -o "$out/canary" ./test/e2e/realnet/canary
         fi
 
+    # The subject's fixed handshake window must not start ticking against an
+    # anchor that is still queued; runs on the host for every subject OS
+    # (including before the FreeBSD VM boots, which has no gh inside).
+    - name: Wait for anchor
+      if: inputs.role == 'subject'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: sh test/e2e/realnet/wait-anchor.sh "${{ inputs.pair }}"
+
     # The anchor gets a done-probe for its pair's subject job, so its hold
     # window becomes a cap rather than a fixed sleep; gh needs only
     # actions:read on the job token for that.

--- a/.github/actions/e2e-realnet/action.yml
+++ b/.github/actions/e2e-realnet/action.yml
@@ -1,0 +1,74 @@
+name: 'E2E realnet peer'
+description: 'Run one side of the two-VM real-network stunmesh e2e and return its conclusions as JSON'
+
+inputs:
+  role:
+    description: 'anchor (fixed far end) or subject (the side under test)'
+    required: true
+  go-version:
+    description: 'Go toolchain version'
+    required: true
+  wg-private-key:
+    description: 'This side''s WireGuard private key (ephemeral, per run)'
+    required: true
+  peer-public-key:
+    description: 'The other side''s WireGuard public key'
+    required: true
+
+outputs:
+  results:
+    description: 'Recorded conclusions as a compact JSON object'
+    value: ${{ steps.run.outputs.results }}
+
+runs:
+  using: 'composite'
+  steps:
+    # Built from source rather than downloaded from the build stage: this
+    # harness needs no cross-compiled artifact, and building here keeps it
+    # independent of the build matrix's naming.
+    - name: Install tools
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y wireguard-tools jq iperf3 tcpdump
+
+    - uses: actions/setup-go@v7
+      with:
+        go-version: ${{ inputs.go-version }}
+
+    - name: Build
+      shell: bash
+      run: |
+        go build -tags builtin_all -o "$RUNNER_TEMP/stunmesh" .
+        go build -o "$RUNNER_TEMP/canary" ./test/e2e/realnet/canary
+
+    - name: Run peer
+      id: run
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        WG_PRIVATE_KEY: ${{ inputs.wg-private-key }}
+        PEER_PUBLIC_KEY: ${{ inputs.peer-public-key }}
+        RESULT_DIR: ${{ runner.temp }}/realnet
+        CANARY_BIN: ${{ runner.temp }}/canary
+      run: |
+        mkdir -p "$RESULT_DIR"
+        sh test/e2e/realnet/run-peer.sh "$RUNNER_TEMP/stunmesh"
+
+    # Collapsible inline logs, so a first look needs no artifact download.
+    - name: Logs
+      if: always()
+      shell: bash
+      run: |
+        for f in "$RUNNER_TEMP"/realnet/*.log "$RUNNER_TEMP"/realnet/results.env; do
+          [ -f "$f" ] || continue
+          echo "::group::${f##*/}"; cat "$f"; echo "::endgroup::"
+        done
+
+    # Evidence for post-mortem only. The captures are header-only (the
+    # payload is encrypted and useless) and ring-buffered, so the upload
+    # stays a few MB outside the throughput window and 100MB at worst.
+    - uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: realnet-${{ inputs.role }}
+        path: ${{ runner.temp }}/realnet
+        retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,9 +267,115 @@ jobs:
             fi
           done
 
+  # Two-VM real-network e2e: two runners behind real cloud NAT punch a hole
+  # and hold a tunnel, then the subject proves STUN still escapes a covering
+  # WireGuard default route. Runs beside e2e/e2e-proxy on the same gates.
+  #
+  # Deliberately advisory: it is excluded from e2e-required and every job
+  # carries continue-on-error, because cloud runners give no NAT-behavior
+  # guarantee -- both sides may land in one region and connect trivially, or
+  # SNAT may behave symmetrically and traversal fails through no fault of
+  # ours. Read the verdict in the step summary; it must never block a merge.
+  # See test/e2e/realnet/.
+  e2e-realnet-keys:
+    name: E2E realnet (keys)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 5
+    needs:
+      - build-required
+      - build-plugins-required
+    outputs:
+      anchor_key: ${{ steps.gen.outputs.anchor_key }}
+      anchor_pub: ${{ steps.gen.outputs.anchor_pub }}
+      subject_key: ${{ steps.gen.outputs.subject_key }}
+      subject_pub: ${{ steps.gen.outputs.subject_pub }}
+    steps:
+      - name: Install wireguard-tools
+        run: sudo apt-get update && sudo apt-get install -y wireguard-tools
+      # The keys are ephemeral and worthless once the run ends, so passing
+      # them through job outputs is intentional: it removes the cross-job
+      # secret exchange entirely. Per-run public keys also namespace the
+      # storage keys, so concurrent runs cannot collide.
+      - name: Generate keypairs
+        id: gen
+        run: |
+          for role in anchor subject; do
+            key=$(wg genkey)
+            echo "${role}_key=$key" >> "$GITHUB_OUTPUT"
+            echo "${role}_pub=$(echo "$key" | wg pubkey)" >> "$GITHUB_OUTPUT"
+          done
+
+  # The fixed far end: always Linux, always the same split-tunnel raw-socket
+  # configuration, so a failure is attributable to the subject side (or to
+  # network weather) by construction.
+  e2e-realnet-anchor:
+    name: E2E realnet (anchor)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: e2e-realnet-keys
+    timeout-minutes: 12
+    outputs:
+      results: ${{ steps.peer.outputs.results }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-realnet
+        id: peer
+        with:
+          role: anchor
+          go-version: ${{ env.GO_VERSION }}
+          wg-private-key: ${{ needs.e2e-realnet-keys.outputs.anchor_key }}
+          peer-public-key: ${{ needs.e2e-realnet-keys.outputs.subject_pub }}
+
+  # The side under test. Adding another subject OS means one entry here plus
+  # its per-OS branches in the scripts -- but note that matrix rows share one
+  # output namespace, so the result plumbing must move to artifacts first.
+  e2e-realnet-subject:
+    name: E2E realnet (${{ matrix.subject }})
+    runs-on: ${{ matrix.subject }}
+    continue-on-error: true
+    needs: e2e-realnet-keys
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        subject: [ubuntu-latest]
+    outputs:
+      results: ${{ steps.peer.outputs.results }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-realnet
+        id: peer
+        with:
+          role: subject
+          go-version: ${{ env.GO_VERSION }}
+          wg-private-key: ${{ needs.e2e-realnet-keys.outputs.subject_key }}
+          peer-public-key: ${{ needs.e2e-realnet-keys.outputs.anchor_pub }}
+
+  e2e-realnet-report:
+    name: E2E realnet
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs:
+      - e2e-realnet-anchor
+      - e2e-realnet-subject
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Combined verdict
+        env:
+          ANCHOR_RESULTS: ${{ needs.e2e-realnet-anchor.outputs.results }}
+          SUBJECT_RESULTS: ${{ needs.e2e-realnet-subject.outputs.results }}
+          ANCHOR_JOB: ${{ needs.e2e-realnet-anchor.result }}
+          SUBJECT_JOB: ${{ needs.e2e-realnet-subject.result }}
+        run: sh test/e2e/realnet/report.sh
+
   # One stable check aggregating the e2e matrix and the proxy cell, mirroring
   # the other summary gates. The ruleset requires it, so every cell must pass
-  # to merge.
+  # to merge. The realnet jobs are deliberately absent: they are advisory.
   e2e-required:
     name: E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
   # are wider for the pairs whose subject boots slowly (brew, the FreeBSD
   # VM, the WireGuard installer).
   e2e-realnet-anchor:
-    name: E2E realnet (linux anchor for ${{ matrix.pair }})
+    name: E2E realnet (anchor for ${{ matrix.pair }})
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: e2e-realnet-keys
@@ -359,6 +359,8 @@ jobs:
         with:
           role: anchor
           os: linux
+          arch: amd64
+          app-name: ${{ env.APP }}
           pair: ${{ matrix.pair }}
           go-version: ${{ env.GO_VERSION }}
           wg-private-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_anchor_key', matrix.pair)] }}
@@ -381,16 +383,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { pair: linux, os: linux, runner: ubuntu-latest, timeout: 12 }
-          - { pair: darwin, os: darwin, runner: macos-26, timeout: 20 }
-          - { pair: freebsd, os: freebsd, runner: ubuntu-latest, timeout: 20 }
-          - { pair: windows, os: windows, runner: windows-latest, timeout: 20 }
+          - { pair: linux, os: linux, arch: amd64, runner: ubuntu-latest, timeout: 12 }
+          - { pair: darwin, os: darwin, arch: arm64, runner: macos-26, timeout: 20 }
+          - { pair: freebsd, os: freebsd, arch: amd64, runner: ubuntu-latest, timeout: 20 }
+          - { pair: windows, os: windows, arch: amd64, runner: windows-latest, timeout: 20 }
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-realnet
         with:
           role: subject
           os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          app-name: ${{ env.APP }}
           pair: ${{ matrix.pair }}
           go-version: ${{ env.GO_VERSION }}
           wg-private-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_subject_key', matrix.pair)] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,13 +190,9 @@ jobs:
     if: github.event_name == 'push'
     name: Build Docker container
     runs-on: ubuntu-latest
-    # e2e-required transitively covers lint/test/build/build-plugins. The
-    # realnet report additionally gates the publish: it is advisory on PRs
-    # (not merge-blocking), but an image should not ship from a commit whose
-    # real-NAT verdict failed outright.
-    needs:
-      - e2e-required
-      - e2e-realnet-report
+    # e2e-required transitively covers lint/test/build/build-plugins and the
+    # realnet report.
+    needs: e2e-required
     steps:
       - uses: actions/checkout@v7
       - name: Build and Push Docker
@@ -284,8 +280,8 @@ jobs:
   # trivially, or SNAT may behave symmetrically and traversal fails through
   # no fault of ours. The report job is the single genuine verdict: it hard-
   # fails only on what is ours to break (results missing, endpoint round-trip
-  # broken, canary corrupted). It stays out of e2e-required so weather never
-  # blocks a merge, but it does gate the docker publish. See test/e2e/realnet/.
+  # broken, canary corrupted), and it feeds e2e-required like every other
+  # e2e cell. See test/e2e/realnet/.
   e2e-realnet-keys:
     name: E2E realnet (keys)
     runs-on: ubuntu-latest
@@ -424,18 +420,21 @@ jobs:
           REALNET_PAIRS: linux darwin freebsd windows
         run: sh test/e2e/realnet/report.sh realnet-results
 
-  # One stable check aggregating the e2e matrix and the proxy cell, mirroring
-  # the other summary gates. The ruleset requires it, so every cell must pass
-  # to merge. The realnet jobs are deliberately absent: they are advisory.
+  # One stable check aggregating the e2e matrix, the proxy cell and the
+  # realnet verdict, mirroring the other summary gates. The ruleset requires
+  # it, so every cell must pass to merge. The realnet peer cells stay
+  # advisory individually; their report job is what carries the verdict here.
   e2e-required:
     name: E2E
     runs-on: ubuntu-latest
     needs:
       - e2e
       - e2e-proxy
+      - e2e-realnet-report
     if: always()
     steps:
       - name: All e2e platforms passed
         run: |
           [ "${{ needs.e2e.result }}" = "success" ] && \
-            [ "${{ needs.e2e-proxy.result }}" = "success" ]
+            [ "${{ needs.e2e-proxy.result }}" = "success" ] && \
+            [ "${{ needs.e2e-realnet-report.result }}" = "success" ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,8 +190,13 @@ jobs:
     if: github.event_name == 'push'
     name: Build Docker container
     runs-on: ubuntu-latest
-    # e2e-required transitively covers lint/test/build/build-plugins.
-    needs: e2e-required
+    # e2e-required transitively covers lint/test/build/build-plugins. The
+    # realnet report additionally gates the publish: it is advisory on PRs
+    # (not merge-blocking), but an image should not ship from a commit whose
+    # real-NAT verdict failed outright.
+    needs:
+      - e2e-required
+      - e2e-realnet-report
     steps:
       - uses: actions/checkout@v7
       - name: Build and Push Docker
@@ -267,16 +272,20 @@ jobs:
             fi
           done
 
-  # Two-VM real-network e2e: two runners behind real cloud NAT punch a hole
-  # and hold a tunnel, then the subject proves STUN still escapes a covering
+  # Two-VM real-network e2e: for every subject OS, two runners behind real
+  # cloud NAT punch a hole and hold a tunnel; where the crash-bunker netns
+  # exists (Linux) the subject then proves STUN still escapes a covering
   # WireGuard default route. Runs beside e2e/e2e-proxy on the same gates.
+  # One pair per subject OS, each against its own fixed Linux anchor, so a
+  # failure is attributable to the subject side by construction.
   #
-  # Deliberately advisory: it is excluded from e2e-required and every job
-  # carries continue-on-error, because cloud runners give no NAT-behavior
-  # guarantee -- both sides may land in one region and connect trivially, or
-  # SNAT may behave symmetrically and traversal fails through no fault of
-  # ours. Read the verdict in the step summary; it must never block a merge.
-  # See test/e2e/realnet/.
+  # The peer cells carry continue-on-error because cloud runners give no
+  # NAT-behavior guarantee -- both sides may land in one region and connect
+  # trivially, or SNAT may behave symmetrically and traversal fails through
+  # no fault of ours. The report job is the single genuine verdict: it hard-
+  # fails only on what is ours to break (results missing, endpoint round-trip
+  # broken, canary corrupted). It stays out of e2e-required so weather never
+  # blocks a merge, but it does gate the docker publish. See test/e2e/realnet/.
   e2e-realnet-keys:
     name: E2E realnet (keys)
     runs-on: ubuntu-latest
@@ -286,76 +295,102 @@ jobs:
       - build-required
       - build-plugins-required
     outputs:
-      anchor_key: ${{ steps.gen.outputs.anchor_key }}
-      anchor_pub: ${{ steps.gen.outputs.anchor_pub }}
-      subject_key: ${{ steps.gen.outputs.subject_key }}
-      subject_pub: ${{ steps.gen.outputs.subject_pub }}
+      linux_anchor_key: ${{ steps.gen.outputs.linux_anchor_key }}
+      linux_anchor_pub: ${{ steps.gen.outputs.linux_anchor_pub }}
+      linux_subject_key: ${{ steps.gen.outputs.linux_subject_key }}
+      linux_subject_pub: ${{ steps.gen.outputs.linux_subject_pub }}
+      darwin_anchor_key: ${{ steps.gen.outputs.darwin_anchor_key }}
+      darwin_anchor_pub: ${{ steps.gen.outputs.darwin_anchor_pub }}
+      darwin_subject_key: ${{ steps.gen.outputs.darwin_subject_key }}
+      darwin_subject_pub: ${{ steps.gen.outputs.darwin_subject_pub }}
+      freebsd_anchor_key: ${{ steps.gen.outputs.freebsd_anchor_key }}
+      freebsd_anchor_pub: ${{ steps.gen.outputs.freebsd_anchor_pub }}
+      freebsd_subject_key: ${{ steps.gen.outputs.freebsd_subject_key }}
+      freebsd_subject_pub: ${{ steps.gen.outputs.freebsd_subject_pub }}
+      windows_anchor_key: ${{ steps.gen.outputs.windows_anchor_key }}
+      windows_anchor_pub: ${{ steps.gen.outputs.windows_anchor_pub }}
+      windows_subject_key: ${{ steps.gen.outputs.windows_subject_key }}
+      windows_subject_pub: ${{ steps.gen.outputs.windows_subject_pub }}
     steps:
       - name: Install wireguard-tools
         run: sudo apt-get update && sudo apt-get install -y wireguard-tools
       # The keys are ephemeral and worthless once the run ends, so passing
       # them through job outputs is intentional: it removes the cross-job
       # secret exchange entirely. Per-run public keys also namespace the
-      # storage keys, so concurrent runs cannot collide.
+      # storage keys, so neither concurrent runs nor the pairs of one run
+      # can collide.
       - name: Generate keypairs
         id: gen
         run: |
-          for role in anchor subject; do
-            key=$(wg genkey)
-            echo "${role}_key=$key" >> "$GITHUB_OUTPUT"
-            echo "${role}_pub=$(echo "$key" | wg pubkey)" >> "$GITHUB_OUTPUT"
+          for pair in linux darwin freebsd windows; do
+            for role in anchor subject; do
+              key=$(wg genkey)
+              echo "${pair}_${role}_key=$key" >> "$GITHUB_OUTPUT"
+              echo "${pair}_${role}_pub=$(echo "$key" | wg pubkey)" >> "$GITHUB_OUTPUT"
+            done
           done
 
-  # The fixed far end: always Linux, always the same split-tunnel raw-socket
-  # configuration, so a failure is attributable to the subject side (or to
-  # network weather) by construction.
+  # The fixed far end of each pair: always Linux, always the same
+  # split-tunnel raw-socket configuration. The hold and handshake windows
+  # are wider for the pairs whose subject boots slowly (brew, the FreeBSD
+  # VM, the WireGuard installer).
   e2e-realnet-anchor:
-    name: E2E realnet (anchor)
+    name: E2E realnet (anchor/${{ matrix.pair }})
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: e2e-realnet-keys
-    timeout-minutes: 12
-    outputs:
-      results: ${{ steps.peer.outputs.results }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-realnet
-        id: peer
-        with:
-          role: anchor
-          go-version: ${{ env.GO_VERSION }}
-          wg-private-key: ${{ needs.e2e-realnet-keys.outputs.anchor_key }}
-          peer-public-key: ${{ needs.e2e-realnet-keys.outputs.subject_pub }}
-
-  # The side under test. Adding another subject OS means one entry here plus
-  # its per-OS branches in the scripts -- but note that matrix rows share one
-  # output namespace, so the result plumbing must move to artifacts first.
-  e2e-realnet-subject:
-    name: E2E realnet (${{ matrix.subject }})
-    runs-on: ${{ matrix.subject }}
-    continue-on-error: true
-    needs: e2e-realnet-keys
-    timeout-minutes: 12
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        subject: [ubuntu-latest]
-    outputs:
-      results: ${{ steps.peer.outputs.results }}
+        pair: [linux, darwin, freebsd, windows]
+    env:
+      ANCHOR_HOLD_SECS: ${{ matrix.pair == 'linux' && '600' || '900' }}
+      HANDSHAKE_TIMEOUT: ${{ matrix.pair == 'linux' && '300' || '780' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-realnet
-        id: peer
+        with:
+          role: anchor
+          os: linux
+          pair: ${{ matrix.pair }}
+          go-version: ${{ env.GO_VERSION }}
+          wg-private-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_anchor_key', matrix.pair)] }}
+          peer-public-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_subject_pub', matrix.pair)] }}
+
+  # The side under test, one row per supported OS. freebsd runs in a VM on a
+  # Linux host, mirroring the same-host e2e.
+  e2e-realnet-subject:
+    name: E2E realnet (${{ matrix.pair }})
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+    needs: e2e-realnet-keys
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { pair: linux, os: linux, runner: ubuntu-latest, timeout: 12 }
+          - { pair: darwin, os: darwin, runner: macos-26, timeout: 20 }
+          - { pair: freebsd, os: freebsd, runner: ubuntu-latest, timeout: 20 }
+          - { pair: windows, os: windows, runner: windows-latest, timeout: 20 }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-realnet
         with:
           role: subject
+          os: ${{ matrix.os }}
+          pair: ${{ matrix.pair }}
           go-version: ${{ env.GO_VERSION }}
-          wg-private-key: ${{ needs.e2e-realnet-keys.outputs.subject_key }}
-          peer-public-key: ${{ needs.e2e-realnet-keys.outputs.anchor_pub }}
+          wg-private-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_subject_key', matrix.pair)] }}
+          peer-public-key: ${{ needs.e2e-realnet-keys.outputs[format('{0}_anchor_pub', matrix.pair)] }}
 
+  # The single genuine realnet verdict, over every pair's uploaded results.
+  # Matrix rows share one job-output namespace, which is why the conclusions
+  # travel as artifacts rather than outputs.
   e2e-realnet-report:
     name: E2E realnet
     runs-on: ubuntu-latest
-    continue-on-error: true
     needs:
       - e2e-realnet-anchor
       - e2e-realnet-subject
@@ -365,13 +400,14 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: realnet-results-*
+          path: realnet-results
       - name: Combined verdict
         env:
-          ANCHOR_RESULTS: ${{ needs.e2e-realnet-anchor.outputs.results }}
-          SUBJECT_RESULTS: ${{ needs.e2e-realnet-subject.outputs.results }}
-          ANCHOR_JOB: ${{ needs.e2e-realnet-anchor.result }}
-          SUBJECT_JOB: ${{ needs.e2e-realnet-subject.result }}
-        run: sh test/e2e/realnet/report.sh
+          REALNET_PAIRS: linux darwin freebsd windows
+        run: sh test/e2e/realnet/report.sh realnet-results
 
   # One stable check aggregating the e2e matrix and the proxy cell, mirroring
   # the other summary gates. The ruleset requires it, so every cell must pass

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,6 +340,12 @@ jobs:
     continue-on-error: true
     needs: e2e-realnet-keys
     timeout-minutes: 20
+    # actions:read lets the anchor poll its subject job's status and release
+    # the hold early; the hold window then only runs out in full when the
+    # subject never reports.
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
   # are wider for the pairs whose subject boots slowly (brew, the FreeBSD
   # VM, the WireGuard installer).
   e2e-realnet-anchor:
-    name: E2E realnet (anchor/${{ matrix.pair }})
+    name: E2E realnet (linux anchor for ${{ matrix.pair }})
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: e2e-realnet-keys

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -372,6 +372,11 @@ jobs:
     continue-on-error: true
     needs: e2e-realnet-keys
     timeout-minutes: ${{ matrix.timeout }}
+    # actions:read is the mirror of the anchor's: the subject waits for its
+    # anchor job to be running before the handshake window starts ticking.
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/test/e2e/realnet/assert.sh
+++ b/test/e2e/realnet/assert.sh
@@ -24,18 +24,28 @@ discovered=$(jq -rc 'select(.message=="discovered IPv4 endpoint")|.ipv4' "$DAEMO
 discovered_all=$(jq -rc 'select(.message=="discovered IPv4 endpoint")|.ipv4' "$DAEMON_LOG" 2>/dev/null | sort -u | paste -sd, -)
 errors=$(jq -c 'select(.level=="error")' "$DAEMON_LOG" 2>/dev/null | wc -l | tr -d ' ')
 
+# In proxy mode the device's peer endpoint is the proxy's own loopback inner
+# socket and the real remote lives in the proxy's demux mapping, so the
+# endpoint that proves the round-trip is the remote the proxy programmed.
+# Windows has no other mode; elsewhere this line is simply absent.
+proxy_remote=$(jq -rc 'select(.message=="peer endpoint substituted with proxy inner socket")|.remote' "$DAEMON_LOG" 2>/dev/null | tail -1)
+wg_endpoint=$(sed -n 's/^wg_endpoint=//p' "$RESULTS" | head -1)
+
 {
 	echo "discovered=${discovered:-(none)}"
 	echo "discovered_all=${discovered_all:-(none)}"
+	echo "peer_endpoint=${proxy_remote:-${wg_endpoint:-(none)}}"
 	echo "error_count=${errors:-0}"
 } >> "$RESULTS"
 
 role=$(sed -n 's/^role=//p' "$RESULTS" | head -1)
 
 # Values may themselves contain '=', so split on the first one only.
-json=$(jq -Rc -n '[inputs | select(length > 0) | split("=") |
-	{(.[0]): (.[1:] | join("="))}] | add' < "$RESULTS")
-echo "results=$json" >> "$OUT"
+# results.json is what report.sh consumes: matrix rows share a single job
+# output namespace, so the conclusions travel as an artifact instead.
+jq -Rc -n '[inputs | select(length > 0) | split("=") |
+	{(.[0]): (.[1:] | join("="))}] | add' < "$RESULTS" > "$WORK/results.json"
+echo "results=$(cat "$WORK/results.json")" >> "$OUT"
 
 {
 	echo "### realnet peer: ${role:-unknown}"

--- a/test/e2e/realnet/assert.sh
+++ b/test/e2e/realnet/assert.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Turns a realnet peer run into machine-readable conclusions: merges the
+# results.env recorded by phases.sh with facts derived from the daemon log,
+# then emits the whole set as one compact JSON job output (guarded -- falls
+# back to stdout when run outside Actions) plus a human table.
+#
+# Conclusions travel in the output, evidence stays in the logs. The verdict
+# itself is report.sh's job, since it needs both sides; this script never
+# fails the peer job on a soft check.
+#
+# Usage: assert.sh RESULT_DIR
+set -eu
+
+WORK=${1:?usage: assert.sh RESULT_DIR}
+RESULTS=$WORK/results.env
+DAEMON_LOG=$WORK/daemon.log
+OUT=${GITHUB_OUTPUT:-/dev/stdout}
+SUM=${GITHUB_STEP_SUMMARY:-/dev/stdout}
+
+# Derived facts from the daemon log. discovered_all is every endpoint STUN
+# found this run: report.sh checks membership rather than the final value,
+# since the NAT may rebind between the two sides' snapshot moments.
+discovered=$(jq -rc 'select(.message=="discovered IPv4 endpoint")|.ipv4' "$DAEMON_LOG" 2>/dev/null | tail -1)
+discovered_all=$(jq -rc 'select(.message=="discovered IPv4 endpoint")|.ipv4' "$DAEMON_LOG" 2>/dev/null | sort -u | paste -sd, -)
+errors=$(jq -c 'select(.level=="error")' "$DAEMON_LOG" 2>/dev/null | wc -l | tr -d ' ')
+
+{
+	echo "discovered=${discovered:-(none)}"
+	echo "discovered_all=${discovered_all:-(none)}"
+	echo "error_count=${errors:-0}"
+} >> "$RESULTS"
+
+role=$(sed -n 's/^role=//p' "$RESULTS" | head -1)
+
+# Values may themselves contain '=', so split on the first one only.
+json=$(jq -Rc -n '[inputs | select(length > 0) | split("=") |
+	{(.[0]): (.[1:] | join("="))}] | add' < "$RESULTS")
+echo "results=$json" >> "$OUT"
+
+{
+	echo "### realnet peer: ${role:-unknown}"
+	echo ""
+	echo "| check | result |"
+	echo "|---|---|"
+	while IFS='=' read -r k v; do
+		[ -n "$k" ] || continue
+		echo "| $k | $v |"
+	done < "$RESULTS"
+} >> "$SUM"
+
+echo "== recorded conclusions =="
+cat "$RESULTS"
+if [ "${errors:-0}" != 0 ]; then
+	echo "note: daemon logged $errors error line(s), tolerated here -- report.sh owns the verdict:"
+	jq -c 'select(.level=="error")|{message,error}' "$DAEMON_LOG" 2>/dev/null | head -20
+fi

--- a/test/e2e/realnet/canary/main.go
+++ b/test/e2e/realnet/canary/main.go
@@ -1,0 +1,49 @@
+// Command canary serves a fixed random blob over HTTP for the realnet e2e
+// full-tunnel check (test-only). The anchor binds it to an off-overlay dummy
+// address; the subject can only reach that address through the covering
+// WireGuard default route, so a successful fetch proves off-overlay traffic
+// genuinely traverses the tunnel. Random content plus per-request nonce paths
+// defeat any caching; the printed sha256 is compared by the report job.
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "canary:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	listen := flag.String("listen", "192.0.2.1:8080", "address to bind")
+	size := flag.Int("size", 1<<20, "blob size in bytes")
+	flag.Parse()
+
+	blob := make([]byte, *size)
+	if _, err := rand.Read(blob); err != nil {
+		return err
+	}
+	sum := sha256.Sum256(blob)
+
+	ln, err := net.Listen("tcp", *listen)
+	if err != nil {
+		return err
+	}
+	// READY only after the listener is bound, so the harness can wait on it.
+	fmt.Printf("CANARY_SHA256=%s\n", hex.EncodeToString(sum[:]))
+	fmt.Println("CANARY_READY=1")
+
+	return http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(blob)
+	}))
+}

--- a/test/e2e/realnet/device.sh
+++ b/test/e2e/realnet/device.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+# Per-OS plumbing for the realnet e2e: the WireGuard device, the network
+# context commands run in, and the ping spellings that differ everywhere.
+# Sourced by run-peer.sh.
+#
+# Only device creation and a few flag spellings are platform-specific; `wg
+# set` and `wg show` are identical on all of them. The one structural
+# difference is the crash bunker: on Linux everything runs in a namespace
+# NAT'd to the real NIC, which is what makes a covering default route safe to
+# install on a CI runner. No other platform here has an equivalent, so their
+# commands run directly on the host and the full-tunnel scenario is skipped
+# rather than blackholing the runner agent.
+
+detect_os() {
+	OS=$(uname -s)
+	# Git Bash reports MINGW64_NT-<ver>/MSYS_NT-<ver>; fold to one name.
+	case "$OS" in MINGW* | MSYS* | CYGWIN*) OS=Windows ;; esac
+	# Hosted Linux/macOS runners are non-root with passwordless sudo; the
+	# FreeBSD VM runs as root and may lack sudo; the Windows runner shell is
+	# already elevated, which stunmesh requires there.
+	if [ "$OS" = Windows ] || [ "$(id -u)" = 0 ]; then SUDO=''; else SUDO='sudo'; fi
+	export SUDO
+	case "$OS" in Linux) HAS_BUNKER=1 ;; *) HAS_BUNKER=0 ;; esac
+}
+
+# ns_exec CMD... -- run in the network context under test.
+ns_exec() {
+	if [ "$HAS_BUNKER" = 1 ]; then
+		$SUDO ip netns exec "$NS" "$@"
+	elif [ "$OS" = Windows ]; then
+		"$@"
+	else
+		$SUDO "$@"
+	fi
+}
+
+# device_up KEYFILE PEER_PUB MY_OVERLAY -- create the device in its
+# split-tunnel baseline shape and set WG_IF to the resolved name.
+device_up() {
+	_keyfile=$1; _peer=$2; _addr=$3
+
+	case "$OS" in
+	Linux)
+		WG_IF=wg0
+		ns_exec ip link add "$WG_IF" type wireguard
+		;;
+	FreeBSD)
+		WG_IF=$($SUDO ifconfig wg create)
+		;;
+	Darwin)
+		_namefile=$WORK/utun.name
+		_wgg=$(command -v wireguard-go) || { echo "wireguard-go not in PATH" >&2; exit 1; }
+		# Foreground under sudo but backgrounded by the shell, so root keeps
+		# the utun while PATH still resolves the brew binary. It writes the
+		# chosen utunN to namefile once up.
+		$SUDO env WG_TUN_NAME_FILE="$_namefile" WG_PROCESS_FOREGROUND=1 \
+			"$_wgg" utun >"$WORK/wireguard-go.log" 2>&1 &
+		for _ in $(seq 1 60); do [ -s "$_namefile" ] && break; sleep 1; done
+		$SUDO test -s "$_namefile" || {
+			echo "wireguard-go never named a utun; its log:" >&2
+			$SUDO cat "$WORK/wireguard-go.log" >&2 || true
+			exit 1
+		}
+		WG_IF=$($SUDO cat "$_namefile")
+		WGGO_PID=$(pgrep -f "$_wgg utun" || true)
+		;;
+	Windows)
+		# WireGuardNT: the tunnel service owns the adapter and applies the
+		# whole config from the .conf (name = file basename), so key, port,
+		# address and peer are set here rather than via `wg set`. stunmesh's
+		# UDP proxy is the outward socket; the adapter only talks loopback.
+		WG_IF=stunmesh0
+		_conf=$WORK/$WG_IF.conf
+		{
+			echo "[Interface]"
+			echo "PrivateKey = $(cat "$_keyfile")"
+			echo "ListenPort = $WG_PORT"
+			echo "Address = $_addr/24"
+			echo "MTU = $MTU"
+			echo ""
+			echo "[Peer]"
+			echo "PublicKey = $_peer"
+			echo "AllowedIPs = $PEER_OVERLAY/32"
+			echo "PersistentKeepalive = $KEEPALIVE"
+		} > "$_conf"
+		# MSYS_NO_PATHCONV stops Git Bash rewriting /installtunnelservice as
+		# a POSIX path; the conf path is pre-converted with cygpath instead.
+		MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
+			wireguard.exe /installtunnelservice "$(cygpath -w "$_conf")"
+		for _ in $(seq 1 60); do
+			wg show "$WG_IF" >/dev/null 2>&1 && break
+			sleep 1
+		done
+		wg show "$WG_IF" >/dev/null 2>&1 || { echo "tunnel $WG_IF never came up" >&2; exit 1; }
+		return 0
+		;;
+	*) echo "unsupported OS: $OS" >&2; exit 1 ;;
+	esac
+
+	# $WORK belongs to the invoking user, so feeding the key on stdin keeps
+	# it out of the process table and off a root-readable path.
+	# shellcheck disable=SC2024
+	ns_exec wg set "$WG_IF" private-key /dev/stdin \
+		listen-port "$WG_PORT" \
+		peer "$_peer" allowed-ips "$PEER_OVERLAY/32" \
+		persistent-keepalive "$KEEPALIVE" < "$_keyfile"
+
+	case "$OS" in
+	Linux)
+		ns_exec ip addr add "$_addr/24" dev "$WG_IF"
+		ns_exec ip link set "$WG_IF" mtu "$MTU" up
+		;;
+	FreeBSD)
+		ns_exec ifconfig "$WG_IF" inet "$_addr/24" mtu "$MTU" up
+		;;
+	Darwin)
+		# utun is point-to-point, so the peer overlay address is the far end
+		# of the link rather than a subnet member.
+		ns_exec ifconfig "$WG_IF" inet "$_addr" "$PEER_OVERLAY" \
+			netmask 255.255.255.255 mtu "$MTU" up
+		;;
+	esac
+}
+
+device_down() {
+	[ -n "${WG_IF:-}" ] || return 0
+	case "$OS" in
+	Linux) ns_exec ip link del "$WG_IF" 2>/dev/null || true ;;
+	FreeBSD) $SUDO ifconfig "$WG_IF" destroy 2>/dev/null || true ;;
+	Darwin) [ -n "${WGGO_PID:-}" ] && $SUDO kill "$WGGO_PID" 2>/dev/null || true ;;
+	Windows) MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
+		wireguard.exe /uninstalltunnelservice "$WG_IF" 2>/dev/null || true ;;
+	esac
+}
+
+# net_ping IP -- three echo requests. -W is a per-reply timeout in seconds on
+# Linux but milliseconds on the BSDs, so use their -t deadline instead.
+net_ping() {
+	case "$OS" in
+	Linux) ns_exec ping -c 3 -W 2 "$1" ;;
+	Windows) ping -n 3 -w 2000 "$1" ;;
+	*) ns_exec ping -c 3 -t 6 "$1" ;;
+	esac
+}
+
+# net_ping_df SIZE IP -- don't-fragment ping at a payload size chosen to fill
+# the overlay MTU exactly.
+net_ping_df() {
+	case "$OS" in
+	Linux) ns_exec ping -M "do" -c 3 -W 2 -s "$1" "$2" ;;
+	Windows) ping -n 3 -w 2000 -f -l "$1" "$2" ;;
+	*) ns_exec ping -c 3 -t 6 -D -s "$1" "$2" ;;
+	esac
+}

--- a/test/e2e/realnet/netns.sh
+++ b/test/e2e/realnet/netns.sh
@@ -7,8 +7,8 @@
 # while the runner agent in the root namespace can never be blackholed by the
 # covering route. This is a crash bunker, not a synthetic network.
 #
-# Requires: $SUDO resolved by the caller. Provides: NS, VETH_NS, HOST_IP,
-# ns_exec, netns_up, netns_down.
+# Requires: $SUDO and ns_exec from device.sh. Provides: NS, VETH_NS,
+# HOST_IP, netns_up, netns_down.
 
 NS=${NS:-stunmesh}
 VETH_HOST=${VETH_HOST:-veth-sm0}
@@ -16,8 +16,6 @@ VETH_NS=${VETH_NS:-veth-sm1}
 HOST_NET=${HOST_NET:-10.200.0.0/24}
 HOST_IP=${HOST_IP:-10.200.0.1}
 NS_IP=${NS_IP:-10.200.0.2}
-
-ns_exec() { $SUDO ip netns exec "$NS" "$@"; }
 
 netns_up() {
 	$SUDO ip netns add "$NS"
@@ -44,6 +42,12 @@ netns_up() {
 }
 
 netns_down() {
+	# Reap whatever is still parked in the namespace (canary, iperf3): the
+	# namespace object would survive them, but a manual run should not leave
+	# strays behind.
+	for _pid in $($SUDO ip netns pids "$NS" 2>/dev/null); do
+		$SUDO kill "$_pid" 2>/dev/null || true
+	done
 	$SUDO iptables -t nat -D POSTROUTING -s "$HOST_NET" ! -o "$VETH_HOST" -j MASQUERADE 2>/dev/null || true
 	$SUDO iptables -D FORWARD -i "$VETH_HOST" -j ACCEPT 2>/dev/null || true
 	$SUDO iptables -D FORWARD -o "$VETH_HOST" -j ACCEPT 2>/dev/null || true

--- a/test/e2e/realnet/netns.sh
+++ b/test/e2e/realnet/netns.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Crash-bunker netns for the realnet e2e (Linux only). Sourced by run-peer.sh.
+#
+# Everything under test (wg device, stunmesh, covering full-tunnel routes)
+# runs inside a namespace that is MASQUERADEd to the host's real NIC, so the
+# WAN side is the real internet (double NAT: netns->host, host->Azure SNAT)
+# while the runner agent in the root namespace can never be blackholed by the
+# covering route. This is a crash bunker, not a synthetic network.
+#
+# Requires: $SUDO resolved by the caller. Provides: NS, VETH_NS, HOST_IP,
+# ns_exec, netns_up, netns_down.
+
+NS=${NS:-stunmesh}
+VETH_HOST=${VETH_HOST:-veth-sm0}
+VETH_NS=${VETH_NS:-veth-sm1}
+HOST_NET=${HOST_NET:-10.200.0.0/24}
+HOST_IP=${HOST_IP:-10.200.0.1}
+NS_IP=${NS_IP:-10.200.0.2}
+
+ns_exec() { $SUDO ip netns exec "$NS" "$@"; }
+
+netns_up() {
+	$SUDO ip netns add "$NS"
+	# ip netns exec bind-mounts this over /etc/resolv.conf; the host stub
+	# resolver (127.0.0.53) is unreachable from inside the namespace.
+	$SUDO mkdir -p "/etc/netns/$NS"
+	printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' |
+		$SUDO tee "/etc/netns/$NS/resolv.conf" >/dev/null
+
+	$SUDO ip link add "$VETH_HOST" type veth peer name "$VETH_NS"
+	$SUDO ip link set "$VETH_NS" netns "$NS"
+	$SUDO ip addr add "$HOST_IP/24" dev "$VETH_HOST"
+	$SUDO ip link set "$VETH_HOST" up
+	ns_exec ip link set lo up
+	ns_exec ip addr add "$NS_IP/24" dev "$VETH_NS"
+	ns_exec ip link set "$VETH_NS" up
+	ns_exec ip route add default via "$HOST_IP"
+
+	$SUDO sysctl -qw net.ipv4.ip_forward=1
+	$SUDO iptables -t nat -A POSTROUTING -s "$HOST_NET" ! -o "$VETH_HOST" -j MASQUERADE
+	# GitHub runners ship docker, which sets the FORWARD policy to DROP.
+	$SUDO iptables -A FORWARD -i "$VETH_HOST" -j ACCEPT
+	$SUDO iptables -A FORWARD -o "$VETH_HOST" -j ACCEPT
+}
+
+netns_down() {
+	$SUDO iptables -t nat -D POSTROUTING -s "$HOST_NET" ! -o "$VETH_HOST" -j MASQUERADE 2>/dev/null || true
+	$SUDO iptables -D FORWARD -i "$VETH_HOST" -j ACCEPT 2>/dev/null || true
+	$SUDO iptables -D FORWARD -o "$VETH_HOST" -j ACCEPT 2>/dev/null || true
+	$SUDO ip link del "$VETH_HOST" 2>/dev/null || true
+	$SUDO ip netns del "$NS" 2>/dev/null || true
+	$SUDO rm -rf "/etc/netns/$NS" 2>/dev/null || true
+}

--- a/test/e2e/realnet/phases.sh
+++ b/test/e2e/realnet/phases.sh
@@ -32,7 +32,7 @@ wait_handshake() {
 ping_probe() {
 	_pp_i=0
 	while [ $_pp_i -lt 5 ]; do
-		if ns_exec ping -c 3 -W 2 "$2" >/dev/null 2>&1; then
+		if net_ping "$2" >/dev/null 2>&1; then
 			rec "$1" pass
 			return 0
 		fi
@@ -46,7 +46,7 @@ ping_probe() {
 # mtu_ping KEY IP -- full-MTU don't-fragment ping; double NAT plus the extra
 # encapsulation is where MTU bugs surface, and small pings can't see them.
 mtu_ping() {
-	if ns_exec ping -M "do" -c 3 -W 2 -s $((MTU - 28)) "$2" >/dev/null 2>&1; then
+	if net_ping_df $((MTU - 28)) "$2" >/dev/null 2>&1; then
 		rec "$1" pass
 	else
 		rec "$1" fail
@@ -76,17 +76,25 @@ split_tunnel_subject() {
 	mtu_ping split_ping_mtu "$PEER_OVERLAY"
 
 	# Sustained stream sanity, never throughput numbers: bandwidth between two
-	# cloud runners is noise, not a regression signal.
+	# cloud runners is noise, not a regression signal. Purpose is only that a
+	# sustained stream does not stall the tunnel, so where iperf3 is not
+	# available the transfer counters alone carry the check.
 	_rx0=$(transfer_rx)
-	if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 --connect-timeout 5000 >/dev/null 2>&1; then
-		rec split_iperf_up pass
+	if command -v iperf3 >/dev/null 2>&1; then
+		if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 --connect-timeout 5000 >/dev/null 2>&1; then
+			rec split_iperf_up pass
+		else
+			rec split_iperf_up fail
+		fi
+		if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 -R --connect-timeout 5000 >/dev/null 2>&1; then
+			rec split_iperf_down pass
+		else
+			rec split_iperf_down fail
+		fi
 	else
-		rec split_iperf_up fail
-	fi
-	if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 -R --connect-timeout 5000 >/dev/null 2>&1; then
-		rec split_iperf_down pass
-	else
-		rec split_iperf_down fail
+		rec split_iperf_up skipped
+		rec split_iperf_down skipped
+		net_ping "$PEER_OVERLAY" >/dev/null 2>&1 || true
 	fi
 	_rx1=$(transfer_rx)
 	if [ "${_rx1:-0}" -gt "${_rx0:-0}" ] 2>/dev/null; then
@@ -183,7 +191,7 @@ full_tunnel_subject() {
 	_surv=pass
 	[ "${_sc1:-0}" -gt "${_sc0:-0}" ] 2>/dev/null || _surv=fail
 	[ "${_rx1:-0}" -gt "${_rx0:-0}" ] 2>/dev/null || _surv=fail
-	ns_exec ping -c 3 -W 2 "$PEER_OVERLAY" >/dev/null 2>&1 || _surv=fail
+	net_ping "$PEER_OVERLAY" >/dev/null 2>&1 || _surv=fail
 	rec fulltunnel_survival "$_surv"
 
 	# The endpoint must not flap to loopback under the covering route.

--- a/test/e2e/realnet/phases.sh
+++ b/test/e2e/realnet/phases.sh
@@ -14,12 +14,22 @@
 wait_handshake() {
 	_hs_t0=$(date +%s)
 	_hs_deadline=$((_hs_t0 + HANDSHAKE_TIMEOUT))
+	_hs_tick=0
 	while [ "$(date +%s)" -lt "$_hs_deadline" ]; do
 		_hs=$(ns_exec wg show "$WG_IF" latest-handshakes | awk 'NR==1{print $2}')
 		if [ "${_hs:-0}" -gt 0 ] 2>/dev/null; then
 			rec "$1" pass
 			rec "$1_secs" $(($(date +%s) - _hs_t0))
 			return 0
+		fi
+		# The anchor must not sit out its whole window against a subject
+		# that already gave up and left; same probe as the hold loop, at
+		# the same 30s budget (every 6th 5s tick).
+		_hs_tick=$((_hs_tick + 1))
+		if [ $((_hs_tick % 6)) -eq 0 ] && [ -n "${SUBJECT_DONE_CMD:-}" ] &&
+			sh -c "$SUBJECT_DONE_CMD" >/dev/null 2>&1; then
+			log "peer's run already completed; abandoning the handshake wait"
+			break
 		fi
 		sleep 5
 	done

--- a/test/e2e/realnet/phases.sh
+++ b/test/e2e/realnet/phases.sh
@@ -1,0 +1,195 @@
+#!/bin/sh
+# Scenario phases for the realnet e2e. Sourced by run-peer.sh, which provides
+# ns_exec/rec/log, start_daemon/stop_daemon and the WG_*/PEER_* globals.
+#
+#   split       baseline: split tunnel (peer overlay /32), raw-socket mode.
+#               Both roles run it; the anchor stays in it for the whole run.
+#   fulltunnel  subject only: a covering 0.0.0.0/1 + 128.0.0.0/1 default route
+#               over WireGuard, proving the STUN socket still escapes it.
+#
+# Every probe records a conclusion via rec; nothing here exits the job. The
+# report step decides the verdict from the recorded conclusions of both sides.
+
+# wait_handshake KEY -- poll until the peer's latest-handshake is nonzero.
+wait_handshake() {
+	_hs_t0=$(date +%s)
+	_hs_deadline=$((_hs_t0 + HANDSHAKE_TIMEOUT))
+	while [ "$(date +%s)" -lt "$_hs_deadline" ]; do
+		_hs=$(ns_exec wg show "$WG_IF" latest-handshakes | awk 'NR==1{print $2}')
+		if [ "${_hs:-0}" -gt 0 ] 2>/dev/null; then
+			rec "$1" pass
+			rec "$1_secs" $(($(date +%s) - _hs_t0))
+			return 0
+		fi
+		sleep 5
+	done
+	rec "$1" fail
+	rec "$1_secs" "-"
+	return 1
+}
+
+# ping_probe KEY IP -- a few short ping rounds; pass on the first clean one.
+ping_probe() {
+	_pp_i=0
+	while [ $_pp_i -lt 5 ]; do
+		if ns_exec ping -c 3 -W 2 "$2" >/dev/null 2>&1; then
+			rec "$1" pass
+			return 0
+		fi
+		_pp_i=$((_pp_i + 1))
+		sleep 3
+	done
+	rec "$1" fail
+	return 1
+}
+
+# mtu_ping KEY IP -- full-MTU don't-fragment ping; double NAT plus the extra
+# encapsulation is where MTU bugs surface, and small pings can't see them.
+mtu_ping() {
+	if ns_exec ping -M "do" -c 3 -W 2 -s $((MTU - 28)) "$2" >/dev/null 2>&1; then
+		rec "$1" pass
+	else
+		rec "$1" fail
+	fi
+}
+
+# store_count -- successful publishes so far, per the daemon log.
+store_count() {
+	jq -c 'select(.message=="store endpoint")' "$DAEMON_LOG" 2>/dev/null | wc -l | tr -d ' '
+}
+
+transfer_rx() {
+	ns_exec wg show "$WG_IF" transfer | awk 'NR==1{print $2}'
+}
+
+split_tunnel_anchor() {
+	log "split tunnel (anchor): waiting for handshake, then holding as the far end"
+	wait_handshake split_handshake || return 0
+	ping_probe split_ping "$PEER_OVERLAY" || true
+	mtu_ping split_ping_mtu "$PEER_OVERLAY"
+}
+
+split_tunnel_subject() {
+	log "split tunnel (subject): raw-socket mode"
+	wait_handshake split_handshake || return 1
+	ping_probe split_ping "$PEER_OVERLAY" || true
+	mtu_ping split_ping_mtu "$PEER_OVERLAY"
+
+	# Sustained stream sanity, never throughput numbers: bandwidth between two
+	# cloud runners is noise, not a regression signal.
+	_rx0=$(transfer_rx)
+	if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 --connect-timeout 5000 >/dev/null 2>&1; then
+		rec split_iperf_up pass
+	else
+		rec split_iperf_up fail
+	fi
+	if ns_exec iperf3 -c "$PEER_OVERLAY" -t 5 -R --connect-timeout 5000 >/dev/null 2>&1; then
+		rec split_iperf_down pass
+	else
+		rec split_iperf_down fail
+	fi
+	_rx1=$(transfer_rx)
+	if [ "${_rx1:-0}" -gt "${_rx0:-0}" ] 2>/dev/null; then
+		rec split_transfer_rise pass
+	else
+		rec split_transfer_rise fail
+	fi
+
+	# Informational, never gating: NAT mapping timeout vs persistent-keepalive.
+	log "split tunnel (subject): 60s idle, then checking ping resumes"
+	sleep 60
+	ping_probe split_idle_resume "$PEER_OVERLAY" || true
+	return 0
+}
+
+# resolve_v4 HOST -- all IPv4 addresses, resolved from inside the namespace so
+# the exclusion routes match what curl/stunmesh will connect to.
+resolve_v4() {
+	ns_exec getent ahostsv4 "$1" 2>/dev/null | awk '{print $1}' | sort -u
+}
+
+full_tunnel_subject() {
+	rec fulltunnel_ran yes
+	log "full tunnel (subject): installing the covering default route"
+
+	# Resolve everything that must keep working before DNS goes dark under
+	# the covering route.
+	_stun_ip=$(resolve_v4 "$STUN_HOST" | head -1)
+	_excl_ips=""
+	for _h in $DHT_HOSTS; do
+		_excl_ips="$_excl_ips $(resolve_v4 "$_h")"
+	done
+	_excl_ips="$_excl_ips 8.8.8.8 1.1.1.1"
+
+	stop_daemon
+	ns_exec wg set "$WG_IF" fwmark "$FWMARK"
+	ns_exec wg set "$WG_IF" peer "$PEER_PUBLIC_KEY" \
+		allowed-ips 0.0.0.0/1,128.0.0.0/1 persistent-keepalive "$KEEPALIVE"
+	ns_exec ip route add 0.0.0.0/1 dev "$WG_IF"
+	ns_exec ip route add 128.0.0.0/1 dev "$WG_IF"
+	# The escape under test: WireGuard's outer packets carry the device
+	# fwmark and stunmesh mirrors it onto the STUN socket (SO_MARK); this
+	# rule is what acts on the mark, exactly as wg-quick's policy routing
+	# would in production.
+	ns_exec ip route add default via "$HOST_IP" dev "$VETH_NS" table "$ESCAPE_TABLE"
+	ns_exec ip rule add fwmark "$FWMARK" lookup "$ESCAPE_TABLE" pref 100
+	# NOT the escape under test: in a production full tunnel the rendezvous
+	# traffic rides the tunnel through an exit node, but the far end here
+	# never forwards, so the storage backend and DNS get explicit exclusion
+	# routes to keep the refresh loop's storage side alive.
+	for _ip in $_excl_ips; do
+		ns_exec ip route add "$_ip/32" via "$HOST_IP" dev "$VETH_NS" 2>/dev/null || true
+	done
+	start_daemon
+	log "full tunnel (subject): routes installed, daemon restarted"
+
+	# Escape mechanism spot-check, plus the cheap route assert that gives a
+	# better failure message when the canary fetch below fails.
+	if [ -n "$_stun_ip" ] &&
+		ns_exec ip route get "$_stun_ip" mark "$FWMARK" 2>/dev/null | grep -q "$VETH_NS"; then
+		rec fulltunnel_escape_route pass
+	else
+		rec fulltunnel_escape_route fail
+	fi
+	if ns_exec ip route get "$CANARY_IP" 2>/dev/null | grep -q "$WG_IF"; then
+		rec fulltunnel_route_canary pass
+	else
+		rec fulltunnel_route_canary fail
+	fi
+
+	# Canary fetch: the destination is off-overlay, so only the covering
+	# route can carry it, and it terminates on the far end's dummy interface,
+	# so no exit-node forwarding is needed. The report compares the sha256
+	# against what the far end's server printed, which is what makes this
+	# prove the traffic really traversed the tunnel intact rather than that
+	# the route table merely looks right.
+	_nonce="$(date +%s)-$$"
+	if ns_exec curl -4 -sS -m 20 -o "$WORK/canary.blob" "http://$CANARY_IP:$CANARY_PORT/$_nonce" 2>>"$WORK/curl.log"; then
+		rec fulltunnel_canary pass
+		rec fulltunnel_canary_sha256 "$(sha256sum "$WORK/canary.blob" | awk '{print $1}')"
+	else
+		rec fulltunnel_canary fail
+		rec fulltunnel_canary_sha256 "-"
+	fi
+
+	# Escape survival: across two or more refresh cycles under the covering
+	# route the publish side keeps reaching its storage and the tunnel keeps
+	# carrying traffic.
+	_sc0=$(store_count)
+	_rx0=$(transfer_rx)
+	sleep 45
+	_sc1=$(store_count)
+	_rx1=$(transfer_rx)
+	_surv=pass
+	[ "${_sc1:-0}" -gt "${_sc0:-0}" ] 2>/dev/null || _surv=fail
+	[ "${_rx1:-0}" -gt "${_rx0:-0}" ] 2>/dev/null || _surv=fail
+	ns_exec ping -c 3 -W 2 "$PEER_OVERLAY" >/dev/null 2>&1 || _surv=fail
+	rec fulltunnel_survival "$_surv"
+
+	# The endpoint must not flap to loopback under the covering route.
+	if ns_exec wg show "$WG_IF" endpoints | grep -q '127\.0\.0\.1'; then
+		rec fulltunnel_endpoint_flap fail
+	else
+		rec fulltunnel_endpoint_flap pass
+	fi
+}

--- a/test/e2e/realnet/report.sh
+++ b/test/e2e/realnet/report.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Combined verdict for a realnet run, from both sides' conclusions.
+#
+# Verification lives here rather than in either peer by construction: the
+# subject cannot self-certify the canary it fetched, and only a step that
+# sees both sides can check that each side's WireGuard peer endpoint is
+# something the *other* side actually discovered via STUN.
+#
+# Hard checks -- a failure here means our bug, not network weather:
+#   * both peer runs completed
+#   * the publish -> store -> establish round-trip propagated real endpoints
+#     in both directions across two independent public IPs
+#   * a fetched canary blob is byte-identical to the one served
+# Everything else (handshake, ping, throughput, escape survival) is recorded
+# for trend-watching only: two cloud runners give no NAT-behavior guarantee,
+# so a hard assert there would fail for reasons that are not ours. Promote a
+# check once its observed success rate justifies it.
+#
+# Env: ANCHOR_RESULTS / SUBJECT_RESULTS  the JSON emitted by assert.sh
+#      ANCHOR_JOB / SUBJECT_JOB          job results ("success" when fine)
+set -eu
+
+ANCHOR_RESULTS=${ANCHOR_RESULTS:-}
+SUBJECT_RESULTS=${SUBJECT_RESULTS:-}
+ANCHOR_JOB=${ANCHOR_JOB:-unknown}
+SUBJECT_JOB=${SUBJECT_JOB:-unknown}
+SUM=${GITHUB_STEP_SUMMARY:-/dev/stdout}
+fail=0
+
+get() { # BLOB KEY -> value, or "(missing)"
+	[ -n "$1" ] || { echo "(missing)"; return; }
+	printf '%s' "$1" | jq -r --arg k "$2" '.[$k] // "(missing)"' 2>/dev/null || echo "(missing)"
+}
+hard() { # NAME OK DETAIL
+	if [ "$2" = ok ]; then _v="pass"; else _v="FAIL"; fail=1; fi
+	echo "| $1 | **$_v** | $3 |" >> "$SUM"
+	echo "hard: $1 -> $_v ($3)"
+}
+info() { # NAME VALUE
+	echo "| $1 | ${2:-(missing)} | recorded, not gating |" >> "$SUM"
+	echo "info: $1 = ${2:-(missing)}"
+}
+member() { # NEEDLE CSV
+	[ -n "$1" ] && [ "$1" != "(none)" ] && [ "$1" != "(missing)" ] || return 1
+	case ",$2," in *",$1,"*) return 0 ;; *) return 1 ;; esac
+}
+
+{
+	echo "## realnet verdict"
+	echo ""
+	echo "| check | result | detail |"
+	echo "|---|---|---|"
+} >> "$SUM"
+
+ok=ok; [ "$ANCHOR_JOB" = success ] || ok=bad
+hard "anchor run" "$ok" "$ANCHOR_JOB"
+ok=ok; [ "$SUBJECT_JOB" = success ] || ok=bad
+hard "subject run" "$ok" "$SUBJECT_JOB"
+
+a_disc=$(get "$ANCHOR_RESULTS" discovered_all)
+s_disc=$(get "$SUBJECT_RESULTS" discovered_all)
+a_ep=$(get "$ANCHOR_RESULTS" peer_endpoint)
+s_ep=$(get "$SUBJECT_RESULTS" peer_endpoint)
+
+# The round-trip a same-host harness can never prove: two independent public
+# IPs, each side's peer endpoint learned only through the storage backend.
+ok=ok; member "$s_ep" "$a_disc" || ok=bad
+hard "endpoint round-trip (anchor to subject)" "$ok" \
+	"subject peer endpoint '$s_ep' among anchor's discovered {$a_disc}"
+ok=ok; member "$a_ep" "$s_disc" || ok=bad
+hard "endpoint round-trip (subject to anchor)" "$ok" \
+	"anchor peer endpoint '$a_ep' among subject's discovered {$s_disc}"
+
+# Integrity is hard whenever a fetch succeeded: a mismatch is corruption,
+# never weather. A fetch that never completed stays informational.
+canary=$(get "$SUBJECT_RESULTS" fulltunnel_canary)
+if [ "$canary" = pass ]; then
+	served=$(get "$ANCHOR_RESULTS" canary_sha256)
+	fetched=$(get "$SUBJECT_RESULTS" fulltunnel_canary_sha256)
+	ok=ok
+	[ "$fetched" = "$served" ] && [ "$served" != "(missing)" ] || ok=bad
+	hard "canary blob integrity" "$ok" "fetched $fetched vs served $served"
+else
+	info "canary fetch" "$canary"
+fi
+
+info "storage preflight (anchor)" "$(get "$ANCHOR_RESULTS" dht_preflight)"
+info "storage preflight (subject)" "$(get "$SUBJECT_RESULTS" dht_preflight)"
+info "handshake (anchor)" "$(get "$ANCHOR_RESULTS" split_handshake) after $(get "$ANCHOR_RESULTS" split_handshake_secs)s"
+info "handshake (subject)" "$(get "$SUBJECT_RESULTS" split_handshake) after $(get "$SUBJECT_RESULTS" split_handshake_secs)s"
+info "overlay ping (anchor to subject)" "$(get "$ANCHOR_RESULTS" split_ping)"
+info "overlay ping (subject to anchor)" "$(get "$SUBJECT_RESULTS" split_ping)"
+info "full-MTU ping" "$(get "$SUBJECT_RESULTS" split_ping_mtu)"
+info "iperf3 up / down" "$(get "$SUBJECT_RESULTS" split_iperf_up) / $(get "$SUBJECT_RESULTS" split_iperf_down)"
+info "transfer counters rose" "$(get "$SUBJECT_RESULTS" split_transfer_rise)"
+info "ping resumes after 60s idle" "$(get "$SUBJECT_RESULTS" split_idle_resume)"
+info "full-tunnel scenario ran" "$(get "$SUBJECT_RESULTS" fulltunnel_ran)"
+info "STUN route escapes the tunnel" "$(get "$SUBJECT_RESULTS" fulltunnel_escape_route)"
+info "canary routed over WireGuard" "$(get "$SUBJECT_RESULTS" fulltunnel_route_canary)"
+info "escape survives refresh cycles" "$(get "$SUBJECT_RESULTS" fulltunnel_survival)"
+info "no endpoint flap to loopback" "$(get "$SUBJECT_RESULTS" fulltunnel_endpoint_flap)"
+info "daemon error lines (anchor / subject)" \
+	"$(get "$ANCHOR_RESULTS" error_count) / $(get "$SUBJECT_RESULTS" error_count)"
+
+if [ "$fail" = 0 ]; then
+	echo "PASS"
+else
+	echo "realnet hard checks failed"
+fi
+exit "$fail"

--- a/test/e2e/realnet/report.sh
+++ b/test/e2e/realnet/report.sh
@@ -1,44 +1,50 @@
 #!/bin/sh
-# Combined verdict for a realnet run, from both sides' conclusions.
+# Combined verdict for a realnet run, over every subject platform.
 #
-# Verification lives here rather than in either peer by construction: the
-# subject cannot self-certify the canary it fetched, and only a step that
-# sees both sides can check that each side's WireGuard peer endpoint is
-# something the *other* side actually discovered via STUN.
+# Verification lives here rather than in either peer by construction: a
+# subject cannot self-certify the canary blob it fetched, and only something
+# that sees both sides can check that each side's WireGuard peer endpoint is
+# an address the *other* side actually discovered via STUN.
 #
-# Hard checks -- a failure here means our bug, not network weather:
-#   * both peer runs completed
+# Hard checks -- a failure means our bug, not network weather:
+#   * both sides of a pair reported conclusions at all
 #   * the publish -> store -> establish round-trip propagated real endpoints
 #     in both directions across two independent public IPs
 #   * a fetched canary blob is byte-identical to the one served
 # Everything else (handshake, ping, throughput, escape survival) is recorded
-# for trend-watching only: two cloud runners give no NAT-behavior guarantee,
-# so a hard assert there would fail for reasons that are not ours. Promote a
-# check once its observed success rate justifies it.
+# for trend-watching only: cloud runners give no NAT-behavior guarantee, so a
+# hard assert there would fail for reasons that are not ours. Promote a check
+# once its observed success rate justifies it.
 #
-# Env: ANCHOR_RESULTS / SUBJECT_RESULTS  the JSON emitted by assert.sh
-#      ANCHOR_JOB / SUBJECT_JOB          job results ("success" when fine)
+# Usage: report.sh ARTIFACT_DIR
+#   ARTIFACT_DIR holds one directory per uploaded result set, named
+#   realnet-results-<pair>-<role>, each containing results.json.
+# Env: REALNET_PAIRS  pairs that were expected to run; a pair listed here but
+#                     missing from ARTIFACT_DIR is a hard failure, which is
+#                     how a job that died before reporting gets caught.
 set -eu
 
-ANCHOR_RESULTS=${ANCHOR_RESULTS:-}
-SUBJECT_RESULTS=${SUBJECT_RESULTS:-}
-ANCHOR_JOB=${ANCHOR_JOB:-unknown}
-SUBJECT_JOB=${SUBJECT_JOB:-unknown}
+DIR=${1:?usage: report.sh ARTIFACT_DIR}
 SUM=${GITHUB_STEP_SUMMARY:-/dev/stdout}
 fail=0
 
-get() { # BLOB KEY -> value, or "(missing)"
-	[ -n "$1" ] || { echo "(missing)"; return; }
-	printf '%s' "$1" | jq -r --arg k "$2" '.[$k] // "(missing)"' 2>/dev/null || echo "(missing)"
+# Default to whatever arrived, which cannot notice a wholly missing pair --
+# the workflow always passes the matrix explicitly.
+PAIRS=${REALNET_PAIRS:-$(find "$DIR" -mindepth 1 -maxdepth 1 -name 'realnet-results-*-anchor' 2>/dev/null |
+	sed -n 's/.*realnet-results-\(.*\)-anchor$/\1/p' | sort -u | tr '\n' ' ')}
+
+get() { # FILE KEY -> value, or "(missing)"
+	[ -f "$1" ] || { echo "(missing)"; return; }
+	jq -r --arg k "$2" '.[$k] // "(missing)"' "$1" 2>/dev/null || echo "(missing)"
 }
-hard() { # NAME OK DETAIL
-	if [ "$2" = ok ]; then _v="pass"; else _v="FAIL"; fail=1; fi
-	echo "| $1 | **$_v** | $3 |" >> "$SUM"
-	echo "hard: $1 -> $_v ($3)"
+hard() { # PAIR NAME OK DETAIL
+	if [ "$3" = ok ]; then _v="pass"; else _v="FAIL"; fail=1; fi
+	echo "| $1 | $2 | **$_v** | $4 |" >> "$SUM"
+	echo "hard[$1]: $2 -> $_v ($4)"
 }
-info() { # NAME VALUE
-	echo "| $1 | ${2:-(missing)} | recorded, not gating |" >> "$SUM"
-	echo "info: $1 = ${2:-(missing)}"
+info() { # PAIR NAME VALUE
+	echo "| $1 | $2 | ${3:-(missing)} | recorded, not gating |" >> "$SUM"
+	echo "info[$1]: $2 = ${3:-(missing)}"
 }
 member() { # NEEDLE CSV
 	[ -n "$1" ] && [ "$1" != "(none)" ] && [ "$1" != "(missing)" ] || return 1
@@ -48,59 +54,80 @@ member() { # NEEDLE CSV
 {
 	echo "## realnet verdict"
 	echo ""
-	echo "| check | result | detail |"
-	echo "|---|---|---|"
+	echo "| pair | check | result | detail |"
+	echo "|---|---|---|---|"
 } >> "$SUM"
 
-ok=ok; [ "$ANCHOR_JOB" = success ] || ok=bad
-hard "anchor run" "$ok" "$ANCHOR_JOB"
-ok=ok; [ "$SUBJECT_JOB" = success ] || ok=bad
-hard "subject run" "$ok" "$SUBJECT_JOB"
+for pair in $PAIRS; do
+	a=$DIR/realnet-results-$pair-anchor/results.json
+	s=$DIR/realnet-results-$pair-subject/results.json
 
-a_disc=$(get "$ANCHOR_RESULTS" discovered_all)
-s_disc=$(get "$SUBJECT_RESULTS" discovered_all)
-a_ep=$(get "$ANCHOR_RESULTS" peer_endpoint)
-s_ep=$(get "$SUBJECT_RESULTS" peer_endpoint)
+	ok=ok; [ -f "$a" ] || ok=bad
+	hard "$pair" "anchor reported" "$ok" "${a#"$DIR"/}"
+	ok=ok; [ -f "$s" ] || ok=bad
+	hard "$pair" "subject reported" "$ok" "${s#"$DIR"/}"
+	if [ ! -f "$a" ] || [ ! -f "$s" ]; then
+		continue
+	fi
 
-# The round-trip a same-host harness can never prove: two independent public
-# IPs, each side's peer endpoint learned only through the storage backend.
-ok=ok; member "$s_ep" "$a_disc" || ok=bad
-hard "endpoint round-trip (anchor to subject)" "$ok" \
-	"subject peer endpoint '$s_ep' among anchor's discovered {$a_disc}"
-ok=ok; member "$a_ep" "$s_disc" || ok=bad
-hard "endpoint round-trip (subject to anchor)" "$ok" \
-	"anchor peer endpoint '$a_ep' among subject's discovered {$s_disc}"
+	a_disc=$(get "$a" discovered_all); s_disc=$(get "$s" discovered_all)
+	a_ep=$(get "$a" peer_endpoint); s_ep=$(get "$s" peer_endpoint)
 
-# Integrity is hard whenever a fetch succeeded: a mismatch is corruption,
-# never weather. A fetch that never completed stays informational.
-canary=$(get "$SUBJECT_RESULTS" fulltunnel_canary)
-if [ "$canary" = pass ]; then
-	served=$(get "$ANCHOR_RESULTS" canary_sha256)
-	fetched=$(get "$SUBJECT_RESULTS" fulltunnel_canary_sha256)
-	ok=ok
-	[ "$fetched" = "$served" ] && [ "$served" != "(missing)" ] || ok=bad
-	hard "canary blob integrity" "$ok" "fetched $fetched vs served $served"
-else
-	info "canary fetch" "$canary"
+	# The round-trip a same-host harness can never prove: two independent
+	# public IPs, each side learning the other's endpoint only through the
+	# storage backend.
+	ok=ok; member "$s_ep" "$a_disc" || ok=bad
+	hard "$pair" "endpoint round-trip (anchor to subject)" "$ok" \
+		"subject peer endpoint '$s_ep' among anchor's discovered {$a_disc}"
+	ok=ok; member "$a_ep" "$s_disc" || ok=bad
+	hard "$pair" "endpoint round-trip (subject to anchor)" "$ok" \
+		"anchor peer endpoint '$a_ep' among subject's discovered {$s_disc}"
+
+	# Integrity is hard whenever a fetch succeeded: a mismatch is corruption,
+	# never weather. A fetch that never completed stays informational.
+	canary=$(get "$s" fulltunnel_canary)
+	if [ "$canary" = pass ]; then
+		served=$(get "$a" canary_sha256); fetched=$(get "$s" fulltunnel_canary_sha256)
+		ok=ok
+		[ "$fetched" = "$served" ] && [ "$served" != "(missing)" ] || ok=bad
+		hard "$pair" "canary blob integrity" "$ok" "fetched $fetched vs served $served"
+	fi
+
+	info "$pair" "subject platform" "$(get "$s" os)"
+	info "$pair" "storage preflight (anchor / subject)" \
+		"$(get "$a" dht_preflight) / $(get "$s" dht_preflight)"
+	info "$pair" "handshake (anchor)" \
+		"$(get "$a" split_handshake) after $(get "$a" split_handshake_secs)s"
+	info "$pair" "handshake (subject)" \
+		"$(get "$s" split_handshake) after $(get "$s" split_handshake_secs)s"
+	info "$pair" "overlay ping (anchor / subject)" \
+		"$(get "$a" split_ping) / $(get "$s" split_ping)"
+	info "$pair" "full-MTU ping" "$(get "$s" split_ping_mtu)"
+	info "$pair" "iperf3 up / down" \
+		"$(get "$s" split_iperf_up) / $(get "$s" split_iperf_down)"
+	info "$pair" "transfer counters rose" "$(get "$s" split_transfer_rise)"
+	info "$pair" "ping resumes after 60s idle" "$(get "$s" split_idle_resume)"
+
+	# The full-tunnel scenario needs the Linux crash bunker; elsewhere the
+	# skip reason is recorded so an absent result is never read as a pass.
+	if [ "$(get "$s" fulltunnel_ran)" = yes ]; then
+		info "$pair" "canary fetch" "$canary"
+		info "$pair" "STUN route escapes the tunnel" "$(get "$s" fulltunnel_escape_route)"
+		info "$pair" "canary routed over WireGuard" "$(get "$s" fulltunnel_route_canary)"
+		info "$pair" "escape survives refresh cycles" "$(get "$s" fulltunnel_survival)"
+		info "$pair" "no endpoint flap to loopback" "$(get "$s" fulltunnel_endpoint_flap)"
+	else
+		info "$pair" "full-tunnel scenario" "skipped: $(get "$s" fulltunnel_skipped)"
+	fi
+	info "$pair" "daemon error lines (anchor / subject)" \
+		"$(get "$a" error_count) / $(get "$s" error_count)"
+done
+
+if [ -z "$PAIRS" ]; then
+	echo "| (none) | pairs reported | **FAIL** | no results found in $DIR |" >> "$SUM"
+	echo "no realnet results found in $DIR"
+	fail=1
 fi
-
-info "storage preflight (anchor)" "$(get "$ANCHOR_RESULTS" dht_preflight)"
-info "storage preflight (subject)" "$(get "$SUBJECT_RESULTS" dht_preflight)"
-info "handshake (anchor)" "$(get "$ANCHOR_RESULTS" split_handshake) after $(get "$ANCHOR_RESULTS" split_handshake_secs)s"
-info "handshake (subject)" "$(get "$SUBJECT_RESULTS" split_handshake) after $(get "$SUBJECT_RESULTS" split_handshake_secs)s"
-info "overlay ping (anchor to subject)" "$(get "$ANCHOR_RESULTS" split_ping)"
-info "overlay ping (subject to anchor)" "$(get "$SUBJECT_RESULTS" split_ping)"
-info "full-MTU ping" "$(get "$SUBJECT_RESULTS" split_ping_mtu)"
-info "iperf3 up / down" "$(get "$SUBJECT_RESULTS" split_iperf_up) / $(get "$SUBJECT_RESULTS" split_iperf_down)"
-info "transfer counters rose" "$(get "$SUBJECT_RESULTS" split_transfer_rise)"
-info "ping resumes after 60s idle" "$(get "$SUBJECT_RESULTS" split_idle_resume)"
-info "full-tunnel scenario ran" "$(get "$SUBJECT_RESULTS" fulltunnel_ran)"
-info "STUN route escapes the tunnel" "$(get "$SUBJECT_RESULTS" fulltunnel_escape_route)"
-info "canary routed over WireGuard" "$(get "$SUBJECT_RESULTS" fulltunnel_route_canary)"
-info "escape survives refresh cycles" "$(get "$SUBJECT_RESULTS" fulltunnel_survival)"
-info "no endpoint flap to loopback" "$(get "$SUBJECT_RESULTS" fulltunnel_endpoint_flap)"
-info "daemon error lines (anchor / subject)" \
-	"$(get "$ANCHOR_RESULTS" error_count) / $(get "$SUBJECT_RESULTS" error_count)"
 
 if [ "$fail" = 0 ]; then
 	echo "PASS"

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -222,7 +222,10 @@ anchor)
 			released=early
 			break
 		fi
-		sleep 30
+		# 15s halves the average release lag vs 30s while staying far from
+		# the shared 1000/h GITHUB_TOKEN budget; anything shorter drowns in
+		# the job's own teardown time.
+		sleep 15
 		left=$((ANCHOR_HOLD_SECS - ($(date +%s) - START_TS)))
 	done
 	rec hold_released "$released"

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -1,0 +1,228 @@
+#!/bin/sh
+# One side of the two-VM real-network e2e (Linux only). Runs stunmesh as a
+# daemon inside a crash-bunker netns (netns.sh) NAT'd to the host's real NIC,
+# and drives this role's scenario phases (phases.sh):
+#
+#   anchor   the boring far end: split tunnel, raw mode, unchanged for the
+#            whole run, plus the canary HTTP server and an iperf3 server;
+#            holds until ANCHOR_HOLD_SECS so the subject can finish.
+#   subject  split tunnel first, then the full-tunnel escape scenario.
+#
+# There is no cross-job rendezvous: endpoint exchange is stunmesh's own data
+# plane (the opendht proxies), and the daemon's refresh loop is the barrier.
+# Every check records a conclusion into $WORK/results.env; assert.sh turns
+# those plus the daemon log into a JSON job output. This script fails only on
+# infra/script errors -- the verdict belongs to report.sh, which sees both
+# sides' conclusions.
+#
+# Usage: run-peer.sh /path/to/stunmesh
+# Env:
+#   ROLE               anchor | subject (required)
+#   WG_PRIVATE_KEY     this side's private key (required)
+#   PEER_PUBLIC_KEY    other side's public key (required)
+#   RESULT_DIR         logs/results directory (default: mktemp -d, kept)
+#   ENDPOINTS          opendht proxy URLs (default: dhtproxy2/3.jami.net)
+#   CANARY_BIN         prebuilt canary server (anchor; default: go build)
+#   ANCHOR_HOLD_SECS   anchor lifetime from script start (default 480)
+#   HANDSHAKE_TIMEOUT  seconds to wait for the first handshake (default 300)
+set -eu
+umask 077
+
+BIN=${1:?usage: run-peer.sh /path/to/stunmesh}
+ROLE=${ROLE:?ROLE=anchor|subject is required}
+WG_PRIVATE_KEY=${WG_PRIVATE_KEY:?}
+PEER_PUBLIC_KEY=${PEER_PUBLIC_KEY:?}
+
+[ "$(uname -s)" = Linux ] || { echo "realnet e2e supports Linux subjects only for now" >&2; exit 1; }
+if [ "$(id -u)" = 0 ]; then SUDO=''; else SUDO='sudo'; fi
+export SUDO
+
+HERE=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+WORK=${RESULT_DIR:-$(mktemp -d)}
+mkdir -p "$WORK/pcap"
+RESULTS=$WORK/results.env
+DAEMON_LOG=$WORK/daemon.log
+: > "$RESULTS"
+START_TS=$(date +%s)
+
+ENDPOINTS=${ENDPOINTS:-'https://dhtproxy2.jami.net https://dhtproxy3.jami.net'}
+# Several of these are consumed only by the sourced phases.sh.
+# shellcheck disable=SC2034
+DHT_HOSTS=$(for u in $ENDPOINTS; do h=${u#*://}; echo "${h%%/*}"; done)
+STUN_HOST=stun.l.google.com
+STUN_PORT=19302
+
+WG_IF=wg0
+WG_PORT=51820
+MTU=1280
+KEEPALIVE=25
+# shellcheck disable=SC2034
+FWMARK=51820
+# shellcheck disable=SC2034
+ESCAPE_TABLE=100
+CANARY_IP=192.0.2.1
+CANARY_PORT=8080
+ANCHOR_HOLD_SECS=${ANCHOR_HOLD_SECS:-480}
+HANDSHAKE_TIMEOUT=${HANDSHAKE_TIMEOUT:-300}
+
+case "$ROLE" in
+anchor) MY_OVERLAY=10.99.0.1 PEER_OVERLAY=10.99.0.2 ;;
+subject) MY_OVERLAY=10.99.0.2 PEER_OVERLAY=10.99.0.1 ;;
+*) echo "unknown ROLE '$ROLE'" >&2; exit 1 ;;
+esac
+
+log() { echo "[realnet:$ROLE] $*"; }
+rec() { echo "$1=$2" >> "$RESULTS"; log "result: $1=$2"; }
+
+. "$HERE/netns.sh"
+. "$HERE/phases.sh"
+
+DPID=''
+TCPDUMP_PID=''
+cleanup() {
+	stop_daemon 2>/dev/null || true
+	[ -n "$TCPDUMP_PID" ] && $SUDO kill "$TCPDUMP_PID" 2>/dev/null || true
+	sleep 1
+	netns_down
+	# tcpdump and the daemon wrote as root; hand the evidence back to the
+	# invoking user so artifact upload can read it.
+	$SUDO chown -R "$(id -u):$(id -g)" "$WORK" 2>/dev/null || true
+	log "logs kept in $WORK"
+}
+trap cleanup EXIT INT TERM
+
+start_daemon() {
+	# $WORK belongs to the invoking user; redirecting the root process's
+	# output into it is intended.
+	# shellcheck disable=SC2024
+	$SUDO ip netns exec "$NS" "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	DPID=$!
+}
+stop_daemon() {
+	[ -n "$DPID" ] || return 0
+	$SUDO kill "$DPID" 2>/dev/null || true
+	wait "$DPID" 2>/dev/null || true
+	DPID=''
+}
+
+log "work=$WORK"
+rec role "$ROLE"
+
+netns_up
+log "netns '$NS' up, MASQUERADE via $VETH_HOST"
+
+# WireGuard device inside the bunker, in the split-tunnel baseline shape that
+# both roles start from (the anchor never leaves it). Explicit MTU so
+# the full-MTU ping asserts a known number, explicit keepalive so the NAT
+# mapping lifetime is a pinned variable rather than an accident.
+KEYFILE=$WORK/wg.key
+printf '%s\n' "$WG_PRIVATE_KEY" > "$KEYFILE"
+ns_exec ip link add "$WG_IF" type wireguard
+# shellcheck disable=SC2024
+$SUDO ip netns exec "$NS" wg set "$WG_IF" private-key /dev/stdin \
+	listen-port "$WG_PORT" \
+	peer "$PEER_PUBLIC_KEY" allowed-ips "$PEER_OVERLAY/32" \
+	persistent-keepalive "$KEEPALIVE" < "$KEYFILE"
+ns_exec ip addr add "$MY_OVERLAY/24" dev "$WG_IF"
+ns_exec ip link set "$WG_IF" mtu "$MTU" up
+log "$WG_IF up: $MY_OVERLAY, peer allowed-ips $PEER_OVERLAY/32"
+
+# Debug level so the escape evidence ("marking STUN socket ...") is in the log.
+{
+	echo "log: {level: debug, format: json}"
+	echo "refresh_interval: 10s"
+	echo "stun: {addresses: [\"$STUN_HOST:$STUN_PORT\"]}"
+	echo "plugins:"
+	echo "  dht:"
+	echo "    type: builtin"
+	echo "    name: opendht"
+	echo "    endpoints:"
+	for url in $ENDPOINTS; do echo "      - $url"; done
+	echo "interfaces:"
+	echo "  $WG_IF:"
+	echo "    protocol: ipv4"
+	echo "    peers:"
+	echo "      peer:"
+	echo "        public_key: \"$PEER_PUBLIC_KEY\""
+	echo "        plugin: dht"
+	echo "        protocol: ipv4"
+} > "$WORK/config.yaml"
+
+# DHT preflight, so the report can classify failures as DHT weather vs NAT
+# weather vs our bug. Any HTTP response counts as reachable.
+preflight=''
+for url in $ENDPOINTS; do
+	h=${url#*://}; h=${h%%/*}
+	if ns_exec curl -4 -sS -o /dev/null -m 10 "$url" 2>>"$WORK/curl.log"; then
+		preflight="$preflight$h=ok,"
+	else
+		preflight="$preflight$h=fail,"
+	fi
+done
+rec dht_preflight "${preflight%,}"
+
+# Size-bounded evidence: headers only (payload is encrypted anyway), 2x50MB
+# ring as the hard cap for the iperf window.
+# shellcheck disable=SC2024
+$SUDO ip netns exec "$NS" tcpdump -i any -s 160 -U -C 50 -W 2 -Z root \
+	-w "$WORK/pcap/realnet.pcap" >"$WORK/tcpdump.log" 2>&1 &
+TCPDUMP_PID=$!
+
+if [ "$ROLE" = anchor ]; then
+	# Off-overlay canary: static from job start, reachable only once the
+	# subject's covering route exists. Replies source from $CANARY_IP, which
+	# only the subject's covering AllowedIPs admit.
+	if [ -z "${CANARY_BIN:-}" ]; then
+		CANARY_BIN=$WORK/canary
+		go build -o "$CANARY_BIN" "$HERE/canary"
+	fi
+	ns_exec ip link add canary0 type dummy
+	ns_exec ip addr add "$CANARY_IP/32" dev canary0
+	ns_exec ip link set canary0 up
+	# shellcheck disable=SC2024
+	$SUDO ip netns exec "$NS" "$CANARY_BIN" -listen "$CANARY_IP:$CANARY_PORT" \
+		>"$WORK/canary.log" 2>&1 &
+	for _ in $(seq 1 20); do
+		grep -q CANARY_READY "$WORK/canary.log" 2>/dev/null && break
+		sleep 1
+	done
+	grep -q CANARY_READY "$WORK/canary.log" || { echo "canary never came up" >&2; exit 1; }
+	rec canary_sha256 "$(sed -n 's/^CANARY_SHA256=//p' "$WORK/canary.log" | head -1)"
+
+	ns_exec iperf3 -s -D --logfile "$WORK/iperf3.log"
+fi
+
+log "starting stunmesh daemon"
+start_daemon
+
+case "$ROLE" in
+anchor)
+	split_tunnel_anchor || true
+	left=$((ANCHOR_HOLD_SECS - ($(date +%s) - START_TS)))
+	if [ "$left" -gt 0 ]; then
+		log "holding as far end for another ${left}s"
+		sleep "$left"
+	fi
+	;;
+subject)
+	# The full-tunnel checks are relative to the split-tunnel baseline: they
+	# run only if it handshook, so NAT weather can never masquerade as a
+	# routing or escape regression.
+	if split_tunnel_subject; then
+		full_tunnel_subject || true
+	else
+		log "no baseline handshake; skipping the full-tunnel scenario"
+		rec fulltunnel_ran no
+	fi
+	;;
+esac
+
+# Final state snapshots while the namespace still exists; peer_endpoint is the
+# report job's half of the publish->store->establish cross-equality.
+ns_exec wg show "$WG_IF" > "$WORK/wg-final.log" 2>&1 || true
+ns_exec wg show "$WG_IF" dump >> "$WORK/wg-final.log" 2>&1 || true
+pe=$(ns_exec wg show "$WG_IF" endpoints | awk 'NR==1{print $2}')
+rec peer_endpoint "${pe:-"(none)"}"
+
+stop_daemon
+sh "$HERE/assert.sh" "$WORK"

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -185,13 +185,16 @@ done
 rec dht_preflight "${preflight%,}"
 
 # Size-bounded evidence: headers only (the payload is encrypted and useless
-# anyway), 2x50MB ring as a hard cap for the throughput window. Linux only:
-# the '-i any' pseudo-interface exists nowhere else, and the capture is
-# post-mortem evidence, never part of any assert.
+# anyway), and the decrypted inner iperf stream is excluded -- its verdict
+# lives in the iperf log and transfer counters, and letting it flood the
+# ring would rotate away the split-phase handshake/STUN packets, the only
+# part of the capture with diagnostic value. 2x10MB ring as the hard cap.
+# Linux only: the '-i any' pseudo-interface exists nowhere else, and the
+# capture is post-mortem evidence, never part of any assert.
 if [ "$OS" = Linux ]; then
 	# shellcheck disable=SC2024
-	ns_exec tcpdump -i any -s 160 -U -C 50 -W 2 -Z root \
-		-w "$WORK/pcap/realnet.pcap" >"$WORK/tcpdump.log" 2>&1 &
+	ns_exec tcpdump -i any -s 160 -U -C 10 -W 2 -Z root \
+		-w "$WORK/pcap/realnet.pcap" 'not tcp port 5201' >"$WORK/tcpdump.log" 2>&1 &
 	TCPDUMP_PID=$!
 fi
 

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -222,10 +222,10 @@ anchor)
 			released=early
 			break
 		fi
-		# 15s halves the average release lag vs 30s while staying far from
-		# the shared 1000/h GITHUB_TOKEN budget; anything shorter drowns in
-		# the job's own teardown time.
-		sleep 15
+		# 30s keeps the whole realnet layer far inside the shared 1000/h
+		# GITHUB_TOKEN budget even with concurrent runs; a faster poll would
+		# only save seconds that the job's own teardown time dwarfs anyway.
+		sleep 30
 		left=$((ANCHOR_HOLD_SECS - ($(date +%s) - START_TS)))
 	done
 	rec hold_released "$released"

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -209,11 +209,23 @@ start_daemon
 case "$ROLE" in
 anchor)
 	split_tunnel_anchor || true
+	# Hold as the far end until the subject's run is over. SUBJECT_DONE_CMD
+	# (CI: subject-done.sh) turns the fixed window into a cap: the anchor
+	# releases as soon as the subject completes, and only a dead subject or
+	# a manual run sleeps the window out.
 	left=$((ANCHOR_HOLD_SECS - ($(date +%s) - START_TS)))
-	if [ "$left" -gt 0 ]; then
-		log "holding as far end for another ${left}s"
-		sleep "$left"
-	fi
+	log "holding as far end for up to ${left}s"
+	released=full
+	while [ "$left" -gt 0 ]; do
+		if [ -n "${SUBJECT_DONE_CMD:-}" ] && sh -c "$SUBJECT_DONE_CMD" >/dev/null 2>&1; then
+			log "subject run completed; releasing the hold early"
+			released=early
+			break
+		fi
+		sleep 30
+		left=$((ANCHOR_HOLD_SECS - ($(date +%s) - START_TS)))
+	done
+	rec hold_released "$released"
 	;;
 subject)
 	# The full-tunnel checks are relative to the split-tunnel baseline: they

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
-# One side of the two-VM real-network e2e (Linux only). Runs stunmesh as a
-# daemon inside a crash-bunker netns (netns.sh) NAT'd to the host's real NIC,
-# and drives this role's scenario phases (phases.sh):
+# One side of the two-VM real-network e2e.
 #
-#   anchor   the boring far end: split tunnel, raw mode, unchanged for the
-#            whole run, plus the canary HTTP server and an iperf3 server;
-#            holds until ANCHOR_HOLD_SECS so the subject can finish.
-#   subject  split tunnel first, then the full-tunnel escape scenario.
+#   anchor   the fixed far end, always Linux and always the same split-tunnel
+#            raw-socket shape, plus the canary and iperf3 servers; holds until
+#            ANCHOR_HOLD_SECS so a slow subject still finds it there.
+#   subject  the side under test: the split-tunnel baseline on every platform,
+#            then the full-tunnel escape scenario where a crash bunker makes
+#            that safe (Linux only -- see device.sh).
 #
 # There is no cross-job rendezvous: endpoint exchange is stunmesh's own data
-# plane (the opendht proxies), and the daemon's refresh loop is the barrier.
+# plane (the storage plugin), and the daemon's refresh loop is the barrier.
 # Every check records a conclusion into $WORK/results.env; assert.sh turns
-# those plus the daemon log into a JSON job output. This script fails only on
+# those plus the daemon log into results.json. This script fails only on
 # infra/script errors -- the verdict belongs to report.sh, which sees both
-# sides' conclusions.
+# sides.
 #
 # Usage: run-peer.sh /path/to/stunmesh
 # Env:
@@ -23,7 +23,7 @@
 #   RESULT_DIR         logs/results directory (default: mktemp -d, kept)
 #   ENDPOINTS          opendht proxy URLs (default: dhtproxy2/3.jami.net)
 #   CANARY_BIN         prebuilt canary server (anchor; default: go build)
-#   ANCHOR_HOLD_SECS   anchor lifetime from script start (default 480)
+#   ANCHOR_HOLD_SECS   anchor lifetime from script start (default 600)
 #   HANDSHAKE_TIMEOUT  seconds to wait for the first handshake (default 300)
 set -eu
 umask 077
@@ -32,10 +32,6 @@ BIN=${1:?usage: run-peer.sh /path/to/stunmesh}
 ROLE=${ROLE:?ROLE=anchor|subject is required}
 WG_PRIVATE_KEY=${WG_PRIVATE_KEY:?}
 PEER_PUBLIC_KEY=${PEER_PUBLIC_KEY:?}
-
-[ "$(uname -s)" = Linux ] || { echo "realnet e2e supports Linux subjects only for now" >&2; exit 1; }
-if [ "$(id -u)" = 0 ]; then SUDO=''; else SUDO='sudo'; fi
-export SUDO
 
 HERE=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 WORK=${RESULT_DIR:-$(mktemp -d)}
@@ -46,15 +42,18 @@ DAEMON_LOG=$WORK/daemon.log
 START_TS=$(date +%s)
 
 ENDPOINTS=${ENDPOINTS:-'https://dhtproxy2.jami.net https://dhtproxy3.jami.net'}
-# Several of these are consumed only by the sourced phases.sh.
+# Consumed by the sourced phases.sh.
 # shellcheck disable=SC2034
 DHT_HOSTS=$(for u in $ENDPOINTS; do h=${u#*://}; echo "${h%%/*}"; done)
 STUN_HOST=stun.l.google.com
 STUN_PORT=19302
 
-WG_IF=wg0
+# Consumed by the sourced device.sh and phases.sh.
+# shellcheck disable=SC2034
 WG_PORT=51820
+# shellcheck disable=SC2034
 MTU=1280
+# shellcheck disable=SC2034
 KEEPALIVE=25
 # shellcheck disable=SC2034
 FWMARK=51820
@@ -62,7 +61,7 @@ FWMARK=51820
 ESCAPE_TABLE=100
 CANARY_IP=192.0.2.1
 CANARY_PORT=8080
-ANCHOR_HOLD_SECS=${ANCHOR_HOLD_SECS:-480}
+ANCHOR_HOLD_SECS=${ANCHOR_HOLD_SECS:-600}
 HANDSHAKE_TIMEOUT=${HANDSHAKE_TIMEOUT:-300}
 
 case "$ROLE" in
@@ -74,8 +73,17 @@ esac
 log() { echo "[realnet:$ROLE] $*"; }
 rec() { echo "$1=$2" >> "$RESULTS"; log "result: $1=$2"; }
 
+. "$HERE/device.sh"
 . "$HERE/netns.sh"
 . "$HERE/phases.sh"
+
+detect_os
+# The anchor is deliberately the same boring Linux far end for every subject,
+# so a failure is attributable to the subject side by construction.
+if [ "$ROLE" = anchor ] && [ "$OS" != Linux ]; then
+	echo "the anchor role is Linux-only by design, got $OS" >&2
+	exit 1
+fi
 
 DPID=''
 TCPDUMP_PID=''
@@ -83,10 +91,11 @@ cleanup() {
 	stop_daemon 2>/dev/null || true
 	[ -n "$TCPDUMP_PID" ] && $SUDO kill "$TCPDUMP_PID" 2>/dev/null || true
 	sleep 1
-	netns_down
+	device_down
+	[ "$HAS_BUNKER" = 1 ] && netns_down
 	# tcpdump and the daemon wrote as root; hand the evidence back to the
 	# invoking user so artifact upload can read it.
-	$SUDO chown -R "$(id -u):$(id -g)" "$WORK" 2>/dev/null || true
+	[ -n "$SUDO" ] && $SUDO chown -R "$(id -u):$(id -g)" "$WORK" 2>/dev/null || true
 	log "logs kept in $WORK"
 }
 trap cleanup EXIT INT TERM
@@ -95,39 +104,38 @@ start_daemon() {
 	# $WORK belongs to the invoking user; redirecting the root process's
 	# output into it is intended.
 	# shellcheck disable=SC2024
-	$SUDO ip netns exec "$NS" "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	ns_exec "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
 	DPID=$!
 }
 stop_daemon() {
 	[ -n "$DPID" ] || return 0
-	$SUDO kill "$DPID" 2>/dev/null || true
+	# ns_exec may wrap the daemon in sudo/ip-netns; both relay the signal to
+	# the child, so killing the shell's own child suffices everywhere.
+	kill "$DPID" 2>/dev/null || $SUDO kill "$DPID" 2>/dev/null || true
 	wait "$DPID" 2>/dev/null || true
 	DPID=''
 }
 
-log "work=$WORK"
+log "OS=$OS work=$WORK"
 rec role "$ROLE"
+rec os "$OS"
 
-netns_up
-log "netns '$NS' up, MASQUERADE via $VETH_HOST"
+if [ "$HAS_BUNKER" = 1 ]; then
+	netns_up
+	log "netns '$NS' up, MASQUERADE via $VETH_HOST"
+else
+	log "no crash bunker on $OS; running on the host, full-tunnel scenario will be skipped"
+fi
 
-# WireGuard device inside the bunker, in the split-tunnel baseline shape that
-# both roles start from (the anchor never leaves it). Explicit MTU so
-# the full-MTU ping asserts a known number, explicit keepalive so the NAT
-# mapping lifetime is a pinned variable rather than an accident.
+# Explicit MTU so the full-MTU ping asserts a known number, explicit keepalive
+# so the NAT mapping lifetime is a pinned variable rather than an accident.
 KEYFILE=$WORK/wg.key
 printf '%s\n' "$WG_PRIVATE_KEY" > "$KEYFILE"
-ns_exec ip link add "$WG_IF" type wireguard
-# shellcheck disable=SC2024
-$SUDO ip netns exec "$NS" wg set "$WG_IF" private-key /dev/stdin \
-	listen-port "$WG_PORT" \
-	peer "$PEER_PUBLIC_KEY" allowed-ips "$PEER_OVERLAY/32" \
-	persistent-keepalive "$KEEPALIVE" < "$KEYFILE"
-ns_exec ip addr add "$MY_OVERLAY/24" dev "$WG_IF"
-ns_exec ip link set "$WG_IF" mtu "$MTU" up
+device_up "$KEYFILE" "$PEER_PUBLIC_KEY" "$MY_OVERLAY"
 log "$WG_IF up: $MY_OVERLAY, peer allowed-ips $PEER_OVERLAY/32"
 
-# Debug level so the escape evidence ("marking STUN socket ...") is in the log.
+# Debug level so the escape evidence ("marking STUN socket ...") and, in
+# proxy mode, the endpoint substitution line are both in the log.
 {
 	echo "log: {level: debug, format: json}"
 	echo "refresh_interval: 10s"
@@ -148,8 +156,8 @@ log "$WG_IF up: $MY_OVERLAY, peer allowed-ips $PEER_OVERLAY/32"
 	echo "        protocol: ipv4"
 } > "$WORK/config.yaml"
 
-# DHT preflight, so the report can classify failures as DHT weather vs NAT
-# weather vs our bug. Any HTTP response counts as reachable.
+# Storage preflight, so the report can tell a backend outage from network
+# weather from our bug. Any HTTP response counts as reachable.
 preflight=''
 for url in $ENDPOINTS; do
 	h=${url#*://}; h=${h%%/*}
@@ -161,17 +169,21 @@ for url in $ENDPOINTS; do
 done
 rec dht_preflight "${preflight%,}"
 
-# Size-bounded evidence: headers only (payload is encrypted anyway), 2x50MB
-# ring as the hard cap for the iperf window.
-# shellcheck disable=SC2024
-$SUDO ip netns exec "$NS" tcpdump -i any -s 160 -U -C 50 -W 2 -Z root \
-	-w "$WORK/pcap/realnet.pcap" >"$WORK/tcpdump.log" 2>&1 &
-TCPDUMP_PID=$!
+# Size-bounded evidence: headers only (the payload is encrypted and useless
+# anyway), 2x50MB ring as a hard cap for the throughput window. Linux only:
+# the '-i any' pseudo-interface exists nowhere else, and the capture is
+# post-mortem evidence, never part of any assert.
+if [ "$OS" = Linux ]; then
+	# shellcheck disable=SC2024
+	ns_exec tcpdump -i any -s 160 -U -C 50 -W 2 -Z root \
+		-w "$WORK/pcap/realnet.pcap" >"$WORK/tcpdump.log" 2>&1 &
+	TCPDUMP_PID=$!
+fi
 
 if [ "$ROLE" = anchor ]; then
-	# Off-overlay canary: static from job start, reachable only once the
-	# subject's covering route exists. Replies source from $CANARY_IP, which
-	# only the subject's covering AllowedIPs admit.
+	# Off-overlay canary: static from job start, reachable only once a
+	# subject installs a covering route. Replies source from $CANARY_IP,
+	# which only that subject's covering AllowedIPs admit.
 	if [ -z "${CANARY_BIN:-}" ]; then
 		CANARY_BIN=$WORK/canary
 		go build -o "$CANARY_BIN" "$HERE/canary"
@@ -180,8 +192,7 @@ if [ "$ROLE" = anchor ]; then
 	ns_exec ip addr add "$CANARY_IP/32" dev canary0
 	ns_exec ip link set canary0 up
 	# shellcheck disable=SC2024
-	$SUDO ip netns exec "$NS" "$CANARY_BIN" -listen "$CANARY_IP:$CANARY_PORT" \
-		>"$WORK/canary.log" 2>&1 &
+	ns_exec "$CANARY_BIN" -listen "$CANARY_IP:$CANARY_PORT" >"$WORK/canary.log" 2>&1 &
 	for _ in $(seq 1 20); do
 		grep -q CANARY_READY "$WORK/canary.log" 2>/dev/null && break
 		sleep 1
@@ -206,23 +217,30 @@ anchor)
 	;;
 subject)
 	# The full-tunnel checks are relative to the split-tunnel baseline: they
-	# run only if it handshook, so NAT weather can never masquerade as a
+	# run only if it handshook, so network weather can never masquerade as a
 	# routing or escape regression.
-	if split_tunnel_subject; then
-		full_tunnel_subject || true
-	else
+	if ! split_tunnel_subject; then
 		log "no baseline handshake; skipping the full-tunnel scenario"
 		rec fulltunnel_ran no
+		rec fulltunnel_skipped "no baseline handshake"
+	elif [ "$HAS_BUNKER" != 1 ]; then
+		# Installing a covering default route with no bunker to contain it
+		# would blackhole the runner agent itself.
+		log "no crash bunker on $OS; skipping the full-tunnel scenario"
+		rec fulltunnel_ran no
+		rec fulltunnel_skipped "no crash bunker on $OS"
+	else
+		full_tunnel_subject || true
 	fi
 	;;
 esac
 
-# Final state snapshots while the namespace still exists; peer_endpoint is the
-# report job's half of the publish->store->establish cross-equality.
+# Final snapshot while the device still exists. assert.sh turns this into the
+# peer_endpoint the report checks, accounting for proxy mode.
 ns_exec wg show "$WG_IF" > "$WORK/wg-final.log" 2>&1 || true
 ns_exec wg show "$WG_IF" dump >> "$WORK/wg-final.log" 2>&1 || true
-pe=$(ns_exec wg show "$WG_IF" endpoints | awk 'NR==1{print $2}')
-rec peer_endpoint "${pe:-"(none)"}"
+wgep=$(ns_exec wg show "$WG_IF" endpoints | awk 'NR==1{print $2}')
+rec wg_endpoint "${wgep:-(none)}"
 
 stop_daemon
 sh "$HERE/assert.sh" "$WORK"

--- a/test/e2e/realnet/run-peer.sh
+++ b/test/e2e/realnet/run-peer.sh
@@ -101,18 +101,33 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 start_daemon() {
+	# Backgrounded as a simple command on purpose: backgrounding the ns_exec
+	# *function* would fork a subshell that does not forward SIGTERM, so
+	# stop_daemon would kill the subshell and orphan the daemon -- exactly
+	# the double-daemon bug this replaces. As a simple command the shell's
+	# child is sudo (or the binary itself), and sudo does relay signals.
 	# $WORK belongs to the invoking user; redirecting the root process's
 	# output into it is intended.
 	# shellcheck disable=SC2024
-	ns_exec "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	if [ "$HAS_BUNKER" = 1 ]; then
+		$SUDO ip netns exec "$NS" "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	elif [ "$OS" = Windows ]; then
+		"$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	else
+		# shellcheck disable=SC2024
+		$SUDO "$BIN" -c "$WORK/config.yaml" >> "$DAEMON_LOG" 2>&1 &
+	fi
 	DPID=$!
 }
 stop_daemon() {
 	[ -n "$DPID" ] || return 0
-	# ns_exec may wrap the daemon in sudo/ip-netns; both relay the signal to
-	# the child, so killing the shell's own child suffices everywhere.
 	kill "$DPID" 2>/dev/null || $SUDO kill "$DPID" 2>/dev/null || true
 	wait "$DPID" 2>/dev/null || true
+	# Belt and suspenders against any orphaned daemon: the config path is
+	# unique to this run, so the pattern cannot match anything else.
+	if command -v pkill >/dev/null 2>&1; then
+		$SUDO pkill -f "$WORK/config.yaml" 2>/dev/null || true
+	fi
 	DPID=''
 }
 

--- a/test/e2e/realnet/subject-done.sh
+++ b/test/e2e/realnet/subject-done.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Exit 0 once this pair's subject job has completed, so the anchor can
+# release its hold early instead of sleeping out the full window. CI-only:
+# outside Actions (no run id, no gh, no token) it exits nonzero, which the
+# caller treats as "keep holding" -- the fixed hold window is the fallback,
+# so a failure here can only ever cost time, never correctness.
+#
+# Usage: subject-done.sh PAIR
+set -eu
+
+pair=${1:?usage: subject-done.sh PAIR}
+[ -n "${GITHUB_RUN_ID:-}" ] || exit 1
+[ -n "${GITHUB_REPOSITORY:-}" ] || exit 1
+command -v gh >/dev/null 2>&1 || exit 1
+
+status=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+	--jq ".jobs[] | select(.name==\"E2E realnet ($pair)\") | .status" 2>/dev/null | head -1)
+[ "$status" = completed ]

--- a/test/e2e/realnet/wait-anchor.sh
+++ b/test/e2e/realnet/wait-anchor.sh
@@ -25,6 +25,6 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 		;;
 	esac
 	echo "anchor for '$pair' is '${status:-unknown}'; waiting"
-	sleep 15
+	sleep 30
 done
 echo "anchor for '$pair' never started within ${ANCHOR_WAIT_SECS:-600}s; proceeding anyway"

--- a/test/e2e/realnet/wait-anchor.sh
+++ b/test/e2e/realnet/wait-anchor.sh
@@ -17,7 +17,7 @@ command -v gh >/dev/null 2>&1 || exit 0
 deadline=$(($(date +%s) + ${ANCHOR_WAIT_SECS:-600}))
 while [ "$(date +%s)" -lt "$deadline" ]; do
 	status=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
-		--jq ".jobs[] | select(.name==\"E2E realnet (linux anchor for $pair)\") | .status" 2>/dev/null | head -1)
+		--jq ".jobs[] | select(.name==\"E2E realnet (anchor for $pair)\") | .status" 2>/dev/null | head -1)
 	case "$status" in
 	in_progress | completed)
 		echo "anchor for '$pair' is $status; proceeding"

--- a/test/e2e/realnet/wait-anchor.sh
+++ b/test/e2e/realnet/wait-anchor.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Wait until this pair's anchor job is at least running, so the subject's
+# fixed handshake window never starts ticking against an anchor that is
+# still queued. The mirror of subject-done.sh, and like it advisory-only:
+# outside Actions, without gh, or on timeout it just returns -- the daemon's
+# refresh loop retries anyway, so the worst case is what we have today.
+#
+# Usage: wait-anchor.sh PAIR
+# Env:   ANCHOR_WAIT_SECS  how long to wait before giving up (default 600)
+set -eu
+
+pair=${1:?usage: wait-anchor.sh PAIR}
+[ -n "${GITHUB_RUN_ID:-}" ] || exit 0
+[ -n "${GITHUB_REPOSITORY:-}" ] || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+
+deadline=$(($(date +%s) + ${ANCHOR_WAIT_SECS:-600}))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+	status=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+		--jq ".jobs[] | select(.name==\"E2E realnet (linux anchor for $pair)\") | .status" 2>/dev/null | head -1)
+	case "$status" in
+	in_progress | completed)
+		echo "anchor for '$pair' is $status; proceeding"
+		exit 0
+		;;
+	esac
+	echo "anchor for '$pair' is '${status:-unknown}'; waiting"
+	sleep 15
+done
+echo "anchor for '$pair' never started within ${ANCHOR_WAIT_SECS:-600}s; proceeding anyway"


### PR DESCRIPTION
## Summary

Adds a third e2e layer: two CI runners behind real cloud NAT punch a hole with stunmesh and hold a tunnel, then the subject proves STUN still escapes a covering WireGuard default route. Nothing today covers this — the same-host e2e shares one public IP, and the netns proxy harness has no real NAT.

Packaged as a composite action (`.github/actions/e2e-realnet/`) and wired into the existing CI workflow, so it runs **beside** `e2e` / `e2e-proxy` on the same gates rather than in a separate workflow.

## Layout

- `.github/actions/e2e-realnet/action.yml` — runs one side (`role: anchor|subject`): installs tools, builds from source, runs the peer script, groups the logs inline, uploads evidence, and returns the recorded conclusions as one JSON output.
- `test/e2e/realnet/`
  - `run-peer.sh` — role-agnostic peer driver. Everything under test runs inside a namespace MASQUERADEd to the runner's real NIC, so the covering route can never blackhole the runner agent while the WAN side stays the real internet.
  - `netns.sh` — namespace setup/teardown (veth, MASQUERADE, namespace-scoped `resolv.conf`, and the `FORWARD` policy docker leaves behind).
  - `phases.sh` — the split-tunnel baseline (handshake, bidirectional and full-MTU ping, short iperf3 each way, idle-resume) and the full-tunnel scenario (covering route, device fwmark + `ip rule` escape, canary fetch, escape survival across refresh cycles, loopback-flap check).
  - `canary/` — small HTTP server the anchor binds to an off-overlay dummy address; a fetch that matches its sha256 proves off-overlay traffic really traversed the tunnel intact, not just that the route table looks right.
  - `assert.sh` / `report.sh` — conclusions to JSON, then the combined verdict.
- `.github/workflows/main.yml` — four jobs (`keys → anchor + subject → report`) on the same `needs` as the existing e2e jobs.

## Design points

- **Advisory, never blocking.** Excluded from `e2e-required`, and every job carries `continue-on-error`. Cloud runners give no NAT-behavior guarantee: both sides may land in one region and connect trivially, or SNAT may behave symmetrically and traversal fails through no fault of ours. The verdict is in the step summary.
- **Hard checks are only what is ours to break**: the endpoint round-trip across two independent public IPs (each side's peer endpoint must be one the *other* side actually discovered — membership, not final equality, since the NAT may rebind between snapshots) and canary blob integrity. Handshake, throughput and escape survival are recorded for trend-watching.
- **Verification is a separate step by construction**: the subject cannot self-certify the canary it fetched, and only a step seeing both sides can check the round-trip. Storage-backend preflight is recorded so a failure can be classified as backend outage vs network weather vs our bug.
- **No rendezvous service**: endpoint exchange is stunmesh's own data plane, per-run keys namespace the storage keys, and the refresh loop is the barrier. Ephemeral keys travel via job outputs deliberately, removing the cross-job secret exchange.
- The full-tunnel scenario runs only if the baseline handshook, so network weather cannot masquerade as an escape regression.
- The storage backend and DNS get explicit exclusion routes under the covering route: in production that traffic rides the tunnel through an exit node, but the far end here never forwards. The escape under test is unaffected — STUN's `SO_MARK` mirror plus the fwmark rule acting on it.

## Validation

`sh -n`, shellcheck, actionlint, gofmt, `go vet`, golangci-lint and a full `-tags builtin_all` build all pass. The report logic was exercised against fixtures for the happy path, canary corruption, an endpoint that never propagated, and both sides missing entirely (no crash, exit 1). The harness itself first runs for real on this PR.

## Follow-ups (not in this PR)

- Proxy-mode phases and their negative control, once the proxy runtime is available on Linux.
- Windows and macOS subject rows. Note that matrix rows share one output namespace, so the result plumbing must move to artifacts before a second row lands — flagged in the workflow comment.