### PR TITLE
feat(mobile): accept non-string plugin config values

### DIFF
--- a/mobile/config.go
+++ b/mobile/config.go
@@ -44,10 +44,13 @@ type peerConfig struct {
 }
 
 type pluginDef struct {
-	Instance string            `json:"instance"`
-	Type     string            `json:"type"`
-	Name     string            `json:"name"`
-	Config   map[string]string `json:"config"`
+	Instance string `json:"instance"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	// Values are free-form like the desktop YAML config: a plugin key may
+	// hold a string, a list (opendht's "endpoints"), or a number. The
+	// plugins' own config helpers deal with the types.
+	Config map[string]any `json:"config"`
 }
 
 type stunConfig struct {


### PR DESCRIPTION
Plugin config values in the mobile JSON config were typed `map[string]string`, so a list-valued key — opendht's `endpoints`, for one — failed to unmarshal, even though the built-in plugins' config helpers (`GetStringSlice`, `GetDuration`) already handle strings, lists and numbers. This types them `map[string]any`, matching what the desktop YAML/mapstructure path hands plugins.

No behavior change for existing string-valued configs. `make mobile-test` passes; desktop builds are untouched (the file is behind the `mobile` tag).

https://claude.ai/code/session_01Az46g1MbA4stEGLkgT9ipJ