### PR TITLE
fix: protect plugin DNS resolution from tunnel escape

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,8 @@ duplication. All three were resolved before this document was written —
 desktop and mobile now share `ctrl.DiscoverEndpoints` (`internal/ctrl/discover.go`)
 and `ctrl.SelectEndpoint` (`internal/ctrl/endpoint_select.go`); mobile
 plugin HTTP traffic is protected from full-tunnel routing (commit
-`baf40a8`, corrected in `38b9a7f`); and the Linux/Darwin-BSD STUN client
+`baf40a8`, corrected in `38b9a7f`; the DNS resolution half of that same
+escape was closed later, in `ebb467e`); and the Linux/Darwin-BSD STUN client
 duplication was collapsed into `internal/stun/helper_socket.go` (commit
 `ed4ae03`). Nothing is presently tracked as known, unresolved duplication;
 this section is left in place as a marker for where such a register would

--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -91,13 +91,29 @@ func Transport() *http.Transport {
 
 // DialContext dials with the escape the platform provides.
 func DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	d := &net.Dialer{
+	return newDialer().DialContext(ctx, network, address)
+}
+
+// newDialer builds the Dialer DialContext uses. Its Resolver.Dial points back
+// at DialContext so hostname lookups reuse the same protected socket path as
+// the eventual TCP connect, instead of falling through to net.DefaultResolver
+// -- on android that resolves via Bionic getaddrinfo/netd, which cannot be
+// protected, so a DNS query would fail outright whenever the covering tunnel
+// it must escape is down. PreferGo forces the Go resolver so Dial is actually
+// consulted (the cgo resolver ignores it). Dial only opens a connection to
+// the resolver's already-known address, so this does not recurse into
+// hostname resolution.
+func newDialer() *net.Dialer {
+	return &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 		// ControlContext, not Control: the escape rides in the context.
 		ControlContext: control,
+		Resolver: &net.Resolver{
+			PreferGo: true,
+			Dial:     DialContext,
+		},
 	}
-	return d.DialContext(ctx, network, address)
 }
 
 // boundInterface resolves the physical default-route interface for platforms

--- a/internal/plugin/dialer/dialer_test.go
+++ b/internal/plugin/dialer/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/tjjh89017/stunmesh-go/internal/routeprobe"
@@ -109,5 +110,28 @@ func TestTransportDialsWithRequestContext(t *testing.T) {
 
 	if got := <-dialed; got.FirewallMark != 0x2a {
 		t.Errorf("dial saw mark %#x, want 0x2a", got.FirewallMark)
+	}
+}
+
+// DNS lookups must not fall through to net.DefaultResolver: on android that
+// resolves via Bionic getaddrinfo/netd, which cannot be protected, so a DNS
+// query would fail outright whenever the covering tunnel it should escape is
+// down. Routing the resolver's own dial through DialContext puts DNS on the
+// same protected path as the TCP connect. http.Transport has no Resolver
+// field of its own -- the wiring belongs on the net.Dialer DialContext uses.
+func TestDialerResolverDialsThroughProtectedPath(t *testing.T) {
+	d := newDialer()
+
+	if d.Resolver == nil {
+		t.Fatal("newDialer().Resolver is nil, want a resolver wired to the protected dial path")
+	}
+	if !d.Resolver.PreferGo {
+		t.Error("newDialer().Resolver.PreferGo = false, want true so DNS queries use the Go resolver's Dial hook instead of the platform resolver")
+	}
+
+	got := reflect.ValueOf(d.Resolver.Dial).Pointer()
+	want := reflect.ValueOf(DialContext).Pointer()
+	if got != want {
+		t.Error("newDialer().Resolver.Dial is not DialContext, want DNS lookups to share the protected dial path with TCP connects")
 	}
 }


### PR DESCRIPTION
## Summary
- DNS resolution performed by the mobile plugin escape transport was not protected: it fell through to `net.DefaultResolver`, which on Android goes through Bionic getaddrinfo/netd and cannot be protected. DNS lookups could therefore route into a dead full-tunnel VPN and fail before any protected dial ever happened.
- Fixed by adding `Resolver: &net.Resolver{PreferGo: true, Dial: DialContext}` to the `net.Dialer` built in `internal/plugin/dialer/dialer.go`'s `newDialer()`, reusing the existing protected dial path. No new plumbing was needed since `DialContext`'s signature already matches `net.Resolver.Dial`.
- Updated `docs/architecture.md` to note that DNS resolution is now covered by the plugin escape protection.

Closes #252

## Test plan
- [x] Unit test covering DNS resolution protection in `internal/plugin/dialer/dialer_test.go`
- [x] `go test ./...`