### PR TITLE
feat: close plugin instances on shutdown via optional io.Closer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,7 @@ Common parameters to remember:
 3. Add a blank import to `internal/plugin/imports.go`
    - That file carries no build tag, and must not: a blank import names no symbol, so importing a built-in that is tagged out (leaving only its stub) is fine. The tag belongs on the implementation, once
 4. Update the built-in plugin list and configuration example in the docs site ([tjjh89017/stunmesh-docs](https://github.com/tjjh89017/stunmesh-docs), published at docs.stunmesh.dev), and the `BUILTIN` examples in README.md if affected
+5. If the plugin holds connections or goroutines, implement `Close() error`; `Manager.Close` calls it on shutdown.
 
 Verify every tag combination, since a built-in must compile alone, under
 `builtin_all`, and alongside the others:

--- a/app/wire.go
+++ b/app/wire.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/google/wire"
+	"github.com/rs/zerolog"
 	"github.com/tjjh89017/stunmesh-go/internal/config"
 	"github.com/tjjh89017/stunmesh-go/internal/crypto"
 	"github.com/tjjh89017/stunmesh-go/internal/ctrl"
@@ -48,13 +49,19 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 	return nil, nil, nil
 }
 
-func providePluginManager(config *config.Config) (*plugin.Manager, error) {
+func providePluginManager(config *config.Config, logger *zerolog.Logger) (*plugin.Manager, func(), error) {
 	manager := plugin.NewManager()
 	ctx := context.Background()
 
 	if err := manager.LoadPlugins(ctx, config.Plugins); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return manager, nil
+	cleanup := func() {
+		if err := manager.Close(); err != nil {
+			logger.Warn().Err(err).Msg("failed to close plugin manager")
+		}
+	}
+
+	return manager, cleanup, nil
 }

--- a/app/wire_gen.go
+++ b/app/wire_gen.go
@@ -8,6 +8,7 @@ package app
 
 import (
 	"context"
+	"github.com/rs/zerolog"
 	"github.com/tjjh89017/stunmesh-go/internal/config"
 	"github.com/tjjh89017/stunmesh-go/internal/crypto"
 	"github.com/tjjh89017/stunmesh-go/internal/ctrl"
@@ -32,7 +33,7 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 	peers := repo.NewPeers(client)
 	filterPeerService := entity.NewFilterPeerService(peers, deviceConfig)
 	bootstrapController := ctrl.NewBootstrapController(client, cfg, deviceConfig, devices, peers, zerologLogger, filterPeerService)
-	manager, err := providePluginManager(cfg)
+	manager, cleanup2, err := providePluginManager(cfg, zerologLogger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -44,19 +45,27 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 	pingMonitorController := ctrl.NewPingMonitorController(cfg, devices, peers, publishController, establishController, zerologLogger)
 	daemonDaemon := daemon.New(cfg, bootstrapController, publishController, establishController, pingMonitorController, zerologLogger)
 	return daemonDaemon, func() {
+		cleanup2()
 		cleanup()
 	}, nil
 }
 
 // wire.go:
 
-func providePluginManager(config2 *config.Config) (*plugin.Manager, error) {
+func providePluginManager(config2 *config.Config, logger2 *zerolog.Logger) (*plugin.Manager, func(), error) {
 	manager := plugin.NewManager()
 	ctx := context.Background()
 
 	if err := manager.LoadPlugins(ctx, config2.Plugins); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return manager, nil
+	cleanup := func() {
+		if err := manager.Close(); err != nil {
+			logger2.
+				Warn().Err(err).Msg("failed to close plugin manager")
+		}
+	}
+
+	return manager, cleanup, nil
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,11 @@ there's a stated reason not to.
   registration that depends on config read at runtime) — `init()`-time
   self-registration assumes registration has no inputs beyond the build
   tags baked into the binary.
+- **Lifecycle**: plugin instances live for the whole `App` lifetime — a
+  plugin owning connections or goroutines implements `io.Closer` to release
+  them. `plugin.Manager.Close` closes every instance that does so and runs
+  from `App.Close` (via the plugin manager provider's cleanup func) and from
+  the mobile controller's `stop`.
 
 ### One escape hatch for every outbound path
 

--- a/internal/plugin/builtin/cloudflare/cloudflare.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare.go
@@ -226,6 +226,13 @@ func (p *CloudflarePlugin) Get(ctx context.Context, key string) (string, error) 
 	return content, nil
 }
 
+// Close closes the plugin's idle HTTP connections. Safe to call more than
+// once.
+func (p *CloudflarePlugin) Close() error {
+	p.client.CloseIdleConnections()
+	return nil
+}
+
 // Set stores a value in Cloudflare DNS
 func (p *CloudflarePlugin) Set(ctx context.Context, key string, value string) error {
 	logger := zerolog.Ctx(ctx)

--- a/internal/plugin/builtin/cloudflare/cloudflare_test.go
+++ b/internal/plugin/builtin/cloudflare/cloudflare_test.go
@@ -3,6 +3,7 @@
 package cloudflare
 
 import (
+	"io"
 	"testing"
 
 	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
@@ -143,3 +144,26 @@ func TestCloudflarePlugin_StructFields(t *testing.T) {
 //       apiURL string     // configurable
 //       ...
 //   }
+
+func TestCloudflarePlugin_Close(t *testing.T) {
+	store, err := NewCloudflarePlugin(pluginapi.PluginConfig{
+		"zone":  "example.com",
+		"token": "test-token",
+	})
+	if err != nil {
+		t.Fatalf("NewCloudflarePlugin() unexpected error: %v", err)
+	}
+
+	closer, ok := store.(io.Closer)
+	if !ok {
+		t.Fatal("CloudflarePlugin does not implement io.Closer")
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Errorf("second Close() unexpected error: %v", err)
+	}
+}

--- a/internal/plugin/builtin/opendht/opendht.go
+++ b/internal/plugin/builtin/opendht/opendht.go
@@ -222,6 +222,13 @@ func (p *OpenDHTPlugin) doRequestTo(ctx context.Context, endpoint, method, key s
 	return data, nil
 }
 
+// Close closes the plugin's idle HTTP connections. Safe to call more than
+// once.
+func (p *OpenDHTPlugin) Close() error {
+	p.client.CloseIdleConnections()
+	return nil
+}
+
 // Get retrieves a value from OpenDHT
 func (p *OpenDHTPlugin) Get(ctx context.Context, key string) (string, error) {
 	logger := zerolog.Ctx(ctx)

--- a/internal/plugin/builtin/opendht/opendht_test.go
+++ b/internal/plugin/builtin/opendht/opendht_test.go
@@ -639,3 +639,25 @@ func TestAllEndpointsFailingReportsEach(t *testing.T) {
 		}
 	}
 }
+
+func TestOpenDHTPlugin_Close(t *testing.T) {
+	store, err := NewOpenDHTPlugin(pluginapi.PluginConfig{
+		configKeyEndpoint: "http://127.0.0.1:1",
+	})
+	if err != nil {
+		t.Fatalf("NewOpenDHTPlugin() unexpected error: %v", err)
+	}
+
+	closer, ok := store.(io.Closer)
+	if !ok {
+		t.Fatal("OpenDHTPlugin does not implement io.Closer")
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Errorf("second Close() unexpected error: %v", err)
+	}
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -2,7 +2,11 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"maps"
+	"slices"
 
 	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 )
@@ -37,6 +41,24 @@ func (m *Manager) GetPlugin(name string) (pluginapi.Store, error) {
 		return nil, fmt.Errorf("plugin %s not found", name)
 	}
 	return store, nil
+}
+
+// Close closes every plugin instance that implements io.Closer, in sorted
+// name order, and joins any errors. It is idempotent: after closing, the
+// plugin set is emptied, so a second call is a no-op returning nil.
+func (m *Manager) Close() error {
+	var errs []error
+	for _, name := range slices.Sorted(maps.Keys(m.plugins)) {
+		closer, ok := m.plugins[name].(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := closer.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("plugin %s: %w", name, err))
+		}
+	}
+	clear(m.plugins)
+	return errors.Join(errs...)
 }
 
 // IsDedup reports whether the named plugin instance has dedup enabled.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -2,10 +2,43 @@ package plugin
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	pluginapi "github.com/tjjh89017/stunmesh-go/pluginapi"
 )
+
+// fakeCloserStore is a Store that also implements io.Closer, recording
+// close calls and optionally failing once.
+type fakeCloserStore struct {
+	closeCalls int
+	closeErr   error
+}
+
+func (f *fakeCloserStore) Get(ctx context.Context, key string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCloserStore) Set(ctx context.Context, key string, value string) error {
+	return nil
+}
+
+func (f *fakeCloserStore) Close() error {
+	f.closeCalls++
+	return f.closeErr
+}
+
+// fakePlainStore is a Store without a Close method.
+type fakePlainStore struct{}
+
+func (f *fakePlainStore) Get(ctx context.Context, key string) (string, error) {
+	return "", nil
+}
+
+func (f *fakePlainStore) Set(ctx context.Context, key string, value string) error {
+	return nil
+}
 
 func TestNewManager(t *testing.T) {
 	m := NewManager()
@@ -221,5 +254,55 @@ func TestIsDedup_UnknownPluginReturnsFalse(t *testing.T) {
 
 	if got := m.IsDedup("nonexistent"); got != false {
 		t.Errorf("IsDedup() = %v, want false for unknown plugin name", got)
+	}
+}
+
+func TestClose_ClosesOnlyClosers(t *testing.T) {
+	m := NewManager()
+	closer := &fakeCloserStore{}
+	plain := &fakePlainStore{}
+	m.plugins["closer"] = closer
+	m.plugins["plain"] = plain
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() unexpected error: %v", err)
+	}
+
+	if closer.closeCalls != 1 {
+		t.Errorf("closer.closeCalls = %d, want 1", closer.closeCalls)
+	}
+}
+
+func TestClose_JoinsAndPrefixesErrors(t *testing.T) {
+	m := NewManager()
+	m.plugins["a"] = &fakeCloserStore{closeErr: errors.New("boom a")}
+	m.plugins["b"] = &fakeCloserStore{closeErr: errors.New("boom b")}
+
+	err := m.Close()
+	if err == nil {
+		t.Fatal("Close() expected error, got nil")
+	}
+
+	for _, want := range []string{"plugin a: boom a", "plugin b: boom b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Close() error = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestClose_IdempotentSecondCallIsNoOp(t *testing.T) {
+	m := NewManager()
+	closer := &fakeCloserStore{}
+	m.plugins["closer"] = closer
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("first Close() unexpected error: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("second Close() unexpected error: %v", err)
+	}
+
+	if closer.closeCalls != 1 {
+		t.Errorf("closer.closeCalls after two Close() calls = %d, want 1", closer.closeCalls)
 	}
 }

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -111,6 +111,9 @@ func (c *controller) start() {
 func (c *controller) stop() {
 	c.cancel()
 	<-c.done
+	if err := c.manager.Close(); err != nil {
+		c.node.listener.OnLog("warn", "plugin manager close: "+err.Error())
+	}
 }
 
 func (c *controller) run(ctx context.Context) {


### PR DESCRIPTION
## Summary

Plugin instances live for the App lifetime, but nothing ever closed them. The HTTP built-ins left idle transports and their goroutines behind on every `New`/`Close` cycle, and a plugin holding a long-lived connection would have no shutdown hook.

- `Manager.Close` closes every instance implementing `io.Closer` and joins the errors. `pluginapi.Store` is unchanged, so existing plugins and external embedders are unaffected.
- `App.Close` reaches `Manager.Close` through the plugin manager provider cleanup; the mobile controller calls it from `stop`.
- cloudflare and opendht implement `Close` by closing idle connections.
- Docs: lifecycle note in `docs/architecture.md` and CLAUDE.md.

Fixes #282

## Test plan

- `go test ./internal/plugin/... ./app/...`
- `go test -tags builtin_all ./internal/plugin/...`
- build tag loop from CLAUDE.md
- mobile vet with `-tags "mobile builtin_all"`
