### PR TITLE
fix: resolve mobile STUN servers through the escaped path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,6 +127,33 @@ there's a stated reason not to.
   self-registration assumes registration has no inputs beyond the build
   tags baked into the binary.
 
+### One escape hatch for every outbound path
+
+- **Where**: `internal/plugin/dialer` (`Escape`, `WithEscape`, `DialContext`,
+  `Resolver`), consumed by the built-in plugins' HTTP transport, by their
+  hostname lookups, and by mobile STUN discovery's server lookups
+  (`mobile/controller.go`'s `resolveSTUN`).
+- **Rule**: anything that opens a socket while stunmesh may be managing a
+  covering tunnel goes through the dialer's escape — including name
+  resolution, which is a socket too. The escape travels in the `context`
+  rather than being fixed at construction, so one instance can serve peers on
+  different interfaces.
+- **Why**: a covering allowed-IPs route swallows the very call that would
+  bring the tunnel up. Name resolution is the half that is easy to miss,
+  because the standard library hides the socket: `net.Resolve*` and
+  `net.DefaultResolver` reach the platform resolver, which on android is
+  Bionic's `getaddrinfo` routing over whatever network is default — the
+  tunnel itself, once up. A lookup needed to establish the tunnel then gets
+  routed into it. `dialer.Resolver` forces the pure-Go resolver so its `Dial`
+  hook is consulted, and points that hook at `Escape.DNSServers` over a
+  protected socket.
+- **Consequence**: low-level components do not resolve names. `mobilebind`'s
+  `Discover` takes an already-resolved `netip.AddrPort` so it has nothing to
+  resolve with, and the caller — which holds the escape — does the lookup.
+- **Revisit if**: a platform gains a resolver that can be pinned to a
+  specific underlay network, which would make the forced pure-Go resolver
+  and the explicit nameserver list unnecessary there.
+
 ## CI/e2e coverage narrowing
 
 `.github/workflows/main.yml` runs three e2e layers gated behind `build`,

--- a/internal/mobilebind/stun.go
+++ b/internal/mobilebind/stun.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"time"
 )
@@ -30,17 +29,22 @@ const (
 
 var ErrStunTimeout = errors.New("stun: no response")
 
-// Discover sends a STUN binding request to server ("host:port") from the
-// shared WG socket and returns the reflexive address. network is "udp4" or
-// "udp6" and selects the address family to discover. The response arrives
-// through the demux path, so the mapping it reports is the one WG traffic
-// uses.
-func (b *Bind) Discover(ctx context.Context, network, server string) (netip.AddrPort, error) {
-	udpAddr, err := net.ResolveUDPAddr(network, server)
-	if err != nil {
-		return netip.AddrPort{}, fmt.Errorf("stun: resolve %s: %w", server, err)
+// Discover sends a STUN binding request to dst from the shared WG socket and
+// returns the reflexive address. dst's address family selects which socket
+// the request leaves by (see connFor), so it is also what picks the family
+// being discovered. The response arrives through the demux path, so the
+// mapping it reports is the one WG traffic uses.
+//
+// dst is an already-resolved address on purpose. Resolving a STUN hostname
+// here would mean the platform resolver, which on android routes over the
+// default network -- the tunnel itself, once up -- and so cannot be relied on
+// to answer while discovery is still trying to establish that tunnel. The
+// caller resolves through the escaped path instead; see mobile's
+// controller.resolveSTUN.
+func (b *Bind) Discover(ctx context.Context, dst netip.AddrPort) (netip.AddrPort, error) {
+	if !dst.IsValid() {
+		return netip.AddrPort{}, errors.New("stun: invalid destination")
 	}
-	dst := udpAddr.AddrPort()
 
 	req, txn, err := buildBindingRequest()
 	if err != nil {

--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -120,10 +120,24 @@ func newDialer() *net.Dialer {
 		KeepAlive: 30 * time.Second,
 		// ControlContext, not Control: the escape rides in the context.
 		ControlContext: control,
-		Resolver: &net.Resolver{
-			PreferGo: true,
-			Dial:     dialDNS,
-		},
+		Resolver:       Resolver(),
+	}
+}
+
+// Resolver exposes the escaped resolver newDialer wires in, for callers that
+// need a hostname turned into an address without dialing it themselves --
+// mobile STUN discovery, which must send from the shared WireGuard socket
+// rather than a socket of the resolver's making. The ctx passed to a lookup
+// carries the Escape, exactly as it does for DialContext.
+//
+// Reaching for net.DefaultResolver instead is the trap this avoids: on
+// android that lands in Bionic's getaddrinfo, which resolves over whatever
+// network is default. Once the tunnel is up that is the tunnel, so a lookup
+// needed to bring the tunnel up is routed into it and fails.
+func Resolver() *net.Resolver {
+	return &net.Resolver{
+		PreferGo: true,
+		Dial:     dialDNS,
 	}
 }
 

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/netip"
+	"strconv"
 	"time"
 
 	"github.com/tjjh89017/stunmesh-go/internal/crypto"
@@ -14,6 +16,7 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	"github.com/tjjh89017/stunmesh-go/internal/mobilebind"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 	"golang.org/x/crypto/curve25519"
 )
@@ -23,8 +26,16 @@ import (
 // socket; tests substitute a fake to exercise discover/discoverFamily
 // without a real network.
 type stunDiscoverer interface {
-	Discover(ctx context.Context, network, server string) (netip.AddrPort, error)
+	Discover(ctx context.Context, dst netip.AddrPort) (netip.AddrPort, error)
 }
+
+// How long one STUN server gets: first to resolve its name, then to answer
+// the binding request. Separate budgets so a slow lookup cannot eat the
+// probe's retransmit schedule (RFC 8489 RTO doubling, ~7.5s worst case).
+const (
+	stunResolveTimeout = 5 * time.Second
+	stunProbeTimeout   = 10 * time.Second
+)
 
 // controller runs the STUNMESH publish/establish cycle on top of the running
 // device: discover the reflexive address through the shared socket, encrypt
@@ -179,15 +190,76 @@ func (c *controller) discover(ctx context.Context) (ctrl.EndpointData, error) {
 func (c *controller) discoverFamily(ctx context.Context, network string) (string, error) {
 	var lastErr error
 	for _, server := range c.cfg.Stun.Addresses {
-		attemptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		addr, err := c.bind.Discover(attemptCtx, network, server)
-		cancel()
-		if err == nil {
-			return addr.String(), nil
+		addr, err := c.probeServer(ctx, network, server)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		lastErr = err
+		return addr.String(), nil
 	}
 	return "", fmt.Errorf("all stun servers failed: %w", lastErr)
+}
+
+// probeServer resolves one configured STUN server for the family and sends it
+// a binding request from the shared socket. A server configured for the other
+// family resolves to nothing here and is reported as a failure, which is how
+// discoverFamily walks a mixed-family list down to the entries that apply.
+func (c *controller) probeServer(ctx context.Context, network, server string) (netip.AddrPort, error) {
+	resolveCtx, cancel := context.WithTimeout(ctx, stunResolveTimeout)
+	dst, err := c.resolveSTUN(resolveCtx, network, server)
+	cancel()
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, stunProbeTimeout)
+	defer cancel()
+	return c.bind.Discover(probeCtx, dst)
+}
+
+// resolveSTUN turns a configured STUN server ("host:port", host a name or an
+// IP literal) into the address to probe for network ("udp4" or "udp6").
+//
+// The lookup takes the plugin dialer's escaped path -- a protected socket
+// aimed at the underlay's resolvers (Node.SetDNSServers) -- rather than the
+// platform's. On android the platform resolver goes through Bionic's
+// getaddrinfo, which resolves over the default network; once the tunnel is up
+// that is the tunnel, so discovery's own lookup gets routed into the very
+// tunnel it is trying to establish. That fails until something else happens
+// to bring the tunnel up, which is exactly the ordering that left a
+// dualstack node with no IPv6 endpoint on its first cycle: IPv4 discovery ran
+// while the tunnel was still down and answered, IPv6 discovery ran after and
+// could not resolve.
+//
+// An IP literal short-circuits inside net.Resolver, so a config that lists
+// addresses instead of names needs no working DNS at all.
+func (c *controller) resolveSTUN(ctx context.Context, network, server string) (netip.AddrPort, error) {
+	host, portStr, err := net.SplitHostPort(server)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("stun server %q: %w", server, err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("stun server %q: port: %w", server, err)
+	}
+
+	escaped := protectedContext(ctx, c.node.protector, c.node.pluginDNSServers())
+	ips, err := dialer.Resolver().LookupNetIP(escaped, ipNetwork(network), host)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("resolve %s: %w", server, err)
+	}
+	// LookupNetIP reports IPv4 results in 4-in-6 form; unmapping keeps the
+	// endpoint string and the bind's socket choice in the right family.
+	return netip.AddrPortFrom(ips[0].Unmap(), uint16(port)), nil
+}
+
+// ipNetwork maps the UDP network discovery works in to the resolver's, so a
+// lookup only returns addresses of the family being discovered.
+func ipNetwork(network string) string {
+	if network == "udp6" {
+		return "ip6"
+	}
+	return "ip4"
 }
 
 func (c *controller) publish(ctx context.Context, data ctrl.EndpointData) {

--- a/mobile/controller_test.go
+++ b/mobile/controller_test.go
@@ -4,7 +4,9 @@ package mobile
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"net"
 	"net/netip"
 	"strings"
 	"testing"
@@ -68,13 +70,24 @@ func TestSelectEndpoint(t *testing.T) {
 
 // fakeDiscoverer is a stunDiscoverer test double keyed by address family
 // ("udp4"/"udp6"), letting tests control per-family success/failure without
-// a real mobilebind.Bind or network access.
+// a real mobilebind.Bind or network access. The family now comes from the
+// destination the controller resolved, which probed also records so tests can
+// assert what was actually aimed at.
 type fakeDiscoverer struct {
 	results map[string]netip.AddrPort
 	errs    map[string]error
+	probed  map[string]netip.AddrPort
 }
 
-func (f *fakeDiscoverer) Discover(_ context.Context, network, _ string) (netip.AddrPort, error) {
+func (f *fakeDiscoverer) Discover(_ context.Context, dst netip.AddrPort) (netip.AddrPort, error) {
+	network := "udp6"
+	if dst.Addr().Is4() {
+		network = "udp4"
+	}
+	if f.probed == nil {
+		f.probed = make(map[string]netip.AddrPort)
+	}
+	f.probed[network] = dst
 	if err, ok := f.errs[network]; ok {
 		return netip.AddrPort{}, err
 	}
@@ -110,12 +123,19 @@ func (f *fakeListener) hasLogContaining(substr string) bool {
 // instead of a real *mobilebind.Bind, so discover/discoverFamily can be
 // exercised through the real controller.discover code path (which invokes
 // the shared ctrl.DiscoverEndpoints) without opening a socket.
+// The STUN servers are IP literals of both families: resolveSTUN short-
+// circuits a literal inside net.Resolver, so discovery stays hermetic, and
+// listing both families exercises discoverFamily walking past the entries
+// that do not apply to the family it is resolving for.
 func newDiscoverTestController(protocol string, disc *fakeDiscoverer, lst *fakeListener) *controller {
 	return &controller{
 		node: &Node{listener: lst},
 		cfg: &tunnelConfig{
 			Interface: ifaceConfig{Protocol: protocol},
-			Stun:      stunConfig{Addresses: []string{"stun.example.com:19302"}},
+			Stun: stunConfig{Addresses: []string{
+				"192.0.2.1:19302",
+				"[2001:db8:5747::1]:19302",
+			}},
 		},
 		bind: disc,
 	}
@@ -202,3 +222,173 @@ func TestControllerDiscover_SingleFamilyHardFails(t *testing.T) {
 		t.Fatal("discover() succeeded despite the only requested family failing; want error")
 	}
 }
+
+// TestControllerDiscoverFamily_PicksServerOfRequestedFamily proves the STUN
+// server a family is probed at is one of that family: a mixed-family list is
+// walked past the entries that cannot serve the family being discovered,
+// rather than the first entry being probed regardless.
+func TestControllerDiscoverFamily_PicksServerOfRequestedFamily(t *testing.T) {
+	disc := &fakeDiscoverer{
+		results: map[string]netip.AddrPort{
+			"udp4": netip.MustParseAddrPort("1.2.3.4:51820"),
+			"udp6": netip.MustParseAddrPort("[2001:db8::1]:51820"),
+		},
+	}
+	c := newDiscoverTestController("dualstack", disc, &fakeListener{})
+
+	if _, err := c.discoverFamily(context.Background(), "udp6"); err != nil {
+		t.Fatalf("discoverFamily(udp6) returned unexpected error: %v", err)
+	}
+	want := netip.MustParseAddrPort("[2001:db8:5747::1]:19302")
+	if got := disc.probed["udp6"]; got != want {
+		t.Errorf("probed %v for udp6, want the v6 server %v", got, want)
+	}
+}
+
+// TestControllerResolveSTUN_UnmapsIPv4 pins the 4-in-6 detail: LookupNetIP
+// reports IPv4 as ::ffff:a.b.c.d, and carrying that through would publish an
+// IPv4 endpoint formatted as "[::ffff:1.2.3.4]:19302".
+func TestControllerResolveSTUN_UnmapsIPv4(t *testing.T) {
+	c := newDiscoverTestController("ipv4", &fakeDiscoverer{}, &fakeListener{})
+
+	got, err := c.resolveSTUN(context.Background(), "udp4", "192.0.2.1:19302")
+	if err != nil {
+		t.Fatalf("resolveSTUN returned unexpected error: %v", err)
+	}
+	if !got.Addr().Is4() {
+		t.Errorf("resolveSTUN = %v (%q), want an unmapped IPv4 address", got, got.String())
+	}
+	if want := netip.MustParseAddrPort("192.0.2.1:19302"); got != want {
+		t.Errorf("resolveSTUN = %v, want %v", got, want)
+	}
+}
+
+// TestControllerResolveSTUN_RejectsMalformedServer covers the config-error
+// path: a server string without a port never reaches the resolver.
+func TestControllerResolveSTUN_RejectsMalformedServer(t *testing.T) {
+	c := newDiscoverTestController("ipv4", &fakeDiscoverer{}, &fakeListener{})
+
+	if _, err := c.resolveSTUN(context.Background(), "udp4", "192.0.2.1"); err == nil {
+		t.Fatal("resolveSTUN accepted a server string with no port; want error")
+	}
+}
+
+// TestControllerResolveSTUN_UsesEscapedResolver is the regression test for
+// the bug this path exists to avoid. The name resolved here exists in no real
+// zone, and the only nameserver that can answer it is the one this test puts
+// in Node.dnsServers -- which is reachable only if the lookup goes through
+// dialer.Resolver()'s Dial hook (the escaped, protected path) rather than the
+// platform resolver. A regression to net.Resolve*/net.DefaultResolver fails
+// here with a lookup error instead of the fake server's answer.
+func TestControllerResolveSTUN_UsesEscapedResolver(t *testing.T) {
+	dns := startFakeDNS(t, netip.MustParseAddr("203.0.113.7"), netip.MustParseAddr("2001:db8::7"))
+	c := newDiscoverTestController("dualstack", &fakeDiscoverer{}, &fakeListener{})
+	c.node.dnsServers = []string{dns.addr()}
+
+	for _, tt := range []struct {
+		network string
+		want    string
+	}{
+		{"udp4", "203.0.113.7:19302"},
+		{"udp6", "[2001:db8::7]:19302"},
+	} {
+		got, err := c.resolveSTUN(context.Background(), tt.network, "stun.invalid.example:19302")
+		if err != nil {
+			t.Fatalf("resolveSTUN(%s) returned unexpected error: %v", tt.network, err)
+		}
+		if want := netip.MustParseAddrPort(tt.want); got != want {
+			t.Errorf("resolveSTUN(%s) = %v, want %v", tt.network, got, want)
+		}
+	}
+}
+
+// fakeDNS is a minimal UDP nameserver that answers every A/AAAA question with
+// one fixed address, whatever the name. Tests point Node.dnsServers at it to
+// prove a lookup travelled the escaped path: nothing else routes a query here.
+type fakeDNS struct {
+	conn *net.UDPConn
+	ip4  netip.Addr
+	ip6  netip.Addr
+	done chan struct{}
+}
+
+func startFakeDNS(t *testing.T, ip4, ip6 netip.Addr) *fakeDNS {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen fake dns: %v", err)
+	}
+	f := &fakeDNS{conn: conn, ip4: ip4, ip6: ip6, done: make(chan struct{})}
+	go f.serve()
+	t.Cleanup(func() {
+		_ = conn.Close() // unblocks serve, whose read then fails and returns
+		<-f.done
+	})
+	return f
+}
+
+func (f *fakeDNS) addr() string { return f.conn.LocalAddr().String() }
+
+func (f *fakeDNS) serve() {
+	defer close(f.done)
+	buf := make([]byte, 512)
+	for {
+		n, from, err := f.conn.ReadFromUDP(buf)
+		if err != nil {
+			return // the test closed the socket
+		}
+		resp, ok := f.answer(buf[:n])
+		if !ok {
+			continue
+		}
+		if _, err := f.conn.WriteToUDP(resp, from); err != nil {
+			return
+		}
+	}
+}
+
+// answer echoes the query's header and question and appends one address
+// record for it. Only the fields Go's resolver checks are filled in.
+func (f *fakeDNS) answer(query []byte) ([]byte, bool) {
+	if len(query) < dnsHeaderLen {
+		return nil, false
+	}
+	// Walk the QNAME's length-prefixed labels to find the question's end.
+	i := dnsHeaderLen
+	for i < len(query) && query[i] != 0 {
+		i += int(query[i]) + 1
+	}
+	end := i + 5 // the root label, then qtype and qclass
+	if end > len(query) {
+		return nil, false
+	}
+
+	qtype := binary.BigEndian.Uint16(query[i+1 : i+3])
+	var rdata []byte
+	switch {
+	case qtype == dnsTypeA && f.ip4.Is4():
+		b := f.ip4.As4()
+		rdata = b[:]
+	case qtype == dnsTypeAAAA && f.ip6.Is6():
+		b := f.ip6.As16()
+		rdata = b[:]
+	default:
+		return nil, false
+	}
+
+	resp := append([]byte(nil), query[:end]...)
+	binary.BigEndian.PutUint16(resp[2:4], 0x8180) // response, recursion available
+	binary.BigEndian.PutUint16(resp[6:8], 1)      // one answer
+	resp = append(resp, 0xc0, byte(dnsHeaderLen)) // name: pointer to the question
+	resp = binary.BigEndian.AppendUint16(resp, qtype)
+	resp = binary.BigEndian.AppendUint16(resp, 1)  // class IN
+	resp = binary.BigEndian.AppendUint32(resp, 60) // ttl
+	resp = binary.BigEndian.AppendUint16(resp, uint16(len(rdata)))
+	return append(resp, rdata...), true
+}
+
+const (
+	dnsHeaderLen = 12
+	dnsTypeA     = 1
+	dnsTypeAAAA  = 28
+)


### PR DESCRIPTION
## Problem

`mobilebind.Bind.Discover` resolved its STUN server name with `net.ResolveUDPAddr`, which reaches the platform resolver. On Android that is Bionic's `getaddrinfo`, which resolves over whatever network is *default* — and once the tunnel is up, the default network is the tunnel. Discovery's own lookup was being routed into the very tunnel it was trying to establish.

Observed on a dualstack Android node as a missing IPv6 endpoint:

```
event endpoint_discovered: ipv4 111.83.107.110:23600
[warn] ipv6 discovery: all stun servers failed: stun: resolve stun.l.google.com:19302:
       lookup stun.l.google.com: no such host
```

IPv4 discovery ran while the tunnel was still down and answered. IPv6 discovery ran after and could not resolve. Only on a later refresh cycle — once IPv4 had brought the tunnel up — did IPv6 discovery start working. The underlay had working IPv6 and working IPv6 DNS the whole time.

## Fix

Resolve through `internal/plugin/dialer`'s escaped resolver: a protected socket aimed at the underlay's nameservers (`Node.SetDNSServers`), which is the same path plugin traffic already takes. This works whether the tunnel is up or down.

- `dialer.Resolver()` exports the escaped resolver `newDialer` already wired in inline, for callers that need a name turned into an address without dialing it themselves — mobile STUN must send from the shared WireGuard socket, not one of the resolver's making.
- `mobile/controller.go` gains `resolveSTUN`, called per server before probing, with its own timeout so a slow lookup cannot eat the probe's RFC 8489 retransmit budget.
- `mobilebind.Discover` now takes an already-resolved `netip.AddrPort` instead of `(network, server string)`. The low-level bind has nothing left to resolve with, so this cannot regress by accident. The address family of `dst` already selects the socket (`connFor`), which is what made the `network` parameter redundant.

IP literals in `stun.addresses` short-circuit inside `net.Resolver`, so a literal-only config needs no working DNS at all.

## Tests

- `TestControllerResolveSTUN_UsesEscapedResolver` is the regression test. It stands up a minimal fake nameserver on loopback and puts it in `Node.dnsServers`; the name it resolves exists in no real zone, so the only way to get an answer is through `dialer.Resolver()`'s `Dial` hook. Reverting `resolveSTUN` to `net.DefaultResolver` fails it with `lookup stun.invalid.example ... no such host` — verified.
- `TestControllerResolveSTUN_UnmapsIPv4` pins the 4-in-6 detail: `LookupNetIP` reports IPv4 as `::ffff:a.b.c.d`, and carrying that through would publish an IPv4 endpoint formatted as `[::ffff:1.2.3.4]:19302`.
- `TestControllerDiscoverFamily_PicksServerOfRequestedFamily` covers a mixed-family server list being walked down to the entries that apply.
- The existing discover tests now use IP literals, keeping them hermetic.

`make lint` clean on all four platforms plus mobile; `go test ./...` passes (the pre-existing `TestTransportDialsWithRequestContext` failure in this sandbox is an outbound-TCP restriction, present on `main` too).

`docs/architecture.md` gains a pattern entry naming the rule this bug broke: everything that opens a socket while stunmesh may be managing a covering tunnel goes through the dialer's escape, name resolution included, because the standard library hides that socket.