### PR TITLE
fix: join ping monitor goroutines and reset device monitors on exit

### DIFF
--- a/internal/ctrl/ping_monitor.go
+++ b/internal/ctrl/ping_monitor.go
@@ -33,6 +33,16 @@ const (
 	PingMonitorStartupDelay = 10 * time.Second
 )
 
+// pingMonitorStartupDelay and newICMPConn are package-level vars (rather than
+// the const and platform func used directly) so tests in this package can
+// shorten the startup wait and inject a fake ICMPConnection.
+var (
+	pingMonitorStartupDelay = PingMonitorStartupDelay
+	newICMPConn             = func(deviceName string) (ICMPConnection, error) {
+		return NewICMPConn(deviceName)
+	}
+)
+
 type PeerPingState struct {
 	peerId       entity.PeerId
 	target       string
@@ -111,11 +121,11 @@ func NewDevicePingMonitor(deviceName string, controller *PingMonitorController, 
 func (c *PingMonitorController) Execute(ctx context.Context) {
 	// Wait for system initialization before starting ping monitoring, but
 	// return immediately on shutdown instead of blocking the full delay.
-	c.logger.Info().Dur("delay", PingMonitorStartupDelay).Msg("waiting before starting ping monitor")
+	c.logger.Info().Dur("delay", pingMonitorStartupDelay).Msg("waiting before starting ping monitor")
 	select {
 	case <-ctx.Done():
 		return
-	case <-time.After(PingMonitorStartupDelay):
+	case <-time.After(pingMonitorStartupDelay):
 	}
 
 	// Get all configured peers from all interfaces
@@ -152,7 +162,7 @@ func (c *PingMonitorController) Execute(ctx context.Context) {
 		monitor := NewDevicePingMonitor(deviceName, c, c.logger)
 
 		// Create device-bound ICMP connection using platform-specific implementation
-		conn, err := NewICMPConn(deviceName)
+		conn, err := newICMPConn(deviceName)
 		if err != nil {
 			c.logger.Error().
 				Err(err).
@@ -178,10 +188,11 @@ func (c *PingMonitorController) Execute(ctx context.Context) {
 	c.mu.Unlock()
 
 	// Start monitoring loops for each device
+	var wg sync.WaitGroup
 	for deviceName, monitor := range c.deviceMonitors {
-		go monitor.deviceSenderLoop(ctx, c.config.PingMonitor.Interval)
-		go monitor.deviceReaderLoop(ctx)
-		go monitor.deviceTimeoutChecker(ctx, c.config.PingMonitor.Timeout)
+		wg.Go(func() { monitor.deviceSenderLoop(ctx, c.config.PingMonitor.Interval) })
+		wg.Go(func() { monitor.deviceReaderLoop(ctx) })
+		wg.Go(func() { monitor.deviceTimeoutChecker(ctx, c.config.PingMonitor.Timeout) })
 
 		c.logger.Info().
 			Str("device", deviceName).
@@ -191,7 +202,8 @@ func (c *PingMonitorController) Execute(ctx context.Context) {
 	// Wait for context cancellation
 	<-ctx.Done()
 
-	// Close all device connections
+	// Close all device connections first so a deviceReaderLoop blocked in
+	// Recv returns instead of waiting out its read deadline.
 	c.mu.Lock()
 	for _, monitor := range c.deviceMonitors {
 		if monitor.conn != nil {
@@ -200,6 +212,16 @@ func (c *PingMonitorController) Execute(ctx context.Context) {
 			}
 		}
 	}
+	c.mu.Unlock()
+
+	// Wait for every loop to exit before returning, so callers (daemon.Run,
+	// App.Close) never observe Execute as done while a loop is still running.
+	wg.Wait()
+
+	// Clear so a later Execute call never starts fresh goroutines against a
+	// stale entry that still holds a closed connection.
+	c.mu.Lock()
+	clear(c.deviceMonitors)
 	c.mu.Unlock()
 }
 

--- a/internal/ctrl/ping_monitor_internal_test.go
+++ b/internal/ctrl/ping_monitor_internal_test.go
@@ -1,7 +1,11 @@
 package ctrl
 
 import (
+	"context"
+	"errors"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -371,5 +375,230 @@ func TestHandlePingResult_HandedOverToRefreshDoesNotRetry(t *testing.T) {
 	}
 	if state.retryCount != 10 {
 		t.Errorf("expected retryCount unchanged at 10, got %d", state.retryCount)
+	}
+}
+
+// fakePeerRepository is a minimal PeerRepository for Execute tests, avoiding
+// an internal_test -> mock -> ctrl import cycle.
+type fakePeerRepository struct {
+	peers   []*entity.Peer
+	listErr error
+}
+
+func (f *fakePeerRepository) List(context.Context) ([]*entity.Peer, error) {
+	return f.peers, f.listErr
+}
+
+func (f *fakePeerRepository) ListByDevice(context.Context, entity.DeviceId) ([]*entity.Peer, error) {
+	return f.peers, f.listErr
+}
+
+func (f *fakePeerRepository) Find(context.Context, entity.PeerId) (*entity.Peer, error) {
+	return nil, entity.ErrPeerNotFound
+}
+
+func (f *fakePeerRepository) Save(context.Context, *entity.Peer) {}
+
+// fakeICMPConn's Recv blocks until Close, like a real blocking socket read,
+// so tests can prove Execute waits for the reader loop to actually exit
+// instead of returning as soon as ctx is cancelled. postCloseDelay simulates
+// the time the reader loop takes to notice the read failed and return.
+type fakeICMPConn struct {
+	closeCh        chan struct{}
+	closeOnce      sync.Once
+	postCloseDelay time.Duration
+	recvCalls      atomic.Int32
+}
+
+func newFakeICMPConn(postCloseDelay time.Duration) *fakeICMPConn {
+	return &fakeICMPConn{closeCh: make(chan struct{}), postCloseDelay: postCloseDelay}
+}
+
+func (c *fakeICMPConn) Send([]byte, net.Addr) error { return nil }
+
+func (c *fakeICMPConn) Recv([]byte, time.Duration) (int, net.Addr, error) {
+	c.recvCalls.Add(1)
+	<-c.closeCh
+	if c.postCloseDelay > 0 {
+		time.Sleep(c.postCloseDelay)
+	}
+	return 0, nil, errors.New("use of closed connection")
+}
+
+func (c *fakeICMPConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closeCh) })
+	return nil
+}
+
+func (c *fakeICMPConn) SetReadDeadline(time.Time) error { return nil }
+
+// waitForRecvCall polls until conn's deviceReaderLoop has entered Recv, so
+// callers cancel ctx only once the reader goroutine is actually running
+// (setting up the monitor and starting the loops happens asynchronously
+// relative to the newICMPConn call that a test observes).
+func waitForRecvCall(t *testing.T, conn *fakeICMPConn) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if conn.recvCalls.Load() > 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for deviceReaderLoop to call Recv")
+}
+
+func testPingPeer(t *testing.T, target string) *entity.Peer {
+	t.Helper()
+	privateKey := [32]byte{10}
+	publicKey := [32]byte{11}
+	peerId := entity.NewPeerId(privateKey[:], publicKey[:])
+	return entity.NewPeer(peerId, entity.DeviceId("wg0"), entity.PeerPublicKey(publicKey), "plugin1", "ipv4", entity.PeerPingConfig{
+		Enabled:  true,
+		Target:   target,
+		Interval: 10 * time.Millisecond,
+		Timeout:  50 * time.Millisecond,
+	})
+}
+
+func TestExecute_WaitsForLoopsBeforeReturning(t *testing.T) {
+	origDelay := pingMonitorStartupDelay
+	pingMonitorStartupDelay = time.Millisecond
+	defer func() { pingMonitorStartupDelay = origDelay }()
+
+	const postCloseDelay = 150 * time.Millisecond
+	conn := newFakeICMPConn(postCloseDelay)
+	connReady := make(chan struct{})
+	origNewConn := newICMPConn
+	newICMPConn = func(string) (ICMPConnection, error) {
+		close(connReady)
+		return conn, nil
+	}
+	defer func() { newICMPConn = origNewConn }()
+
+	logger := zerolog.Nop()
+	cfg := &config.Config{
+		PingMonitor: config.PingMonitor{
+			Interval: 10 * time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		},
+		RefreshInterval: time.Hour,
+	}
+	peers := &fakePeerRepository{peers: []*entity.Peer{testPingPeer(t, "127.0.0.1")}}
+	pingCtrl := NewPingMonitorController(cfg, nil, peers, &fakePublisher{}, &fakeEstablisher{}, &logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pingCtrl.Execute(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-connReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the ICMP connection to be created")
+	}
+	waitForRecvCall(t, conn)
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Execute did not return after ctx cancellation")
+	}
+	elapsed := time.Since(start)
+
+	// If Execute returned without waiting for deviceReaderLoop, elapsed would
+	// be far below postCloseDelay since the loop is still sleeping in Recv.
+	if elapsed < postCloseDelay/2 {
+		t.Errorf("Execute returned after %v, want it to wait at least ~%v for the reader loop to exit", elapsed, postCloseDelay)
+	}
+	if calls := conn.recvCalls.Load(); calls != 1 {
+		t.Errorf("expected exactly one Recv call, got %d (possible hot loop on closed conn)", calls)
+	}
+
+	pingCtrl.mu.RLock()
+	remaining := len(pingCtrl.deviceMonitors)
+	pingCtrl.mu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("expected deviceMonitors to be cleared after Execute returns, got %d entries", remaining)
+	}
+}
+
+func TestExecute_SecondRunCreatesFreshConnAndNoStaleLoop(t *testing.T) {
+	origDelay := pingMonitorStartupDelay
+	pingMonitorStartupDelay = time.Millisecond
+	defer func() { pingMonitorStartupDelay = origDelay }()
+
+	connCh := make(chan *fakeICMPConn, 2)
+	var connsCreated atomic.Int32
+	origNewConn := newICMPConn
+	newICMPConn = func(string) (ICMPConnection, error) {
+		connsCreated.Add(1)
+		c := newFakeICMPConn(0)
+		connCh <- c
+		return c, nil
+	}
+	defer func() { newICMPConn = origNewConn }()
+
+	logger := zerolog.Nop()
+	cfg := &config.Config{
+		PingMonitor: config.PingMonitor{
+			Interval: 10 * time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		},
+		RefreshInterval: time.Hour,
+	}
+	peers := &fakePeerRepository{peers: []*entity.Peer{testPingPeer(t, "127.0.0.1")}}
+	pingCtrl := NewPingMonitorController(cfg, nil, peers, &fakePublisher{}, &fakeEstablisher{}, &logger)
+
+	runOnce := func() *fakeICMPConn {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			pingCtrl.Execute(ctx)
+			close(done)
+		}()
+
+		var conn *fakeICMPConn
+		select {
+		case conn = <-connCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the ICMP connection to be created")
+		}
+		waitForRecvCall(t, conn)
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Execute did not return after ctx cancellation")
+		}
+		return conn
+	}
+
+	conn1 := runOnce()
+	conn2 := runOnce()
+
+	if conn1 == conn2 {
+		t.Error("expected the second Execute call to create a fresh ICMP connection")
+	}
+	if got := connsCreated.Load(); got != 2 {
+		t.Errorf("expected newICMPConn to be called twice, got %d", got)
+	}
+	// conn1's reader loop must have exited with the first Execute call, not
+	// been left running to call Recv again against the now-closed conn.
+	if calls := conn1.recvCalls.Load(); calls != 1 {
+		t.Errorf("stale conn1 was read from again after the first Execute returned: %d Recv calls", calls)
+	}
+
+	pingCtrl.mu.RLock()
+	remaining := len(pingCtrl.deviceMonitors)
+	pingCtrl.mu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("expected deviceMonitors to be cleared after Execute returns, got %d entries", remaining)
 	}
 }


### PR DESCRIPTION
## Summary

`PingMonitorController.Execute` started three goroutines per device and returned on ctx cancellation without waiting for them. `daemon.Run` and `App.Close` could therefore complete while the loops were still running and still calling `TriggerForPeer`. `deviceMonitors` was never cleared, so a second `Execute` on the same controller reused entries holding closed ICMP conns and the reader loop spun on the closed fd under the new, not-yet-cancelled ctx.

- Track the per-device loops in a `sync.WaitGroup`.
- On ctx cancellation: close the conns, wait for the loops, clear `deviceMonitors`.
- The reader loop is unchanged: it already exits once ctx is done. The spin only happened because a stale entry was reused under a fresh ctx, which clearing the map removes.
- Tests: `Execute` returns only after all loops exit; a second `Execute` creates a fresh conn and no stale loop touches the closed one. Two package-level seams (`newICMPConn`, `pingMonitorStartupDelay`) were added for the tests.

Fixes #281

## Test plan

- `go test -race ./internal/ctrl ./internal/daemon`
- `go vet ./internal/ctrl`
