### PR TITLE
fix: give the mobile plugin resolver explicit nameservers

### DIFF
--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -152,7 +153,9 @@ func pickDNSServer(servers []string) (string, bool) {
 	if len(servers) == 0 {
 		return "", false
 	}
-	start := int(dnsRotation.Add(1) - 1)
+	// Modulo in uint32 space: a plain int conversion goes negative on 32-bit
+	// targets once the counter wraps, and a negative index panics.
+	start := int((dnsRotation.Add(1) - 1) % uint32(len(servers)))
 	for i := range servers {
 		if addr, ok := normalizeDNSAddr(servers[(start+i)%len(servers)]); ok {
 			return addr, true
@@ -173,6 +176,11 @@ func normalizeDNSAddr(s string) (string, bool) {
 	}
 	if port == "" {
 		port = "53"
+	} else if p, err := strconv.Atoi(port); err != nil || p < 1 || p > 65535 {
+		// SplitHostPort does not validate the port; an unusable one must not
+		// count as a usable entry, or it would keep a caller's list non-empty
+		// and defeat their all-invalid fallback.
+		return "", false
 	}
 	if _, err := netip.ParseAddr(host); err != nil {
 		return "", false

--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tjjh89017/stunmesh-go/internal/routeprobe"
@@ -39,6 +40,13 @@ type Escape struct {
 	// VpnService.protect, for platforms with no mark/fib/interface primitive.
 	// Nil means nothing to call, which is every caller except mobile.
 	Protector Protector
+	// DNSServers lists the nameservers ("host" or "host:port", port
+	// defaulting to 53) hostname lookups dial instead of the ones Go reads
+	// from /etc/resolv.conf. Android has no resolv.conf, so the pure-Go
+	// resolver otherwise falls back to localhost and every lookup dies with
+	// a connection refused; mobile fills this in. Empty trusts resolv.conf,
+	// which is every other platform.
+	DNSServers []string
 }
 
 // Protector is the fd-level escape Android provides in place of a
@@ -94,15 +102,15 @@ func DialContext(ctx context.Context, network, address string) (net.Conn, error)
 	return newDialer().DialContext(ctx, network, address)
 }
 
-// newDialer builds the Dialer DialContext uses. Its Resolver.Dial points back
-// at DialContext so hostname lookups reuse the same protected socket path as
-// the eventual TCP connect, instead of falling through to net.DefaultResolver
-// -- on android that resolves via Bionic getaddrinfo/netd, which cannot be
-// protected, so a DNS query would fail outright whenever the covering tunnel
-// it must escape is down. PreferGo forces the Go resolver so Dial is actually
-// consulted (the cgo resolver ignores it). Dial only opens a connection to
-// the resolver's already-known address, so this does not recurse into
-// hostname resolution.
+// newDialer builds the Dialer DialContext uses. Its Resolver.Dial routes
+// back through DialContext so hostname lookups reuse the same protected
+// socket path as the eventual TCP connect, instead of falling through to
+// net.DefaultResolver -- on android that resolves via Bionic getaddrinfo/
+// netd, which cannot be protected, so a DNS query would fail outright
+// whenever the covering tunnel it must escape is down. PreferGo forces the
+// Go resolver so Dial is actually consulted (the cgo resolver ignores it).
+// Dial only opens a connection to the resolver's already-known address, so
+// this does not recurse into hostname resolution.
 func newDialer() *net.Dialer {
 	return &net.Dialer{
 		Timeout:   10 * time.Second,
@@ -111,9 +119,37 @@ func newDialer() *net.Dialer {
 		ControlContext: control,
 		Resolver: &net.Resolver{
 			PreferGo: true,
-			Dial:     DialContext,
+			Dial:     dialDNS,
 		},
 	}
+}
+
+// dnsRotation spreads successive lookups across Escape.DNSServers, so the
+// resolver's retries for one lookup (each of which lands here as a fresh
+// Dial call) move on to the next server instead of hammering the first.
+var dnsRotation atomic.Uint32
+
+// dialDNS is the Resolver.Dial hook. address is the nameserver Go derived
+// from /etc/resolv.conf; when the Escape carries explicit DNSServers -- the
+// android case, where no resolv.conf exists and Go's fallback is a localhost
+// address nothing answers -- the target is swapped for one of those instead.
+// The ctx is the lookup's own, so the Escape rides in the same way it does
+// for the connection the lookup is for.
+func dialDNS(ctx context.Context, network, address string) (net.Conn, error) {
+	if servers := escapeFrom(ctx).DNSServers; len(servers) > 0 {
+		address = normalizeDNSAddr(servers[int(dnsRotation.Add(1)-1)%len(servers)])
+	}
+	return DialContext(ctx, network, address)
+}
+
+// normalizeDNSAddr accepts "host", "[host]" or "host:port" and returns
+// "host:port" with the port defaulting to 53, so Escape.DNSServers can carry
+// addresses the way platforms report them (bare IPs, IPv6 included).
+func normalizeDNSAddr(s string) string {
+	if _, _, err := net.SplitHostPort(s); err == nil {
+		return s
+	}
+	return net.JoinHostPort(strings.Trim(s, "[]"), "53")
 }
 
 // boundInterface resolves the physical default-route interface for platforms

--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -109,8 +110,9 @@ func DialContext(ctx context.Context, network, address string) (net.Conn, error)
 // netd, which cannot be protected, so a DNS query would fail outright
 // whenever the covering tunnel it must escape is down. PreferGo forces the
 // Go resolver so Dial is actually consulted (the cgo resolver ignores it).
-// Dial only opens a connection to the resolver's already-known address, so
-// this does not recurse into hostname resolution.
+// Dial only ever connects to an address that is already an IP literal --
+// resolv.conf-derived, or an Escape.DNSServers entry pickDNSServer vetted --
+// so it does not recurse into hostname resolution.
 func newDialer() *net.Dialer {
 	return &net.Dialer{
 		Timeout:   10 * time.Second,
@@ -130,26 +132,62 @@ func newDialer() *net.Dialer {
 var dnsRotation atomic.Uint32
 
 // dialDNS is the Resolver.Dial hook. address is the nameserver Go derived
-// from /etc/resolv.conf; when the Escape carries explicit DNSServers -- the
+// from /etc/resolv.conf; when the Escape carries usable DNSServers -- the
 // android case, where no resolv.conf exists and Go's fallback is a localhost
 // address nothing answers -- the target is swapped for one of those instead.
 // The ctx is the lookup's own, so the Escape rides in the same way it does
 // for the connection the lookup is for.
 func dialDNS(ctx context.Context, network, address string) (net.Conn, error) {
-	if servers := escapeFrom(ctx).DNSServers; len(servers) > 0 {
-		address = normalizeDNSAddr(servers[int(dnsRotation.Add(1)-1)%len(servers)])
+	if server, ok := pickDNSServer(escapeFrom(ctx).DNSServers); ok {
+		address = server
 	}
 	return DialContext(ctx, network, address)
 }
 
-// normalizeDNSAddr accepts "host", "[host]" or "host:port" and returns
-// "host:port" with the port defaulting to 53, so Escape.DNSServers can carry
-// addresses the way platforms report them (bare IPs, IPv6 included).
-func normalizeDNSAddr(s string) string {
-	if _, _, err := net.SplitHostPort(s); err == nil {
-		return s
+// pickDNSServer rotates across servers, skipping entries that are not IP
+// literals: dialing a hostname would recurse into this very hook to resolve
+// it, with the same list in the Escape, and never terminate. ok=false means
+// no usable entry, leaving the resolv.conf-derived address in place.
+func pickDNSServer(servers []string) (string, bool) {
+	if len(servers) == 0 {
+		return "", false
 	}
-	return net.JoinHostPort(strings.Trim(s, "[]"), "53")
+	start := int(dnsRotation.Add(1) - 1)
+	for i := range servers {
+		if addr, ok := normalizeDNSAddr(servers[(start+i)%len(servers)]); ok {
+			return addr, true
+		}
+	}
+	return "", false
+}
+
+// normalizeDNSAddr accepts an IP literal as "host", "[host]" or "host:port"
+// and returns "host:port" with the port defaulting to 53, so
+// Escape.DNSServers can carry addresses the way platforms report them (bare
+// IPs, IPv6 included). ok=false rejects anything whose host is not an IP
+// literal -- see pickDNSServer for why hostnames cannot serve here.
+func normalizeDNSAddr(s string) (string, bool) {
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		host, port = strings.Trim(s, "[]"), ""
+	}
+	if port == "" {
+		port = "53"
+	}
+	if _, err := netip.ParseAddr(host); err != nil {
+		return "", false
+	}
+	return net.JoinHostPort(host, port), true
+}
+
+// ValidNameserver reports whether s is usable as an Escape.DNSServers entry:
+// an IP literal, optionally bracketed or carrying a port. Callers building a
+// list from platform-reported strings filter with this so a stray hostname
+// is dropped (a hostname needs resolving, which needs a nameserver) rather
+// than silently poisoning the list.
+func ValidNameserver(s string) bool {
+	_, ok := normalizeDNSAddr(s)
+	return ok
 }
 
 // boundInterface resolves the physical default-route interface for platforms

--- a/internal/plugin/dialer/dialer_test.go
+++ b/internal/plugin/dialer/dialer_test.go
@@ -6,7 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"testing"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
 
 	"github.com/tjjh89017/stunmesh-go/internal/routeprobe"
 )
@@ -130,8 +134,135 @@ func TestDialerResolverDialsThroughProtectedPath(t *testing.T) {
 	}
 
 	got := reflect.ValueOf(d.Resolver.Dial).Pointer()
-	want := reflect.ValueOf(DialContext).Pointer()
+	want := reflect.ValueOf(dialDNS).Pointer()
 	if got != want {
-		t.Error("newDialer().Resolver.Dial is not DialContext, want DNS lookups to share the protected dial path with TCP connects")
+		t.Error("newDialer().Resolver.Dial is not dialDNS, want DNS lookups to share the protected dial path with TCP connects")
 	}
+}
+
+// Escape.DNSServers entries arrive the way platforms report them; the dial
+// needs "host:port".
+func TestNormalizeDNSAddr(t *testing.T) {
+	for in, want := range map[string]string{
+		"8.8.8.8":            "8.8.8.8:53",
+		"8.8.8.8:5353":       "8.8.8.8:5353",
+		"2001:db8::1":        "[2001:db8::1]:53",
+		"[2001:db8::1]":      "[2001:db8::1]:53",
+		"[2001:db8::1]:5353": "[2001:db8::1]:5353",
+		"dns.example":        "dns.example:53",
+		"dns.example:5353":   "dns.example:5353",
+	} {
+		if got := normalizeDNSAddr(in); got != want {
+			t.Errorf("normalizeDNSAddr(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// With DNSServers in the Escape, dialDNS must ignore the address Go derived
+// from /etc/resolv.conf -- on android that is a localhost fallback nothing
+// answers -- and rotate across the configured servers so a lookup's retries
+// reach a second server instead of re-dialing a dead first one. A UDP dial
+// sends nothing, so RemoteAddr shows where a query would have gone.
+func TestDialDNSUsesEscapeServers(t *testing.T) {
+	ctx := WithEscape(context.Background(), Escape{
+		DNSServers: []string{"192.0.2.1", "192.0.2.2:5353"},
+	})
+
+	seen := make(map[string]bool)
+	for range 2 {
+		conn, err := dialDNS(ctx, "udp", "127.0.0.1:53")
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[conn.RemoteAddr().String()] = true
+		_ = conn.Close()
+	}
+	if !seen["192.0.2.1:53"] || !seen["192.0.2.2:5353"] {
+		t.Errorf("two dials reached %v, want both 192.0.2.1:53 and 192.0.2.2:5353", seen)
+	}
+}
+
+// Without DNSServers the resolv.conf-derived address is dialed unchanged --
+// the desktop path, where resolv.conf is trustworthy.
+func TestDialDNSWithoutEscapeServers(t *testing.T) {
+	conn, err := dialDNS(context.Background(), "udp", "127.0.0.1:5353")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if got := conn.RemoteAddr().String(); got != "127.0.0.1:5353" {
+		t.Errorf("dial went to %s, want 127.0.0.1:5353", got)
+	}
+}
+
+// End to end through the real Go resolver: a lookup with Escape.DNSServers
+// pointing at a local fake must query that server, not whatever
+// /etc/resolv.conf says. This is the android scenario in miniature -- the
+// configured list is the only thing standing between the resolver and a
+// dead localhost fallback.
+func TestResolverUsesEscapeDNSServer(t *testing.T) {
+	server := fakeDNSServer(t)
+
+	ctx, cancel := context.WithTimeout(
+		WithEscape(context.Background(), Escape{DNSServers: []string{server}}),
+		5*time.Second)
+	defer cancel()
+
+	addrs, err := newDialer().Resolver.LookupHost(ctx, "escape-test.invalid")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if !slices.Contains(addrs, "127.0.0.99") {
+		t.Errorf("LookupHost = %v, want to contain the fake server's answer 127.0.0.99", addrs)
+	}
+}
+
+// fakeDNSServer answers every A question with 127.0.0.99 and everything else
+// with an empty success, and returns its "host:port".
+func fakeDNSServer(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			var query dnsmessage.Message
+			if err := query.Unpack(buf[:n]); err != nil {
+				continue
+			}
+			resp := dnsmessage.Message{
+				Header: dnsmessage.Header{
+					ID:            query.ID,
+					Response:      true,
+					Authoritative: true,
+				},
+				Questions: query.Questions,
+			}
+			if len(query.Questions) == 1 && query.Questions[0].Type == dnsmessage.TypeA {
+				resp.Answers = []dnsmessage.Resource{{
+					Header: dnsmessage.ResourceHeader{
+						Name:  query.Questions[0].Name,
+						Type:  dnsmessage.TypeA,
+						Class: dnsmessage.ClassINET,
+						TTL:   60,
+					},
+					Body: &dnsmessage.AResource{A: [4]byte{127, 0, 0, 99}},
+				}}
+			}
+			packed, err := resp.Pack()
+			if err != nil {
+				continue
+			}
+			_, _ = pc.WriteTo(packed, addr)
+		}
+	}()
+	return pc.LocalAddr().String()
 }

--- a/internal/plugin/dialer/dialer_test.go
+++ b/internal/plugin/dialer/dialer_test.go
@@ -141,20 +141,51 @@ func TestDialerResolverDialsThroughProtectedPath(t *testing.T) {
 }
 
 // Escape.DNSServers entries arrive the way platforms report them; the dial
-// needs "host:port".
+// needs "host:port", and anything that is not an IP literal must be refused
+// -- a hostname here would send the dial back through the resolver whose
+// nameserver it was supposed to be, recursing without end.
 func TestNormalizeDNSAddr(t *testing.T) {
 	for in, want := range map[string]string{
 		"8.8.8.8":            "8.8.8.8:53",
+		"8.8.8.8:":           "8.8.8.8:53",
 		"8.8.8.8:5353":       "8.8.8.8:5353",
 		"2001:db8::1":        "[2001:db8::1]:53",
 		"[2001:db8::1]":      "[2001:db8::1]:53",
 		"[2001:db8::1]:5353": "[2001:db8::1]:5353",
-		"dns.example":        "dns.example:53",
-		"dns.example:5353":   "dns.example:5353",
 	} {
-		if got := normalizeDNSAddr(in); got != want {
-			t.Errorf("normalizeDNSAddr(%q) = %q, want %q", in, got, want)
+		got, ok := normalizeDNSAddr(in)
+		if !ok || got != want {
+			t.Errorf("normalizeDNSAddr(%q) = (%q, %v), want (%q, true)", in, got, ok, want)
 		}
+	}
+	for _, in := range []string{"dns.example", "dns.example:5353", "", ":53", "not an address"} {
+		if got, ok := normalizeDNSAddr(in); ok {
+			t.Errorf("normalizeDNSAddr(%q) = (%q, true), want rejection", in, got)
+		}
+	}
+}
+
+// ValidNameserver is the exported face of the same rule, for callers
+// (mobile's SetDNSServers) filtering platform-reported strings.
+func TestValidNameserver(t *testing.T) {
+	if !ValidNameserver("8.8.8.8") || ValidNameserver("dns.example") {
+		t.Error("ValidNameserver should accept IP literals and reject hostnames")
+	}
+}
+
+// Hostname entries that slip into the list anyway (only mobile filters
+// today) are skipped, not dialed: recursion protection lives here, at the
+// point of use, not only in the callers.
+func TestPickDNSServerSkipsHostnames(t *testing.T) {
+	addr, ok := pickDNSServer([]string{"dns.example", "192.0.2.7"})
+	if !ok || addr != "192.0.2.7:53" {
+		t.Errorf("pickDNSServer = (%q, %v), want (\"192.0.2.7:53\", true)", addr, ok)
+	}
+	if addr, ok := pickDNSServer([]string{"dns.example", "other.example"}); ok {
+		t.Errorf("all-hostname list picked %q, want ok=false so the resolv.conf address stands", addr)
+	}
+	if addr, ok := pickDNSServer(nil); ok {
+		t.Errorf("empty list picked %q, want ok=false", addr)
 	}
 }
 

--- a/internal/plugin/dialer/dialer_test.go
+++ b/internal/plugin/dialer/dialer_test.go
@@ -158,7 +158,10 @@ func TestNormalizeDNSAddr(t *testing.T) {
 			t.Errorf("normalizeDNSAddr(%q) = (%q, %v), want (%q, true)", in, got, ok, want)
 		}
 	}
-	for _, in := range []string{"dns.example", "dns.example:5353", "", ":53", "not an address"} {
+	for _, in := range []string{
+		"dns.example", "dns.example:5353", "", ":53", "not an address",
+		"8.8.8.8:0", "8.8.8.8:99999", "8.8.8.8:-1", "8.8.8.8:notaport",
+	} {
 		if got, ok := normalizeDNSAddr(in); ok {
 			t.Errorf("normalizeDNSAddr(%q) = (%q, true), want rejection", in, got)
 		}
@@ -186,6 +189,19 @@ func TestPickDNSServerSkipsHostnames(t *testing.T) {
 	}
 	if addr, ok := pickDNSServer(nil); ok {
 		t.Errorf("empty list picked %q, want ok=false", addr)
+	}
+}
+
+// The rotation counter lives as long as the process; past 2^31 dials a plain
+// int conversion of it goes negative on 32-bit targets (armeabi-v7a is a
+// shipping mobile ABI) and a negative modulo would index out of range.
+func TestPickDNSServerCounterWrap(t *testing.T) {
+	old := dnsRotation.Load()
+	defer dnsRotation.Store(old)
+
+	dnsRotation.Store(1<<31 + 1)
+	if addr, ok := pickDNSServer([]string{"192.0.2.1", "192.0.2.2"}); !ok || addr == "" {
+		t.Errorf("pickDNSServer after counter wrap = (%q, %v), want a server", addr, ok)
 	}
 }
 

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -129,7 +129,7 @@ func (c *controller) cycle(ctx context.Context) {
 	// boundary -- factory ctors aren't ctx-threaded, so Store.Get/Set (via
 	// publish/establish's storeCtx) remain the real protected network path.
 	if !c.pluginsReady {
-		loadCtx := protectedContext(ctx, c.node.protector)
+		loadCtx := protectedContext(ctx, c.node.protector, c.node.pluginDNSServers())
 		if err := c.manager.LoadPlugins(loadCtx, c.pluginDefs); err != nil {
 			listener.OnLog("warn", "plugin init: "+err.Error())
 			return
@@ -223,7 +223,7 @@ func (c *controller) publish(ctx context.Context, data ctrl.EndpointData) {
 			listener.OnLog("error", "encrypt for "+peer.Name+": "+err.Error())
 			continue
 		}
-		storeCtx := protectedContext(ctx, c.node.protector)
+		storeCtx := protectedContext(ctx, c.node.protector, c.node.pluginDNSServers())
 		if err := store.Set(storeCtx, localId, res.Data); err != nil {
 			listener.OnLog("warn", "publish for "+peer.Name+": "+err.Error())
 			continue
@@ -246,7 +246,7 @@ func (c *controller) establish(ctx context.Context) {
 		if err != nil {
 			continue
 		}
-		storeCtx := protectedContext(ctx, c.node.protector)
+		storeCtx := protectedContext(ctx, c.node.protector, c.node.pluginDNSServers())
 		encrypted, err := store.Get(storeCtx, peerId.RemoteEndpointKey())
 		if err != nil {
 			listener.OnLog("debug", "no record for "+peer.Name+": "+err.Error())

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/tjjh89017/stunmesh-go/internal/mobilebind"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/tun"
 )
@@ -155,12 +156,14 @@ func (n *Node) Stop() {
 // and call again from its network callback whenever that network changes.
 // The tunnel's dns_servers are deliberately not used: plugin sockets are
 // protected out of the tunnel, so a tunnel-internal resolver would be
-// unreachable from them. An empty string reverts to built-in public
-// resolvers. Callable at any time, including before Start.
+// unreachable from them. Entries must be IP literals; anything else is
+// dropped (a hostname would itself need resolving). An empty or all-invalid
+// string reverts to built-in public resolvers. Callable at any time,
+// including before Start.
 func (n *Node) SetDNSServers(servers string) {
 	var list []string
 	for _, s := range strings.Split(servers, ",") {
-		if s = strings.TrimSpace(s); s != "" {
+		if s = strings.TrimSpace(s); s != "" && dialer.ValidNameserver(s) {
 			list = append(list, s)
 		}
 	}

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -5,6 +5,7 @@ package mobile
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/tjjh89017/stunmesh-go/internal/mobilebind"
@@ -12,15 +13,23 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 )
 
+// defaultPluginDNSServers backs plugin hostname lookups until the app calls
+// SetDNSServers: public resolvers reachable from most underlay networks.
+// Without them, the pure-Go resolver the plugin dialer forces (see
+// internal/plugin/dialer) has no /etc/resolv.conf to read on android and
+// falls back to localhost, where nothing answers.
+var defaultPluginDNSServers = []string{"8.8.8.8:53", "1.1.1.1:53", "[2001:4860:4860::8888]:53"}
+
 // Node is one running STUNMESH instance: an embedded wireguard-go device on
 // a demuxing bind, plus (later) the STUNMESH controllers for discovery,
 // publish and establish.
 type Node struct {
-	mu        sync.Mutex
-	cfg       *tunnelConfig
-	tunP      TunProvider
-	protector SocketProtector
-	listener  EventListener
+	mu         sync.Mutex
+	cfg        *tunnelConfig
+	tunP       TunProvider
+	protector  SocketProtector
+	listener   EventListener
+	dnsServers []string
 
 	dev     *device.Device
 	bind    *mobilebind.Bind
@@ -137,6 +146,40 @@ func (n *Node) Stop() {
 	n.running = false
 	n.mu.Unlock()
 	n.listener.OnStateChanged(StateDown)
+}
+
+// SetDNSServers sets the nameservers plugin hostname lookups use, as a
+// comma-separated list of "host" or "host:port" entries (port defaults to
+// 53; bare IPv6 is fine). The app should pass the underlay network's own
+// resolvers -- LinkProperties.dnsServers of the network the VPN runs over --
+// and call again from its network callback whenever that network changes.
+// The tunnel's dns_servers are deliberately not used: plugin sockets are
+// protected out of the tunnel, so a tunnel-internal resolver would be
+// unreachable from them. An empty string reverts to built-in public
+// resolvers. Callable at any time, including before Start.
+func (n *Node) SetDNSServers(servers string) {
+	var list []string
+	for _, s := range strings.Split(servers, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			list = append(list, s)
+		}
+	}
+	n.mu.Lock()
+	n.dnsServers = list
+	n.mu.Unlock()
+}
+
+// pluginDNSServers is what the controller hands the plugin dialer: the
+// app-provided list, or the public fallback so lookups work before the app
+// provides one. The slice is replaced wholesale by SetDNSServers, never
+// mutated, so returning it unlocked is safe.
+func (n *Node) pluginDNSServers() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.dnsServers) > 0 {
+		return n.dnsServers
+	}
+	return defaultPluginDNSServers
 }
 
 // RenewTun swaps in a fresh tun fd after a platform network change without

--- a/mobile/node_test.go
+++ b/mobile/node_test.go
@@ -19,6 +19,7 @@ func TestSetDNSServersParsing(t *testing.T) {
 		{"plain", "192.0.2.1,192.0.2.2", []string{"192.0.2.1", "192.0.2.2"}},
 		{"spaces and trailing comma", " 192.0.2.1 , 2001:db8::1 ,", []string{"192.0.2.1", "2001:db8::1"}},
 		{"with ports", "192.0.2.1:53,[2001:db8::1]:53", []string{"192.0.2.1:53", "[2001:db8::1]:53"}},
+		{"hostnames dropped", "dns.example,192.0.2.1", []string{"192.0.2.1"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -43,5 +44,10 @@ func TestPluginDNSServersFallback(t *testing.T) {
 	n.SetDNSServers("  ,, ")
 	if got := n.pluginDNSServers(); !reflect.DeepEqual(got, defaultPluginDNSServers) {
 		t.Errorf("after clearing: pluginDNSServers() = %v, want fallback %v", got, defaultPluginDNSServers)
+	}
+
+	n.SetDNSServers("dns.example,other.example")
+	if got := n.pluginDNSServers(); !reflect.DeepEqual(got, defaultPluginDNSServers) {
+		t.Errorf("all-invalid list: pluginDNSServers() = %v, want fallback %v", got, defaultPluginDNSServers)
 	}
 }

--- a/mobile/node_test.go
+++ b/mobile/node_test.go
@@ -1,0 +1,47 @@
+//go:build mobile && (linux || android)
+
+package mobile
+
+import (
+	"reflect"
+	"testing"
+)
+
+// SetDNSServers takes the list as one gomobile-safe string; entries are
+// comma-separated with optional whitespace, and empties are dropped so a
+// trailing comma or a plain "" cannot smuggle in an unusable entry.
+func TestSetDNSServersParsing(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", "192.0.2.1,192.0.2.2", []string{"192.0.2.1", "192.0.2.2"}},
+		{"spaces and trailing comma", " 192.0.2.1 , 2001:db8::1 ,", []string{"192.0.2.1", "2001:db8::1"}},
+		{"with ports", "192.0.2.1:53,[2001:db8::1]:53", []string{"192.0.2.1:53", "[2001:db8::1]:53"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &Node{}
+			n.SetDNSServers(tc.in)
+			if got := n.pluginDNSServers(); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("pluginDNSServers() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Before the app supplies a list -- and again after it clears one -- lookups
+// fall back to the public resolvers, so plugins work out of the box.
+func TestPluginDNSServersFallback(t *testing.T) {
+	n := &Node{}
+	if got := n.pluginDNSServers(); !reflect.DeepEqual(got, defaultPluginDNSServers) {
+		t.Errorf("zero-value node: pluginDNSServers() = %v, want fallback %v", got, defaultPluginDNSServers)
+	}
+
+	n.SetDNSServers("192.0.2.1")
+	n.SetDNSServers("  ,, ")
+	if got := n.pluginDNSServers(); !reflect.DeepEqual(got, defaultPluginDNSServers) {
+		t.Errorf("after clearing: pluginDNSServers() = %v, want fallback %v", got, defaultPluginDNSServers)
+	}
+}

--- a/mobile/transport.go
+++ b/mobile/transport.go
@@ -22,6 +22,11 @@ import (
 // not happen once a Node is running) carries a nil Escape.Protector, which
 // dialer/control_default.go already treats as a no-op -- the known,
 // documented gap for a caller that never wires one up.
-func protectedContext(ctx context.Context, protector SocketProtector) context.Context {
-	return dialer.WithEscape(ctx, dialer.Escape{Protector: protector})
+//
+// dnsServers rides along as Escape.DNSServers: android has no
+// /etc/resolv.conf for the forced pure-Go resolver to read, so without an
+// explicit list every plugin hostname lookup would dial Go's localhost
+// fallback and fail. See Node.SetDNSServers for where the list comes from.
+func protectedContext(ctx context.Context, protector SocketProtector, dnsServers []string) context.Context {
+	return dialer.WithEscape(ctx, dialer.Escape{Protector: protector, DNSServers: dnsServers})
 }

--- a/mobile/transport_test.go
+++ b/mobile/transport_test.go
@@ -29,7 +29,7 @@ func (p *fakeProtector) Protect(fd int32) bool {
 func TestProtectedContextCarriesProtector(t *testing.T) {
 	protector := &fakeProtector{ok: true}
 
-	ctx := protectedContext(context.Background(), protector)
+	ctx := protectedContext(context.Background(), protector, nil)
 
 	got := dialer.EscapeFrom(ctx).Protector
 	if got == nil {
@@ -52,8 +52,25 @@ func TestProtectedContextCarriesProtector(t *testing.T) {
 // as nil, matching dialer/control_default.go's documented no-op fallback --
 // this is the pre-fix gap for any caller that skips protectedContext.
 func TestProtectedContextNilProtector(t *testing.T) {
-	ctx := protectedContext(context.Background(), nil)
+	ctx := protectedContext(context.Background(), nil, nil)
 	if got := dialer.EscapeFrom(ctx).Protector; got != nil {
 		t.Errorf("Escape.Protector = %v, want nil", got)
+	}
+}
+
+// The DNS list must reach Escape.DNSServers -- that is what dialer's
+// Resolver.Dial reads to know where lookups go on a platform with no
+// /etc/resolv.conf.
+func TestProtectedContextCarriesDNSServers(t *testing.T) {
+	want := []string{"192.0.2.1:53", "192.0.2.2:53"}
+	ctx := protectedContext(context.Background(), &fakeProtector{ok: true}, want)
+	got := dialer.EscapeFrom(ctx).DNSServers
+	if len(got) != len(want) {
+		t.Fatalf("Escape.DNSServers = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Escape.DNSServers[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #262.

Since the v1.13.0-rc3 dialer change, plugin hostname lookups on Android die with `read: connection refused`: the forced pure-Go resolver reads `/etc/resolv.conf`, which Android does not have, so Go falls back to `127.0.0.1:53` where nothing answers.

- `dialer.Escape` gains `DNSServers`; the resolver's `Dial` hook swaps the resolv.conf-derived target for one of them, rotating across the list so retries reach a second server. Empty list (every desktop caller) leaves behavior unchanged.
- Entries must be IP literals — a hostname would recurse into the very hook meant to resolve it — enforced at the point of use (`pickDNSServer`) and at intake (`SetDNSServers` via `dialer.ValidNameserver`). Ports must parse to 1–65535; the rotation index is computed in uint32 space so the counter wrap cannot go negative on 32-bit ABIs.
- `Node.SetDNSServers` (comma-separated, gomobile-safe) lets the app supply the underlay network's resolvers (`LinkProperties.dnsServers`) at tunnel start and on network changes. The tunnel's `dns_servers` are deliberately not used: plugin sockets are protected out of the tunnel, so a tunnel-internal resolver would be unreachable from them.
- Until the app provides a list, lookups fall back to `8.8.8.8`, `1.1.1.1` and `2001:4860:4860::8888`, so plugins work out of the box.

## Testing

- `go test ./...`, `go test -race` on the dialer, mobile-tagged tests, `make lint` all green locally.
- New tests: normalization/validation table, rotation + hostname-skip + counter-wrap, protectedContext DNS carry, SetDNSServers parsing/fallback, and an end-to-end lookup through the real Go resolver against a fake DNS server proving `Escape.DNSServers` is what gets queried.

## Follow-up

stunmesh-android needs the counterpart: call `node.setDNSServers(...)` with the underlay `LinkProperties.dnsServers` at tunnel start and from the network callback.