### PR TITLE
ci: push docker images to ghcr.io and keep latest off rc tags

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: 'Application name for Docker image'
     required: true
   docker-token:
-    description: 'Docker registry token'
+    description: 'Docker Hub registry token'
+    required: true
+  ghcr-token:
+    description: 'GitHub token with packages:write for ghcr.io'
     required: true
   repository-owner:
     description: 'Repository owner for Docker image'
@@ -32,10 +35,22 @@ runs:
         username: ${{ inputs.repository-owner }}
         password: ${{ inputs.docker-token }}
 
+    - uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.ghcr-token }}
+
     - uses: docker/metadata-action@v6
       id: meta
       with:
-        images: ${{ inputs.repository-owner }}/${{ inputs.app-name }}
+        images: |
+          ${{ inputs.repository-owner }}/${{ inputs.app-name }}
+          ghcr.io/${{ inputs.repository-owner }}/${{ inputs.app-name }}
+        # latest=auto would move `latest` on every tag push, rc included;
+        # only a non-prerelease tag may move it.
+        flavor: |
+          latest=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'rc') }}
 
     - uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,9 @@ jobs:
     if: github.event_name == 'push'
     name: Build Docker container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     # e2e-required transitively covers lint/test/build/build-plugins and the
     # realnet report.
     needs: e2e-required
@@ -267,6 +270,7 @@ jobs:
         with:
           app-name: ${{ env.APP }}
           docker-token: ${{ secrets.DOCKER_TOKEN }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           repository-owner: ${{ github.repository_owner }}
 
   # Runtime test of the real publish -> opendht -> establish pipeline with two

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,9 @@ jobs:
   docker:
     name: Build Docker container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - create-release
     steps:
@@ -200,4 +203,5 @@ jobs:
         with:
           app-name: ${{ env.APP }}
           docker-token: ${{ secrets.DOCKER_TOKEN }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           repository-owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- Push the docker image to both Docker Hub and ghcr.io (`ghcr.io/<owner>/stunmesh`), logging in to GHCR with the workflow `GITHUB_TOKEN` (jobs gain `packages: write`).
- Stop rc tags from moving `latest`: the default `latest=auto` flavor applies `latest` on every tag push, so `v1.13.0-rc*` would have overwritten it. Now `latest` is only applied on a non-prerelease tag (`contains(github.ref_name, 'rc')` is case-insensitive, so it covers both `-rc1` and `-RC1` styles).

Tag naming is unchanged (`type=ref,event=tag`, e.g. `v1.13.0-rc4`), and branch pushes to main still publish the `main` tag to both registries.