### PR TITLE
test: remove stale DNS escape workaround from realnet full-tunnel e2e

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,24 @@ jobs:
       - name: All plugin build cells passed
         run: '[ "${{ needs.build-plugins.result }}" = "success" ]'
 
+  # Shell-protocol smoke tests for the contrib plugins (cloudflare-shell,
+  # opendht, opendht-shell) plus `go test` for the separate cloudflare Go
+  # module. Not a matrix, so this job's own name is already a stable check --
+  # no paired -required gate needed. It exercises contrib/ scripts, not the
+  # core build, so it isn't in e2e's needs.
+  contrib-test:
+    name: Contrib Smoke Tests
+    runs-on: ubuntu-latest
+    needs:
+      - lint-required
+      - test-required
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make contrib-test
+
   android-aar:
     name: Build Android AAR
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ go test ./internal/repo -v       # Run repository tests
 The contrib plugins have script-level smoke tests
 (`contrib/*/smoke_test.sh`, run manually from the repo root; the
 `contrib/cloudflare` Go module also has `go test`) exercising the real
-exec/shell protocols against fake backends. They are not yet wired into
-`make` or CI.
+exec/shell protocols against fake backends. Run them via `make contrib-test`
+from the repo root, or use the `contrib-test` job in CI.
 
 ### Linting
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -217,3 +217,10 @@ plugin-uninstall:
 
 .PHONY: contrib-uninstall
 contrib-uninstall: plugin-uninstall
+
+.PHONY: plugin-test
+plugin-test:
+	$(MAKE) -C contrib test
+
+.PHONY: contrib-test
+contrib-test: plugin-test

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -40,6 +40,13 @@ uninstall:
 		$(MAKE) -C $$plugin uninstall PREFIX=$(PREFIX) BINDIR=$(BINDIR) || exit 1; \
 	done
 
+.PHONY: test
+test:
+	@for plugin in $(PLUGINS); do \
+		echo "Testing $$plugin..."; \
+		$(MAKE) -C $$plugin test || exit 1; \
+	done
+
 .PHONY: list
 list:
 	@echo "Available plugins:"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -56,6 +56,16 @@ Stores peer endpoint information in the OpenDHT distributed hash table via an Op
 
 See [opendht/README.md](opendht/README.md) for setup instructions and limitations.
 
+## Testing
+
+Each plugin may include a `smoke_test.sh` script (e.g., `cloudflare-shell/`,
+`opendht/`, `opendht-shell/`) that exercises its exec/shell protocol against a
+fake/mock backend. Run smoke tests individually, e.g.
+`contrib/opendht/smoke_test.sh` (from the repo root), or run all smoke tests
+plus any `go test` targets with `make contrib-test`, also from the repo root.
+The `make contrib-test` target runs automatically in CI on every PR/push via
+the `contrib-test` job.
+
 ## Creating Your Own Plugin
 
 Stunmesh supports two plugin protocols: **exec** (JSON-based) and **shell** (shell variable-based).

--- a/contrib/cloudflare-shell/Makefile
+++ b/contrib/cloudflare-shell/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/cloudflare-shell/smoke_test.sh
+++ b/contrib/cloudflare-shell/smoke_test.sh
@@ -10,8 +10,8 @@
 # a real plugin binary. The real cloudflare-shell.sh runs unmodified; only
 # the `curl` it shells out to is swapped.
 #
-# Requires: bash (script uses [[ ]] arrays are not used, but declares
-# `#!/bin/bash`), grep, sed.
+# Requires: bash (the script uses [[ ]] conditionals and declares
+# `#!/bin/bash`, even though it doesn't use arrays), grep, sed.
 set -eu
 
 HERE=$(CDPATH='' cd "$(dirname "$0")" && pwd)

--- a/contrib/cloudflare/Makefile
+++ b/contrib/cloudflare/Makefile
@@ -14,6 +14,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	go test ./...
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/opendht-shell/Makefile
+++ b/contrib/opendht-shell/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/contrib/opendht/Makefile
+++ b/contrib/opendht/Makefile
@@ -16,6 +16,10 @@ build:
 clean:
 	rm -f $(PLUGIN)
 
+.PHONY: test
+test:
+	./smoke_test.sh
+
 .PHONY: install
 install: build
 	install -d $(BINDIR)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -289,7 +288,7 @@ func validateConfigForGOOS(cfg *Config, goos string) error {
 	for ifaceName, iface := range cfg.Interfaces {
 		// 0 means unset (ephemeral); reject anything outside the port range.
 		if iface.Proxy.Listen < 0 || iface.Proxy.Listen > 65535 {
-			return fmt.Errorf("invalid proxy listen port %s for interface '%s', must be between 0 and 65535", strconv.Itoa(iface.Proxy.Listen), ifaceName)
+			return fmt.Errorf("invalid proxy listen port %d for interface '%s', must be between 0 and 65535", iface.Proxy.Listen, ifaceName)
 		}
 
 		// 0 means unset (escape off); the true kernel limit is net.fibs-1,
@@ -297,7 +296,7 @@ func validateConfigForGOOS(cfg *Config, goos string) error {
 		// check -- a fib the running kernel rejects surfaces as a setsockopt
 		// error at runtime instead.
 		if iface.Proxy.Fib < 0 || iface.Proxy.Fib > 65535 {
-			return fmt.Errorf("invalid proxy fib %s for interface '%s', must be between 0 and 65535", strconv.Itoa(iface.Proxy.Fib), ifaceName)
+			return fmt.Errorf("invalid proxy fib %d for interface '%s', must be between 0 and 65535", iface.Proxy.Fib, ifaceName)
 		}
 
 		// Windows has no non-proxy mode; an explicit opt-out can't be honored.

--- a/internal/ctrl/discover_test.go
+++ b/internal/ctrl/discover_test.go
@@ -14,6 +14,20 @@ func resolverReturning(endpoint string, err error) ctrl.FamilyResolver {
 	}
 }
 
+// mustNotBeCalledResolver fails the test immediately if invoked, used for
+// the family that a given protocol mode must never resolve (e.g. ipv6 when
+// protocol is "ipv4"). A plain error-returning resolver wouldn't do here:
+// DiscoverEndpoints ignores the untargeted family's error in single-family
+// modes, so a wrongly-invoked resolver's sentinel error would be silently
+// swallowed instead of failing the test.
+func mustNotBeCalledResolver(t *testing.T) ctrl.FamilyResolver {
+	t.Helper()
+	return func(ctx context.Context) (string, error) {
+		t.Fatal("resolver must not be called")
+		return "", nil
+	}
+}
+
 // TestDiscoverEndpoints_SharedPolicy exercises the single DiscoverEndpoints
 // policy used by both PublishController.discoverEndpoints (desktop,
 // raw-socket STUN) and the mobile controller's discover
@@ -40,20 +54,20 @@ func TestDiscoverEndpoints_SharedPolicy(t *testing.T) {
 			name:     "ipv4 succeeds",
 			protocol: "ipv4",
 			ipv4:     resolverReturning("1.2.3.4:51820", nil),
-			ipv6:     resolverReturning("", errors.New("must not be called")),
+			ipv6:     nil, // must not be called
 			wantIPv4: "1.2.3.4:51820",
 		},
 		{
 			name:     "ipv4 hard-fails on its own error",
 			protocol: "ipv4",
 			ipv4:     resolverReturning("", ipv4Err),
-			ipv6:     resolverReturning("", errors.New("must not be called")),
+			ipv6:     nil, // must not be called
 			wantErr:  ipv4Err,
 		},
 		{
 			name:     "ipv6 hard-fails on its own error",
 			protocol: "ipv6",
-			ipv4:     resolverReturning("", errors.New("must not be called")),
+			ipv4:     nil, // must not be called
 			ipv6:     resolverReturning("", ipv6Err),
 			wantErr:  ipv6Err,
 		},
@@ -92,8 +106,8 @@ func TestDiscoverEndpoints_SharedPolicy(t *testing.T) {
 		{
 			name:     "unknown protocol errors before resolving",
 			protocol: "carrier-pigeon",
-			ipv4:     resolverReturning("", errors.New("must not be called")),
-			ipv6:     resolverReturning("", errors.New("must not be called")),
+			ipv4:     nil, // must not be called
+			ipv6:     nil, // must not be called
 			wantErr:  errors.New("unknown protocol: carrier-pigeon"),
 		},
 	}
@@ -105,7 +119,15 @@ func TestDiscoverEndpoints_SharedPolicy(t *testing.T) {
 				warned = append(warned, family)
 			}
 
-			ipv4, ipv6, err := ctrl.DiscoverEndpoints(context.Background(), tt.protocol, warn, tt.ipv4, tt.ipv6)
+			resolveIPv4, resolveIPv6 := tt.ipv4, tt.ipv6
+			if resolveIPv4 == nil {
+				resolveIPv4 = mustNotBeCalledResolver(t)
+			}
+			if resolveIPv6 == nil {
+				resolveIPv6 = mustNotBeCalledResolver(t)
+			}
+
+			ipv4, ipv6, err := ctrl.DiscoverEndpoints(context.Background(), tt.protocol, warn, resolveIPv4, resolveIPv6)
 
 			if tt.wantErr != nil {
 				if err == nil || err.Error() != tt.wantErr.Error() {

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -179,9 +179,7 @@ func (c *PublishController) Execute(ctx context.Context) {
 		for _, peer := range peers {
 			logger := logger.With().Str("peer", peer.LocalId()).Logger()
 
-			if err := c.publishToPeer(ctx, logger.WithContext(ctx), device, peer, ipv4Endpoint, ipv6Endpoint, logger); err != nil {
-				continue
-			}
+			_ = c.publishToPeer(ctx, logger.WithContext(ctx), device, peer, ipv4Endpoint, ipv6Endpoint, logger)
 		}
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -46,6 +46,10 @@ type Daemon struct {
 	wg            sync.WaitGroup
 	// sleep is overridden in tests to avoid RunOneshot's real multi-second pacing.
 	sleep func(time.Duration)
+	// signalReady, when non-nil, is closed by Run right after signal.Notify
+	// registers the handler. It exists solely so tests can wait for
+	// registration instead of sleeping before sending a real OS signal.
+	signalReady chan struct{}
 }
 
 func New(
@@ -71,6 +75,9 @@ func (d *Daemon) Run(ctx context.Context) {
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	if d.signalReady != nil {
+		close(d.signalReady)
+	}
 
 	defer func() {
 		d.logger.Info().Msg("shutting down")

--- a/internal/daemon/daemon_signal_test.go
+++ b/internal/daemon/daemon_signal_test.go
@@ -21,14 +21,22 @@ func TestRun_ShouldReturnWhenSignalReceived(t *testing.T) {
 	// one to the current process rather than cancelling the context.
 	d, _, _, _ := newTestDaemon(t, time.Hour)
 
+	// Signaled once Run has called signal.Notify, so the test can wait for
+	// registration instead of sleeping and hoping it was long enough.
+	signalReady := make(chan struct{})
+	d.signalReady = signalReady
+
 	done := make(chan struct{})
 	go func() {
 		d.Run(context.Background())
 		close(done)
 	}()
 
-	// Give Run time to register its signal.Notify before we send the signal.
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-signalReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not register its signal handler in time")
+	}
 
 	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
 		t.Fatalf("failed to send SIGINT: %v", err)

--- a/internal/wg/client_ctrl_windows_test.go
+++ b/internal/wg/client_ctrl_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows && !wgcli && (wgctrl || !freebsd)
+
+package wg
+
+import (
+	"errors"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// isAccessDenied only recognizes ERROR_ACCESS_DENIED on Windows (see
+// elevation_windows.go), so the actual access-denied -> ErrElevationRequired
+// mapping can only be exercised here.
+
+func TestCtrlClient_Device_AccessDeniedMapsToElevationRequired(t *testing.T) {
+	backend := &fakeWgctrlBackend{
+		deviceFn: func(name string) (*wgtypes.Device, error) {
+			return nil, errorAccessDenied
+		},
+	}
+	c := &ctrlClient{c: backend}
+
+	_, err := c.Device("testdev")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrElevationRequired) {
+		t.Errorf("Device error = %v, want it to be marked ErrElevationRequired", err)
+	}
+}
+
+func TestCtrlClient_UpdatePeerEndpoint_AccessDeniedMapsToElevationRequired(t *testing.T) {
+	backend := &fakeWgctrlBackend{
+		configureDeviceFn: func(name string, cfg wgtypes.Config) error {
+			return errorAccessDenied
+		},
+	}
+	c := &ctrlClient{c: backend}
+
+	err := c.UpdatePeerEndpoint(PeerEndpointUpdate{DeviceName: "testdev"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrElevationRequired) {
+		t.Errorf("UpdatePeerEndpoint error = %v, want it to be marked ErrElevationRequired", err)
+	}
+}

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -125,9 +125,12 @@ func (c *controller) cycle(ctx context.Context) {
 	listener := c.node.listener
 
 	// Plugin init can need the network (e.g. a zone lookup), so it retries
-	// each cycle until it succeeds.
+	// each cycle until it succeeds. This only protects the LoadPlugins call
+	// boundary -- factory ctors aren't ctx-threaded, so Store.Get/Set (via
+	// publish/establish's storeCtx) remain the real protected network path.
 	if !c.pluginsReady {
-		if err := c.manager.LoadPlugins(ctx, c.pluginDefs); err != nil {
+		loadCtx := protectedContext(ctx, c.node.protector)
+		if err := c.manager.LoadPlugins(loadCtx, c.pluginDefs); err != nil {
 			listener.OnLog("warn", "plugin init: "+err.Error())
 			return
 		}

--- a/test/e2e/realnet/phases.sh
+++ b/test/e2e/realnet/phases.sh
@@ -136,12 +136,9 @@ full_tunnel_subject() {
 	# The storage backend is deliberately NOT excluded: its socket carries
 	# the device fwmark and leaves through the escape rule installed below,
 	# which is what makes the refresh loop survive a covering route. An
-	# exclusion route here would hide a regression in that escape.
-	#
-	# DNS still needs one. The escape is applied to the socket that carries
-	# the connection, and the name lookup happens on a separate socket that
-	# never sees it -- see issue #248.
-	_excl_ips="8.8.8.8 1.1.1.1"
+	# exclusion route here would hide a regression in that escape. DNS
+	# lookups go through the same escaped socket via the plugin dialer's
+	# PreferGo resolver (#248), so they need no exclusion either.
 
 	stop_daemon
 	ns_exec wg set "$WG_IF" fwmark "$FWMARK"
@@ -155,10 +152,6 @@ full_tunnel_subject() {
 	# would in production.
 	ns_exec ip route add default via "$HOST_IP" dev "$VETH_NS" table "$ESCAPE_TABLE"
 	ns_exec ip rule add fwmark "$FWMARK" lookup "$ESCAPE_TABLE" pref 100
-	# The remaining exclusion is DNS only; see the note above.
-	for _ip in $_excl_ips; do
-		ns_exec ip route add "$_ip/32" via "$HOST_IP" dev "$VETH_NS" 2>/dev/null || true
-	done
 	start_daemon
 	log "full tunnel (subject): routes installed, daemon restarted"
 


### PR DESCRIPTION
## Summary
- `test/e2e/realnet/phases.sh`'s `full_tunnel_subject()` installed host-route exclusions for `8.8.8.8`/`1.1.1.1` because plugin DNS lookups didn't escape a covering tunnel route (#248) -- only the TCP connection did, via #247's `ControlContext` hook, since `net.Dialer` resolves on a separate socket that never saw it.
- That's fixed: `internal/plugin/dialer`'s `newDialer()` now wires a `PreferGo` `net.Resolver` whose `Dial` reuses the same escaped `DialContext` (commit 3707f69), so DNS lookups go through the identical protected path as the TCP connect.
- The realnet e2e's storage backend (builtin `opendht`) already uses this dialer via `Transport()`, so the workaround is no longer needed. Removed the exclusion routes and updated the stale comment.

Fixes remaining cleanup for #248 (the underlying bug fix landed separately in 3707f69/0cefd29)

## Test plan
- [x] `sh -n test/e2e/realnet/phases.sh` clean
- [x] `shellcheck test/e2e/realnet/phases.sh` clean
- [x] Manual review: no dangling `_excl_ips` references, no other files reference the removed workaround (checked `test/e2e/realnet/` for `8.8.8.8`/`1.1.1.1`/`#248`)
- [ ] CI green on this PR

Note: this script requires the real network-namespace / "crash bunker" infra that only exists in the scheduled realnet e2e CI job -- it cannot be executed live in a sandbox, so verification here is limited to syntax/lint checks and code review, not a live run.