### PR TITLE
fix: let shutdown cancel the store write in ExecuteForPeer

### DIFF
--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -100,9 +100,9 @@ func (c *PublishController) discoverEndpoints(ctx context.Context, device *entit
 // publishToPeer builds the endpoint JSON, applies dedup, encrypts and
 // stores it for a single peer, and records it in lastPublished on success.
 // storeCtx is the context used for the store.Set call (after applying the
-// dialer escape); callers pass different bases (Execute keeps the
-// peer-scoped logger attached, ExecuteForPeer detaches from cancellation)
-// while ctx is used unchanged for encryption.
+// dialer escape); ctx is used unchanged for encryption. Both Execute and
+// ExecuteForPeer pass the same cancellable context, with the peer-scoped
+// logger attached to storeCtx.
 func (c *PublishController) publishToPeer(ctx, storeCtx context.Context, device *entity.Device, peer *entity.Peer, ipv4Endpoint, ipv6Endpoint string, logger zerolog.Logger) error {
 	// Build endpoint data in plain JSON
 	endpointData := EndpointData{
@@ -222,7 +222,7 @@ func (c *PublishController) ExecuteForPeer(ctx context.Context, peerId entity.Pe
 		Str("ipv6", ipv6Endpoint).
 		Msg("discovered endpoints for peer")
 
-	if err := c.publishToPeer(ctx, context.WithoutCancel(ctx), device, peer, ipv4Endpoint, ipv6Endpoint, logger); err != nil {
+	if err := c.publishToPeer(ctx, logger.WithContext(ctx), device, peer, ipv4Endpoint, ipv6Endpoint, logger); err != nil {
 		return
 	}
 

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -769,6 +769,81 @@ func TestPublishController_ExecuteForPeer_Success(t *testing.T) {
 	controller.ExecuteForPeer(ctx, peerId)
 }
 
+// cancellationCapturingStore records whether the context it receives on
+// Set was already done, so tests can assert it carries the parent's
+// cancellation.
+type cancellationCapturingStore struct {
+	doneAtCall bool
+	called     bool
+}
+
+func (s *cancellationCapturingStore) Get(ctx context.Context, key string) (string, error) {
+	return "", nil
+}
+
+func (s *cancellationCapturingStore) Set(ctx context.Context, key string, value string) error {
+	s.called = true
+	s.doneAtCall = ctx.Err() != nil
+	return nil
+}
+
+// Test ExecuteForPeer's store ctx is cancelled when the triggering ctx is,
+// matching Execute's behavior.
+func TestPublishController_ExecuteForPeer_StoreCtxCancelledWithParent(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockResolver := mock.NewMockStunResolver(mockCtrl)
+	mockEncryptor := mock.NewMockEndpointEncryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	store := &cancellationCapturingStore{}
+	pluginProvider := mock.NewMockPluginProvider(mockCtrl)
+	pluginProvider.EXPECT().IsDedup("test_plugin").Return(false).AnyTimes()
+	pluginProvider.EXPECT().GetPlugin("test_plugin").Return(store, nil).AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	device := createTestDevice("wg0", 51820, "ipv4")
+	peer := createTestPeer("wg0", "test_plugin", "ipv4")
+	publicKey := peer.PublicKey()
+	peerId := entity.NewPeerId(make([]byte, 32), publicKey[:])
+
+	mockPeers.EXPECT().Find(gomock.Any(), peerId).Return(peer, nil)
+	mockDevices.EXPECT().Find(gomock.Any(), entity.DeviceId("wg0")).Return(device, nil)
+	mockResolver.EXPECT().
+		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
+		Return("1.2.3.4", 51820, nil)
+	mockEncryptor.EXPECT().
+		Encrypt(gomock.Any(), gomock.Any()).
+		Return(&ctrl.EndpointEncryptResponse{Data: "encrypted_data"}, nil)
+
+	controller := ctrl.NewPublishController(
+		mockDevices,
+		mockPeers,
+		pluginProvider,
+		mockResolver,
+		mockEncryptor,
+		nil,
+		&logger,
+	)
+
+	// Cancel the parent ctx before the call, to prove the store ctx carries
+	// the cancellation instead of being detached from it.
+	cancel()
+
+	controller.ExecuteForPeer(ctx, peerId)
+
+	if !store.called {
+		t.Fatal("store.Set was not called")
+	}
+	if !store.doneAtCall {
+		t.Error("store ctx was not done at call time, want it cancelled with the parent ctx")
+	}
+}
+
 // Test Execute with dedup ON and a changed endpoint - should publish every time
 func TestPublishController_Execute_Dedup_ChangedEndpoint_Publishes(t *testing.T) {
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary

`ExecuteForPeer` detached its `store.Set` from the daemon context with `context.WithoutCancel`, so a hung exec/shell plugin blocked shutdown indefinitely.

The context it receives is the daemon context, cancelled only at shutdown. No per-trigger cancellation exists, so the detach protected nothing. The periodic `Execute` path and the establish read already use the cancellable context.

- Use the cancellable context for the store write, matching `Execute`.
- Add a test that cancels the parent context before the call and asserts the store sees a cancelled context.

Fixes #283

## Test plan

- `go test ./internal/ctrl`
- `go vet ./internal/ctrl`
