### PR TITLE
fix: resolve desktop STUN servers through the escaped path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,9 +130,11 @@ there's a stated reason not to.
 ### One escape hatch for every outbound path
 
 - **Where**: `internal/plugin/dialer` (`Escape`, `WithEscape`, `DialContext`,
-  `Resolver`), consumed by the built-in plugins' HTTP transport, by their
-  hostname lookups, and by mobile STUN discovery's server lookups
-  (`mobile/controller.go`'s `resolveSTUN`).
+  `Resolver`, `ResolveAddrPort`), consumed by the built-in plugins' HTTP
+  transport, by their hostname lookups, and by STUN discovery's server
+  lookups on every platform — mobile's `controller.resolveSTUN`, and desktop's
+  `stun.Connect` (socket-owning and proxy-backed alike), which read the escape
+  `ctrl.PublishController.discoverEndpoints` puts in the discovery context.
 - **Rule**: anything that opens a socket while stunmesh may be managing a
   covering tunnel goes through the dialer's escape — including name
   resolution, which is a socket too. The escape travels in the `context`
@@ -144,12 +146,17 @@ there's a stated reason not to.
   `net.DefaultResolver` reach the platform resolver, which on android is
   Bionic's `getaddrinfo` routing over whatever network is default — the
   tunnel itself, once up. A lookup needed to establish the tunnel then gets
-  routed into it. `dialer.Resolver` forces the pure-Go resolver so its `Dial`
-  hook is consulted, and points that hook at `Escape.DNSServers` over a
-  protected socket.
+  routed into it. On desktop the socket is unmarked and unbound instead, so a
+  covering allowed-IPs route sends it the same way. `dialer.Resolver` forces
+  the pure-Go resolver so its `Dial` hook is consulted; the hook applies the
+  platform's escape and, where `Escape.DNSServers` is set (mobile only —
+  desktop keeps its resolv.conf nameservers), aims at those servers.
 - **Consequence**: low-level components do not resolve names. `mobilebind`'s
   `Discover` takes an already-resolved `netip.AddrPort` so it has nothing to
   resolve with, and the caller — which holds the escape — does the lookup.
+  Desktop's `stun.Connect` still takes a `host:port` string (it is the
+  `StunClient` contract, shared with the proxy-backed client), but resolves it
+  through `dialer.ResolveAddrPort` rather than `net.ResolveUDPAddr`.
 - **Revisit if**: a platform gains a resolver that can be pinned to a
   specific underlay network, which would make the forced pure-Go resolver
   and the explicit nameserver list unnecessary there.

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -62,6 +62,11 @@ func NewPublishController(devices DeviceRepository, peers PeerRepository, plugin
 // DiscoverEndpoints (internal/ctrl/discover.go); this wraps it with the
 // raw-socket StunResolver and this controller's logging.
 func (c *PublishController) discoverEndpoints(ctx context.Context, device *entity.Device, logger zerolog.Logger) (ipv4Endpoint, ipv6Endpoint string, err error) {
+	// The escape rides into discovery for the STUN server's name lookup: the
+	// probe socket escapes by itself (fwmark/pcap), but the lookup is a socket
+	// too, and the only one in the discovery path nothing else covers.
+	ctx = dialer.WithEscape(ctx, escapeFor(c.deviceConfig, device))
+
 	resolveFamily := func(family string) FamilyResolver {
 		return func(ctx context.Context) (string, error) {
 			host, port, err := c.resolver.Resolve(ctx, string(device.Name()), uint16(device.ListenPort()), family, device.FirewallMark())

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -13,6 +13,7 @@ import (
 	mock "github.com/tjjh89017/stunmesh-go/internal/ctrl/mock"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 	"go.uber.org/mock/gomock"
 )
 
@@ -117,7 +118,7 @@ func TestPublishController_Execute_STUNError(t *testing.T) {
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("", 0, errors.New("STUN failed"))
 
 	controller := ctrl.NewPublishController(
@@ -155,7 +156,7 @@ func TestPublishController_Execute_ForwardsDeviceFirewallMark(t *testing.T) {
 	// Exact value, not gomock.Any(): this is the assertion. Erroring out here
 	// keeps the test to the one thing it is about.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", mark).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", mark).
 		Return("", 0, errors.New("stop after the resolver call"))
 
 	controller := ctrl.NewPublishController(
@@ -169,6 +170,50 @@ func TestPublishController_Execute_ForwardsDeviceFirewallMark(t *testing.T) {
 	)
 
 	controller.Execute(ctx)
+}
+
+// The STUN server's name lookup is a socket like any other, and the only one
+// in the discovery path that neither the raw probe socket nor the plugin
+// dialer covers. It escapes a covering tunnel only if the escape reaches the
+// resolver in the context, so that is what this asserts.
+func TestPublishController_Execute_CarriesEscapeIntoDiscovery(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+	pluginManager := plugin.NewManager()
+
+	const mark = 0xca6c
+	device := entity.NewDevice(entity.DeviceId("wg0"), 51820, make([]byte, 32), "ipv4", mark)
+
+	var got dialer.Escape
+	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockResolver.EXPECT().
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
+		DoAndReturn(func(resolveCtx context.Context, _ string, _ uint16, _ string, _ int) (string, int, error) {
+			got = dialer.EscapeFrom(resolveCtx)
+			return "", 0, errors.New("stop after the resolver call")
+		})
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		nil,
+		pluginManager,
+		mockResolver,
+		nil,
+		nil,
+		&logger,
+	)
+
+	controller.Execute(ctx)
+
+	if got.FirewallMark != mark {
+		t.Errorf("resolver context carried escape %+v, want FirewallMark %#x", got, mark)
+	}
 }
 
 // Test Execute with peer list error
@@ -189,7 +234,7 @@ func TestPublishController_Execute_PeerListError(t *testing.T) {
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).
 		Return(nil, errors.New("failed to list peers"))
@@ -229,7 +274,7 @@ func TestPublishController_Execute_EncryptionError(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 
 	// Expect encryption to fail
@@ -272,7 +317,7 @@ func TestPublishController_Execute_SuccessfulEncryption(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 
 	// Verify the JSON content being encrypted
@@ -333,7 +378,7 @@ func TestPublishController_Execute_IPv6(t *testing.T) {
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -388,10 +433,10 @@ func TestPublishController_Execute_Dualstack(t *testing.T) {
 
 	// Expect both IPv4 and IPv6 resolution
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -443,10 +488,10 @@ func TestPublishController_Execute_Dualstack_BothFail(t *testing.T) {
 
 	// Both resolutions fail
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("", 0, errors.New("IPv4 failed"))
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("", 0, errors.New("IPv6 failed"))
 
 	controller := ctrl.NewPublishController(
@@ -496,10 +541,10 @@ func TestPublishController_Execute_Dualstack_PartialFail(t *testing.T) {
 
 	// IPv4 resolves, IPv6 fails
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("", 0, errors.New("IPv6 failed"))
 
 	encryptCalled := false
@@ -569,7 +614,7 @@ func TestPublishController_Execute_MultipleDevices(t *testing.T) {
 	// Device 1 (wg0)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer1}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockEncryptor.EXPECT().
 		Encrypt(ctx, gomock.Any()).
@@ -578,7 +623,7 @@ func TestPublishController_Execute_MultipleDevices(t *testing.T) {
 	// Device 2 (wg1)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg1")).Return([]*entity.Peer{peer2}, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg1", uint16(51821), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg1", uint16(51821), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51821, nil)
 	mockEncryptor.EXPECT().
 		Encrypt(ctx, gomock.Any()).
@@ -688,10 +733,10 @@ func TestPublishController_ExecuteForPeer_Success(t *testing.T) {
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv6", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
 		Return("2001:db8::1", 51820, nil)
 
 	mockEncryptor.EXPECT().
@@ -747,10 +792,10 @@ func TestPublishController_Execute_Dedup_ChangedEndpoint_Publishes(t *testing.T)
 	// Two calls, two different resolved endpoints.
 	gomock.InOrder(
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+			Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("1.2.3.4", 51820, nil),
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+			Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("5.6.7.8", 51820, nil),
 	)
 
@@ -799,7 +844,7 @@ func TestPublishController_Execute_Dedup_UnchangedEndpoint_Skips(t *testing.T) {
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -849,7 +894,7 @@ func TestPublishController_Execute_Dedup_OffByDefault_AlwaysPublishes(t *testing
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -901,7 +946,7 @@ func TestPublishController_ExecuteForPeer_Dedup_UnchangedEndpoint_Skips(t *testi
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 
@@ -957,10 +1002,10 @@ func TestPublishController_ExecuteForPeer_Dedup_ChangedEndpoint_Publishes(t *tes
 	// Two calls, two different resolved endpoints.
 	gomock.InOrder(
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+			Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("1.2.3.4", 51820, nil),
 		mockResolver.EXPECT().
-			Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+			Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 			Return("5.6.7.8", 51820, nil),
 	)
 
@@ -1013,7 +1058,7 @@ func TestPublishController_Execute_Dedup_FailedStore_DoesNotCacheAndRetries(t *t
 
 	// Same endpoint resolved both times.
 	mockResolver.EXPECT().
-		Resolve(ctx, "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil).
 		Times(2)
 

--- a/internal/plugin/dialer/dialer.go
+++ b/internal/plugin/dialer/dialer.go
@@ -13,6 +13,7 @@ package dialer
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
@@ -138,6 +139,47 @@ func Resolver() *net.Resolver {
 	return &net.Resolver{
 		PreferGo: true,
 		Dial:     dialDNS,
+	}
+}
+
+// ResolveAddrPort turns "host:port" -- host a name or an IP literal -- into
+// the address to send to, looked up through Resolver for network's family
+// ("udp4"/"udp6", or the "ip4"/"ip6" the resolver itself speaks). It is for
+// callers that must resolve a name but then send from a socket of their own
+// making rather than one DialContext opened: STUN discovery, whose probe
+// leaves through a raw socket (desktop) or the shared WireGuard socket
+// (mobile). The ctx carries the Escape, exactly as it does for DialContext.
+//
+// An IP literal short-circuits inside net.Resolver, so a config that lists
+// addresses instead of names needs no working DNS at all.
+func ResolveAddrPort(ctx context.Context, network, hostport string) (netip.AddrPort, error) {
+	host, portStr, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("resolve %q: %w", hostport, err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("resolve %q: port: %w", hostport, err)
+	}
+
+	ips, err := Resolver().LookupNetIP(ctx, ipNetwork(network), host)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("resolve %s: %w", hostport, err)
+	}
+	// LookupNetIP reports IPv4 results in 4-in-6 form; unmapping keeps the
+	// address in the family the caller asked for, which is what picks the
+	// socket the probe leaves by.
+	return netip.AddrPortFrom(ips[0].Unmap(), uint16(port)), nil
+}
+
+// ipNetwork maps the UDP network a caller works in to the resolver's, so a
+// lookup only returns addresses of the family being asked for.
+func ipNetwork(network string) string {
+	switch network {
+	case "udp6", "ip6":
+		return "ip6"
+	default:
+		return "ip4"
 	}
 }
 

--- a/internal/plugin/dialer/dialer_test.go
+++ b/internal/plugin/dialer/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"reflect"
 	"slices"
 	"testing"
@@ -312,4 +313,57 @@ func fakeDNSServer(t *testing.T) string {
 		}
 	}()
 	return pc.LocalAddr().String()
+}
+
+// The regression test for the desktop half of the STUN-lookup escape: the name
+// resolved here exists in no real zone, and only the nameserver this test puts
+// in the Escape can answer it -- reachable solely through the escaped resolver's
+// Dial hook. A regression to net.ResolveUDPAddr/net.DefaultResolver fails here.
+func TestResolveAddrPortUsesEscapedResolver(t *testing.T) {
+	server := fakeDNSServer(t)
+
+	ctx, cancel := context.WithTimeout(
+		WithEscape(context.Background(), Escape{DNSServers: []string{server}}),
+		5*time.Second)
+	defer cancel()
+
+	got, err := ResolveAddrPort(ctx, "udp4", "stun.escape-test.invalid:19302")
+	if err != nil {
+		t.Fatalf("ResolveAddrPort: %v", err)
+	}
+	if want := netip.MustParseAddrPort("127.0.0.99:19302"); got != want {
+		t.Errorf("ResolveAddrPort = %v, want the fake server's answer %v", got, want)
+	}
+	// LookupNetIP reports IPv4 in 4-in-6 form; unmapped, or the address
+	// formats as "[::ffff:127.0.0.99]:19302" and picks the wrong socket.
+	if !got.Addr().Is4() {
+		t.Errorf("ResolveAddrPort = %q, want an unmapped IPv4 address", got)
+	}
+}
+
+// An IP literal is answered inside net.Resolver, so a config listing addresses
+// needs no working DNS at all -- including for a bracketed IPv6 literal.
+func TestResolveAddrPortIPLiterals(t *testing.T) {
+	for _, tt := range []struct{ network, in, want string }{
+		{"udp4", "192.0.2.1:3478", "192.0.2.1:3478"},
+		{"udp6", "[2001:db8::1]:3478", "[2001:db8::1]:3478"},
+	} {
+		got, err := ResolveAddrPort(context.Background(), tt.network, tt.in)
+		if err != nil {
+			t.Fatalf("ResolveAddrPort(%s, %s): %v", tt.network, tt.in, err)
+		}
+		if want := netip.MustParseAddrPort(tt.want); got != want {
+			t.Errorf("ResolveAddrPort(%s, %s) = %v, want %v", tt.network, tt.in, got, want)
+		}
+	}
+}
+
+// A malformed server string is a config error, and must be reported as one
+// rather than reaching the resolver.
+func TestResolveAddrPortRejectsMalformed(t *testing.T) {
+	for _, in := range []string{"192.0.2.1", "192.0.2.1:stun", "192.0.2.1:70000"} {
+		if _, err := ResolveAddrPort(context.Background(), "udp4", in); err == nil {
+			t.Errorf("ResolveAddrPort(%q) succeeded, want an error", in)
+		}
+	}
 }

--- a/internal/stun/helper_socket.go
+++ b/internal/stun/helper_socket.go
@@ -9,6 +9,7 @@ import (
 
 	stun "github.com/pion/stun/v3"
 	"github.com/rs/zerolog"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 )
 
 // getUDPAddressFamily, Connect and createStunBindingPacket were identical
@@ -30,12 +31,19 @@ func (s *Stun) Connect(ctx context.Context, stunAddr string) (string, int, error
 
 	logger.Info().Msgf("connecting to STUN server: %s", stunAddr)
 
-	addr, err := net.ResolveUDPAddr(s.getUDPAddressFamily(), stunAddr)
+	// Resolved through the dialer's escaped resolver, not net.ResolveUDPAddr:
+	// the probe itself already escapes a covering tunnel (raw socket carrying
+	// the device's fwmark, or pcap), but a stdlib lookup opens an unmarked UDP
+	// socket that a covering allowed-IPs route sends into the very tunnel
+	// discovery is trying to establish. ctx carries the escape; see
+	// ctrl.PublishController.discoverEndpoints.
+	dst, err := dialer.ResolveAddrPort(ctx, s.getUDPAddressFamily(), stunAddr)
 	if err != nil {
 		return "", 0, err
 	}
+	addr := net.UDPAddrFromAddrPort(dst)
 
-	packet, err := createStunBindingPacket(s.port, uint16(addr.Port))
+	packet, err := createStunBindingPacket(s.port, dst.Port())
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/stun/proxy_client.go
+++ b/internal/stun/proxy_client.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"sync"
 
 	stun "github.com/pion/stun/v3"
 	"github.com/rs/zerolog"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 )
 
 // ErrTxnIDMismatch means the response echoed a different transaction ID.
@@ -77,12 +77,14 @@ func (c *ProxyBacked) Connect(ctx context.Context, stunAddr string) (string, int
 	if c.protocol == "ipv6" {
 		network = "udp6"
 	}
-	addr, err := net.ResolveUDPAddr(network, stunAddr)
+	// Escaped resolver rather than net.ResolveUDPAddr, for the same reason as
+	// the socket-owning client: the exchange rides the proxy's escaped outer
+	// socket, but a stdlib lookup would not, and a covering allowed-IPs route
+	// would send it into the tunnel discovery is establishing.
+	server, err := dialer.ResolveAddrPort(ctx, network, stunAddr)
 	if err != nil {
 		return "", 0, err
 	}
-	server := addr.AddrPort()
-	server = netip.AddrPortFrom(server.Addr().Unmap(), server.Port())
 
 	req, err := stun.Build(stun.TransactionID, stun.BindingRequest)
 	if err != nil {

--- a/internal/stun/proxy_client_test.go
+++ b/internal/stun/proxy_client_test.go
@@ -11,7 +11,9 @@ import (
 
 	stunmsg "github.com/pion/stun/v3"
 	"github.com/rs/zerolog"
+	"github.com/tjjh89017/stunmesh-go/internal/plugin/dialer"
 	"github.com/tjjh89017/stunmesh-go/internal/wgproxy"
+	"golang.org/x/net/dns/dnsmessage"
 )
 
 // Compile-time guard: *wgproxy.Proxy satisfies StunTransport structurally.
@@ -256,4 +258,76 @@ func TestProxyLookupFactory_NoWarnWithoutIgnoredArgs(t *testing.T) {
 	if strings.Contains(buf.String(), "ignored") {
 		t.Fatalf("unexpected ignored-args warning: %s", buf.String())
 	}
+}
+
+// The proxy carries the exchange out through its escaped outer socket, but the
+// server name's lookup is a socket of its own. This pins that it goes through
+// the dialer's escaped resolver: the name exists in no real zone and only the
+// nameserver in the Escape answers it, so a regression to net.ResolveUDPAddr
+// fails here instead of silently resolving over the default route.
+func TestProxyBackedConnect_ResolvesThroughEscapedPath(t *testing.T) {
+	ft := &fakeTransport{
+		respond: func(txnID [12]byte, _ []byte) ([]byte, error) {
+			return bindingSuccess(t, txnID, net.ParseIP("203.0.113.9"), 41414), nil
+		},
+	}
+	logger := zerolog.Nop()
+	client := NewProxyBacked(ft, "ipv4", &logger)
+
+	ctx := dialer.WithEscape(context.Background(), dialer.Escape{
+		DNSServers: []string{fakeDNSServer(t)},
+	})
+	if _, _, err := client.Connect(ctx, "stun.escape-test.invalid:3478"); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	want := netip.MustParseAddrPort("127.0.0.99:3478")
+	if ft.lastAddr != want {
+		t.Fatalf("server addr = %v, want the fake nameserver's answer %v", ft.lastAddr, want)
+	}
+}
+
+// fakeDNSServer answers every A question with 127.0.0.99 and everything else
+// with an empty success, and returns its "host:port".
+func fakeDNSServer(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			var query dnsmessage.Message
+			if err := query.Unpack(buf[:n]); err != nil {
+				continue
+			}
+			resp := dnsmessage.Message{
+				Header:    dnsmessage.Header{ID: query.ID, Response: true, Authoritative: true},
+				Questions: query.Questions,
+			}
+			if len(query.Questions) == 1 && query.Questions[0].Type == dnsmessage.TypeA {
+				resp.Answers = []dnsmessage.Resource{{
+					Header: dnsmessage.ResourceHeader{
+						Name:  query.Questions[0].Name,
+						Type:  dnsmessage.TypeA,
+						Class: dnsmessage.ClassINET,
+						TTL:   60,
+					},
+					Body: &dnsmessage.AResource{A: [4]byte{127, 0, 0, 99}},
+				}}
+			}
+			packed, err := resp.Pack()
+			if err != nil {
+				continue
+			}
+			_, _ = pc.WriteTo(packed, addr)
+		}
+	}()
+	return pc.LocalAddr().String()
 }

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -6,9 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/netip"
-	"strconv"
 	"time"
 
 	"github.com/tjjh89017/stunmesh-go/internal/crypto"
@@ -230,36 +228,9 @@ func (c *controller) probeServer(ctx context.Context, network, server string) (n
 // dualstack node with no IPv6 endpoint on its first cycle: IPv4 discovery ran
 // while the tunnel was still down and answered, IPv6 discovery ran after and
 // could not resolve.
-//
-// An IP literal short-circuits inside net.Resolver, so a config that lists
-// addresses instead of names needs no working DNS at all.
 func (c *controller) resolveSTUN(ctx context.Context, network, server string) (netip.AddrPort, error) {
-	host, portStr, err := net.SplitHostPort(server)
-	if err != nil {
-		return netip.AddrPort{}, fmt.Errorf("stun server %q: %w", server, err)
-	}
-	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		return netip.AddrPort{}, fmt.Errorf("stun server %q: port: %w", server, err)
-	}
-
 	escaped := protectedContext(ctx, c.node.protector, c.node.pluginDNSServers())
-	ips, err := dialer.Resolver().LookupNetIP(escaped, ipNetwork(network), host)
-	if err != nil {
-		return netip.AddrPort{}, fmt.Errorf("resolve %s: %w", server, err)
-	}
-	// LookupNetIP reports IPv4 results in 4-in-6 form; unmapping keeps the
-	// endpoint string and the bind's socket choice in the right family.
-	return netip.AddrPortFrom(ips[0].Unmap(), uint16(port)), nil
-}
-
-// ipNetwork maps the UDP network discovery works in to the resolver's, so a
-// lookup only returns addresses of the family being discovered.
-func ipNetwork(network string) string {
-	if network == "udp6" {
-		return "ip6"
-	}
-	return "ip4"
+	return dialer.ResolveAddrPort(escaped, network, server)
 }
 
 func (c *controller) publish(ctx context.Context, data ctrl.EndpointData) {


### PR DESCRIPTION
Closes #267.

## What was unescaped

`internal/stun/helper_socket.go` and `internal/stun/proxy_client.go` both resolved the configured STUN server with `net.ResolveUDPAddr`, i.e. the system resolver on an unmarked, unbound UDP socket. Everything else in the discovery path escapes a covering tunnel: the probe itself leaves through the raw socket carrying the device's fwmark (Linux), pcap (darwin/bsd) or the proxy's outer socket (Windows), and plugin traffic goes through `internal/plugin/dialer`. The server's name lookup was the one socket left.

## Change

- `dialer.ResolveAddrPort(ctx, network, "host:port")` — the escaped-resolver lookup, lifted out of mobile's `resolveSTUN` (which now delegates to it) so both platforms share one path, including the 4-in-6 `Unmap()` trap.
- `ctrl.PublishController.discoverEndpoints` puts the device's `Escape` in the discovery context, exactly as it already did for `store.Set`.
- Both STUN clients resolve through it.

`Escape.DNSServers` is empty on desktop, so the resolv.conf-derived nameservers are untouched — only *how* the query socket leaves the host changes.

## On reproduction

The issue asked for a repro before patching, and I do not have one: the netns setup it describes (covering full-tunnel route, nameserver reachable only outside, tunnel not yet up) is what `test/e2e/realnet`'s Linux full-tunnel scenario already builds, and as the issue notes a DNS failure there lands in advisory output rather than a red check. So this is not "confirmed to bite on desktop" — it is the exposure closed by construction, at the cost of one context value and one call. If you would rather see it reproduced first, this can wait.

## Tests

- `dialer`: `ResolveAddrPort` resolves a name that only the `Escape.DNSServers` fake nameserver can answer (a regression to `net.Resolve*` fails there), plus IP-literal short-circuit and malformed-input cases.
- `stun`: proxy-backed `Connect` resolves a hostname through the escaped path, asserted on the address handed to the transport.
- `ctrl`: `Execute` carries the device's escape into the resolver's context.

`go test ./...`, `make lint` (linux/darwin/freebsd/windows + mobile), and `GOOS=... go build` for all four platforms pass locally. One pre-existing local failure, `TestTransportDialsWithRequestContext`, fails on `main` too — my sandbox blocks loopback TCP.