### PR TITLE
ci: wire contrib smoke tests into CI and Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,24 @@ jobs:
       - name: All plugin build cells passed
         run: '[ "${{ needs.build-plugins.result }}" = "success" ]'
 
+  # Shell-protocol smoke tests for the contrib plugins (cloudflare-shell,
+  # opendht, opendht-shell) plus `go test` for the separate cloudflare Go
+  # module. Not a matrix, so this job's own name is already a stable check --
+  # no paired -required gate needed. It exercises contrib/ scripts, not the
+  # core build, so it isn't in e2e's needs.
+  contrib-test:
+    name: Contrib Smoke Tests
+    runs-on: ubuntu-latest
+    needs:
+      - lint-required
+      - test-required
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make contrib-test
+
   android-aar:
     name: Build Android AAR
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ go test ./internal/repo -v       # Run repository tests
 The contrib plugins have script-level smoke tests
 (`contrib/*/smoke_test.sh`, run manually from the repo root; the
 `contrib/cloudflare` Go module also has `go test`) exercising the real
-exec/shell protocols against fake backends. They are not yet wired into
-`make` or CI.
+exec/shell protocols against fake backends. Run them via `make contrib-test`
+from the repo root, or use the `contrib-test` job in CI.
 
 ### Linting
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -217,3 +217,10 @@ plugin-uninstall:
 
 .PHONY: contrib-uninstall
 contrib-uninstall: plugin-uninstall
+
+.PHONY: plugin-test
+plugin-test:
+	$(MAKE) -C contrib test
+
+.PHONY: contrib-test
+contrib-test: plugin-test

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -40,6 +40,13 @@ uninstall:
 		$(MAKE) -C $$plugin uninstall PREFIX=$(PREFIX) BINDIR=$(BINDIR) || exit 1; \
 	done
 
+.PHONY: test
+test:
+	@for plugin in $(PLUGINS); do \
+		echo "Testing $$plugin..."; \
+		$(MAKE) -C $$plugin test || exit 1; \
+	done
+
 .PHONY: list
 list:
 	@echo "Available plugins:"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -56,6 +56,16 @@ Stores peer endpoint information in the OpenDHT distributed hash table via an Op
 
 See [opendht/README.md](opendht/README.md) for setup instructions and limitations.
 
+## Testing
+
+Each plugin may include a `smoke_test.sh` script (e.g., `cloudflare-shell/`,
+`opendht/`, `opendht-shell/`) that exercises its exec/shell protocol against a
+fake/mock backend. Run smoke tests individually, e.g.
+`contrib/opendht/smoke_test.sh` (from the repo root), or run all smoke tests
+plus any `go test` targets with `make contrib-test`, also from the repo root.
+The `make contrib-test` target runs automatically in CI on every PR/push via
+the `contrib-test` job.
+
 ## Creating Your Own Plugin
 
 Stunmesh supports two plugin protocols: **exec** (JSON-based) and **shell** (shell variable-based).

--- a/contrib/cloudflare-shell/Makefile
+++ b/contrib/cloudflare-shell/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/cloudflare/Makefile
+++ b/contrib/cloudflare/Makefile
@@ -14,6 +14,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	go test ./...
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/opendht-shell/Makefile
+++ b/contrib/opendht-shell/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/opendht/Makefile
+++ b/contrib/opendht/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)


### PR DESCRIPTION
## Summary
- Add `plugin-test`/`contrib-test` Makefile targets (root `Makefile` -> `contrib/Makefile` -> per-plugin Makefiles) that run each plugin's `smoke_test.sh` or `go test`, mirroring the existing `build`/`clean`/`install`/`uninstall` pattern
- Wire a new `contrib-test` CI job into `.github/workflows/main.yml`, gated on `lint-required`/`test-required`
- Document the smoke tests and `make contrib-test` in `contrib/README.md` and `CLAUDE.md`

Closes #253

## Test plan
- [x] `make contrib-test` passes locally (3 shell smoke tests + `go test` in `contrib/cloudflare`)
- [x] `go build ./...` / `go vet ./...` clean
- [x] YAML validated (`actionlint` clean)
- [ ] CI green on this PR