### PR TITLE
docs: point quickstart at the ghcr.io container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For best results, ensure at least one peer is behind a cone NAT type.
 Download a binary from the [releases page](https://github.com/tjjh89017/stunmesh-go/releases), or use the container image:
 
 ```bash
-docker pull tjjh89017/stunmesh
+docker pull ghcr.io/tjjh89017/stunmesh
 ```
 
 On Linux, macOS, and FreeBSD, stunmesh-go needs raw socket access, so run it as root next to an already-configured WireGuard interface (Windows differs — see [Windows](#windows) below):


### PR DESCRIPTION
## Summary
ghcr.io is now the primary registry for the container image (#264); Docker Hub is a mirror that may be removed later. Update the quickstart's `docker pull` accordingly. Matches tjjh89017/stunmesh-docs#9.