### PR TITLE
fix: give App a lifetime context and make Close wait for Run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,10 @@ dependencies are wired together — both the CLI (`main.go`) and any external
 embedder import it. `app.New(app.Options{ConfigFile, ConfigDir})` loads
 config and wires everything, returning an `*app.App` with `Run(ctx)`,
 `RunOneshot(ctx)`, and `Close()`. `Close` is idempotent and safe to call more
-than once. `app.Options` mirrors the CLI's `-c/--config`/`--config-dir`
+than once; it also cancels an in-flight `Run`/`RunOneshot` and waits for it
+to return before releasing resources, and `Run`/`RunOneshot` return
+`ErrAlreadyRunning`/`ErrClosed` when called concurrently or after `Close`.
+`app.Options` mirrors the CLI's `-c/--config`/`--config-dir`
 flags; exported `app` signatures never mention `internal/*` types.
 
 ### Dependency Injection with Google Wire

--- a/app/app.go
+++ b/app/app.go
@@ -2,15 +2,26 @@
 // and its dependencies (config, wg client, STUN, plugins, controllers) and
 // exposes a small embeddable API so an external Go program can run the
 // daemon in-process and stop/restart it via repeated New/Close cycles.
+//
+// Lifecycle: New wires everything, Run (or RunOneshot) drives the daemon one
+// call at a time, and Close cancels any in-flight Run, waits for it to
+// return, then releases resources. New/Close cycles may be repeated.
 package app
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/tjjh89017/stunmesh-go/internal/config"
-	"github.com/tjjh89017/stunmesh-go/internal/daemon"
 )
+
+// ErrAlreadyRunning is returned by Run or RunOneshot when a previous call is
+// still in flight on the same App.
+var ErrAlreadyRunning = errors.New("app: already running")
+
+// ErrClosed is returned by Run or RunOneshot after Close has been called.
+var ErrClosed = errors.New("app: closed")
 
 // Options configures a new App. Its fields mirror the stunmesh-go CLI's
 // -c/--config and --config-dir flags.
@@ -22,12 +33,31 @@ type Options struct {
 	ConfigDir string
 }
 
+// runner is the subset of *daemon.Daemon that App drives.
+type runner interface {
+	Run(ctx context.Context) error
+	RunOneshot(ctx context.Context) error
+}
+
 // App is a fully wired stunmesh-go daemon. Call Run or RunOneshot to drive
 // it, and Close to release its resources once done.
 type App struct {
-	daemon  *daemon.Daemon
+	daemon  runner
 	cleanup func()
-	once    sync.Once
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// mu guards running and closed so a Run/RunOneshot call and a
+	// concurrent Close agree on whether the call is admitted before it
+	// registers with runs; without that, Close could observe an empty
+	// runs and return before the just-admitted call finishes.
+	mu      sync.Mutex
+	running bool
+	closed  bool
+	runs    sync.WaitGroup
+
+	closeOnce sync.Once
 }
 
 // New loads configuration per opts and wires the daemon and its dependencies.
@@ -37,26 +67,75 @@ func New(opts Options) (*App, error) {
 		return nil, err
 	}
 
-	d, cleanup, err := setup(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	d, cleanup, err := setup(ctx, cfg)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
-	return &App{daemon: d, cleanup: cleanup}, nil
+	return &App{daemon: d, cleanup: cleanup, ctx: ctx, cancel: cancel}, nil
 }
 
-// Run runs the daemon until ctx is cancelled.
+// Run runs the daemon until ctx is cancelled, the App is closed, or the
+// daemon returns. It returns ErrAlreadyRunning if another Run or RunOneshot
+// call is already in flight, and ErrClosed if Close has already been called.
 func (a *App) Run(ctx context.Context) error {
-	return a.daemon.Run(ctx)
+	return a.run(ctx, a.daemon.Run)
 }
 
-// RunOneshot runs the daemon's publish/establish cycle three times, then returns.
+// RunOneshot runs the daemon's publish/establish cycle three times, then
+// returns. It returns ErrAlreadyRunning if another Run or RunOneshot call is
+// already in flight, and ErrClosed if Close has already been called.
 func (a *App) RunOneshot(ctx context.Context) error {
-	return a.daemon.RunOneshot(ctx)
+	return a.run(ctx, a.daemon.RunOneshot)
 }
 
-// Close releases resources acquired by New (the WireGuard client and the
-// wgproxy manager). It is idempotent and safe to call more than once.
+func (a *App) run(ctx context.Context, do func(context.Context) error) error {
+	a.mu.Lock()
+	switch {
+	case a.closed:
+		a.mu.Unlock()
+		return ErrClosed
+	case a.running:
+		a.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	a.running = true
+	a.runs.Add(1)
+	a.mu.Unlock()
+
+	defer func() {
+		a.mu.Lock()
+		a.running = false
+		a.mu.Unlock()
+		a.runs.Done()
+	}()
+
+	// runCtx is cancelled when either the caller's ctx or the App's own
+	// lifetime ctx is cancelled, while keeping ctx as the parent so its
+	// values (e.g. logger) still flow through.
+	runCtx, stop := context.WithCancel(ctx)
+	defer stop()
+	stopAfterFunc := context.AfterFunc(a.ctx, stop)
+	defer stopAfterFunc()
+
+	return do(runCtx)
+}
+
+// Close cancels any in-flight Run or RunOneshot, waits for it to return,
+// then releases resources acquired by New (the WireGuard client and the
+// wgproxy manager). It is idempotent and safe to call more than once; Run
+// and RunOneshot return ErrClosed if called afterward.
 func (a *App) Close() {
-	a.once.Do(a.cleanup)
+	a.closeOnce.Do(func() {
+		a.mu.Lock()
+		a.closed = true
+		a.mu.Unlock()
+
+		a.cancel()
+		a.runs.Wait()
+		a.cleanup()
+	})
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeRunner is a runner whose Run blocks until its ctx is cancelled, then
+// signals exit via the started/exited channels so tests can assert ordering.
+type fakeRunner struct {
+	started chan struct{}
+	exited  chan struct{}
+
+	oneshotCalls int
+	mu           sync.Mutex
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{
+		started: make(chan struct{}, 1),
+		exited:  make(chan struct{}, 1),
+	}
+}
+
+func (f *fakeRunner) Run(ctx context.Context) error {
+	f.started <- struct{}{}
+	<-ctx.Done()
+	f.exited <- struct{}{}
+	return ctx.Err()
+}
+
+func (f *fakeRunner) RunOneshot(ctx context.Context) error {
+	f.mu.Lock()
+	f.oneshotCalls++
+	f.mu.Unlock()
+	return nil
+}
+
+func newTestApp(r runner) *App {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &App{
+		daemon:  r,
+		cleanup: func() {},
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+func TestClose_WaitsForInFlightRun(t *testing.T) {
+	r := newFakeRunner()
+	a := newTestApp(r)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- a.Run(context.Background())
+	}()
+
+	select {
+	case <-r.started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		a.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-r.exited:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the in-flight Run")
+	}
+
+	select {
+	case err := <-runErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after being cancelled")
+	}
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after Run returned")
+	}
+}
+
+func TestRun_SecondConcurrentCallReturnsErrAlreadyRunning(t *testing.T) {
+	r := newFakeRunner()
+	a := newTestApp(r)
+	defer a.Close()
+
+	go func() {
+		_ = a.Run(context.Background())
+	}()
+
+	select {
+	case <-r.started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	if err := a.Run(context.Background()); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second Run = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestRun_AfterCloseReturnsErrClosed(t *testing.T) {
+	r := newFakeRunner()
+	a := newTestApp(r)
+	a.Close()
+
+	if err := a.Run(context.Background()); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Run after Close = %v, want ErrClosed", err)
+	}
+	if err := a.RunOneshot(context.Background()); !errors.Is(err, ErrClosed) {
+		t.Fatalf("RunOneshot after Close = %v, want ErrClosed", err)
+	}
+}
+
+func TestRun_CallerCtxCancellationStopsRun(t *testing.T) {
+	r := newFakeRunner()
+	a := newTestApp(r)
+	defer a.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- a.Run(ctx)
+	}()
+
+	select {
+	case <-r.started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-runErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after caller ctx was cancelled")
+	}
+}
+
+func TestClose_TwiceIsNoOp(t *testing.T) {
+	closes := 0
+	a := newTestApp(newFakeRunner())
+	a.cleanup = func() { closes++ }
+
+	a.Close()
+	a.Close()
+
+	if closes != 1 {
+		t.Fatalf("cleanup called %d times, want 1", closes)
+	}
+}
+
+func TestRunOneshot_SequentialCallsAllowed(t *testing.T) {
+	r := newFakeRunner()
+	a := newTestApp(r)
+	defer a.Close()
+
+	if err := a.RunOneshot(context.Background()); err != nil {
+		t.Fatalf("first RunOneshot: %v", err)
+	}
+	if err := a.RunOneshot(context.Background()); err != nil {
+		t.Fatalf("second RunOneshot: %v", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.oneshotCalls != 2 {
+		t.Fatalf("oneshotCalls = %d, want 2", r.oneshotCalls)
+	}
+}

--- a/app/wire.go
+++ b/app/wire.go
@@ -19,7 +19,7 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/wg"
 )
 
-func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
+func setup(ctx context.Context, cfg *config.Config) (*daemon.Daemon, func(), error) {
 	wire.Build(
 		newProxyStack,
 		wire.FieldsOf(new(*proxyStack), "Client", "Resolver"),
@@ -49,9 +49,8 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 	return nil, nil, nil
 }
 
-func providePluginManager(config *config.Config, logger *zerolog.Logger) (*plugin.Manager, func(), error) {
+func providePluginManager(ctx context.Context, config *config.Config, logger *zerolog.Logger) (*plugin.Manager, func(), error) {
 	manager := plugin.NewManager()
-	ctx := context.Background()
 
 	if err := manager.LoadPlugins(ctx, config.Plugins); err != nil {
 		return nil, nil, err

--- a/app/wire_gen.go
+++ b/app/wire_gen.go
@@ -21,7 +21,7 @@ import (
 
 // Injectors from wire.go:
 
-func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
+func setup(ctx context.Context, cfg *config.Config) (*daemon.Daemon, func(), error) {
 	deviceConfig := config.NewDeviceConfig(cfg)
 	zerologLogger := logger.NewLogger(cfg)
 	appProxyStack, cleanup, err := newProxyStack(cfg, deviceConfig, zerologLogger)
@@ -33,7 +33,7 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 	peers := repo.NewPeers(client)
 	filterPeerService := entity.NewFilterPeerService(peers, deviceConfig)
 	bootstrapController := ctrl.NewBootstrapController(client, cfg, deviceConfig, devices, peers, zerologLogger, filterPeerService)
-	manager, cleanup2, err := providePluginManager(cfg, zerologLogger)
+	manager, cleanup2, err := providePluginManager(ctx, cfg, zerologLogger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -52,9 +52,8 @@ func setup(cfg *config.Config) (*daemon.Daemon, func(), error) {
 
 // wire.go:
 
-func providePluginManager(config2 *config.Config, logger2 *zerolog.Logger) (*plugin.Manager, func(), error) {
+func providePluginManager(ctx context.Context, config2 *config.Config, logger2 *zerolog.Logger) (*plugin.Manager, func(), error) {
 	manager := plugin.NewManager()
-	ctx := context.Background()
 
 	if err := manager.LoadPlugins(ctx, config2.Plugins); err != nil {
 		return nil, nil, err

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,13 @@ there's a stated reason not to.
   plugin owning connections or goroutines implements `io.Closer` to release
   them. `plugin.Manager.Close` closes every instance that does so and runs
   from `App.Close` (via the plugin manager provider's cleanup func) and from
-  the mobile controller's `stop`.
+  the mobile controller's `stop`. `App.New` creates the App's own lifetime
+  `context.Context` and passes it into the plugin manager provider (instead
+  of `context.Background()`), so plugin construction is tied to the App
+  rather than to whichever `Run` call happens to be active. `App.Close`
+  cancels that context and waits for any in-flight `Run`/`RunOneshot` to
+  return before releasing resources, so a plugin is never closed out from
+  under a live worker.
 
 ### One escape hatch for every outbound path
 


### PR DESCRIPTION
## Summary

`App` stored no context, so the plugin manager was built with `context.Background` and nothing tied plugin construction to the App. `Close` only guarded re-entry and did not wait for an in-flight `Run`, so an embedder calling `Close` while `Run` was active closed plugins, the WireGuard client and the proxy underneath live workers. `Run` had no guard against concurrent calls; the CLI only worked because `main.go` defers `Close` after `Run` returns.

- `New` creates the App context and passes it to the plugin manager provider.
- `Run`/`RunOneshot` derive their context from both the caller's and the App's, return `ErrAlreadyRunning` when a run is in flight, and `ErrClosed` after `Close`.
- `Close` cancels the App context, waits for the run to return, then releases resources. Still idempotent.
- Exported signatures unchanged.

Note: `PublishController` dedup state persists across sequential `Run` calls on one `App`; a fresh `App` resets it.

Fixes #285

## Test plan

- `go test -race ./app/... ./internal/daemon/...`
- `go vet ./...`
