### PR TITLE
feat: add big-endian mips builds and default MIPS to soft-float

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, freebsd, windows]
-        arch: [amd64, arm64, arm, mipsle]
+        arch: [amd64, arm64, arm, mipsle, mips]
         embedca: [0, 1]
         exclude:
           - os: darwin
@@ -100,17 +100,23 @@ jobs:
           - os: darwin
             arch: mipsle
           - os: darwin
+            arch: mips
+          - os: darwin
             embedca: 1
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
           - os: freebsd
+            arch: mips
+          - os: freebsd
             embedca: 1
           - os: windows
             arch: arm
           - os: windows
             arch: mipsle
+          - os: windows
+            arch: mips
           - os: windows
             embedca: 1
     steps:
@@ -149,16 +155,20 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, freebsd]
-        arch: [amd64, arm64, arm, mipsle]
+        arch: [amd64, arm64, arm, mipsle, mips]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
             arch: mipsle
+          - os: darwin
+            arch: mips
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
+          - os: freebsd
+            arch: mips
     steps:
       - uses: actions/checkout@v7
       - name: Build All Plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, freebsd, windows]
-        arch: [amd64, arm64, arm, mipsle]
+        arch: [amd64, arm64, arm, mipsle, mips]
         embedca: [0, 1]
         exclude:
           - os: darwin
@@ -53,17 +53,23 @@ jobs:
           - os: darwin
             arch: mipsle
           - os: darwin
+            arch: mips
+          - os: darwin
             embedca: 1
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
           - os: freebsd
+            arch: mips
+          - os: freebsd
             embedca: 1
           - os: windows
             arch: arm
           - os: windows
             arch: mipsle
+          - os: windows
+            arch: mips
           - os: windows
             embedca: 1
     steps:
@@ -113,16 +119,20 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, freebsd]
-        arch: [amd64, arm64, arm, mipsle]
+        arch: [amd64, arm64, arm, mipsle, mips]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
             arch: mipsle
+          - os: darwin
+            arch: mips
           - os: freebsd
             arch: arm
           - os: freebsd
             arch: mipsle
+          - os: freebsd
+            arch: mips
     steps:
       - uses: actions/checkout@v7
       - name: tag

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ APP ?= stunmesh-go
 GO_FLAGS ?=
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+# 32-bit MIPS routers commonly lack an FPU, so default both endians to
+# soft-float. Set GOMIPS=hardfloat to override.
+ifneq ($(filter mips mipsle,$(GOARCH)),)
+GOMIPS ?= softfloat
+endif
 STRIP ?= 1
 TRIMPATH ?= 1
 UPX ?= 0
@@ -99,7 +104,7 @@ all: clean build $(UPX_TARGET)
 
 .PHONY: build
 build:
-	CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GO_FLAGS} -v -o ${APP}
+	CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} GOMIPS=${GOMIPS} go build ${GO_FLAGS} -v -o ${APP}
 
 .PHONY: upx
 upx:

--- a/contrib/cloudflare/Makefile
+++ b/contrib/cloudflare/Makefile
@@ -2,13 +2,18 @@ PLUGIN ?= stunmesh-cloudflare
 CGO_ENABLED ?= 0
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
+# 32-bit MIPS routers commonly lack an FPU, so default both endians to
+# soft-float. Set GOMIPS=hardfloat to override.
+ifneq ($(filter mips mipsle,$(GOARCH)),)
+GOMIPS ?= softfloat
+endif
 
 .PHONY: all
 all: clean build
 
 .PHONY: build
 build:
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(PLUGIN)
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) GOMIPS=$(GOMIPS) go build -o $(PLUGIN)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## Summary
- Add `mips` (big-endian) to the build/release matrices for the main binary and contrib plugins, linux-only like `mipsle` (excluded on darwin/freebsd/windows, no embedca cell)
- Default `GOMIPS=softfloat` for both 32-bit MIPS endians in the root Makefile and `contrib/cloudflare/Makefile` — such routers commonly lack an FPU; `GOMIPS=hardfloat` still overrides
- The CI build actions need no changes: they already pass `GOARCH` into `make`, and the Makefiles now derive `GOMIPS` from it

## Test plan
- [x] `make build GOOS=linux GOARCH=mips` / `GOARCH=mipsle` — binaries build, `go version -m` shows `GOMIPS=softfloat` in both
- [x] `contrib/cloudflare`: `GOOS=linux GOARCH=mips make build` — plugin builds with `GOMIPS=softfloat`
- [ ] CI matrix (build + build-plugins + release dry-run via this PR's checks)