### PR TITLE
fix: skip peer endpoint families the local host cannot reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ of its own.
      - `ipv6`: Use IPv6 endpoint only (returns error if empty)
      - `prefer_ipv4`: Prefer IPv4, fallback to IPv6 if unavailable
      - `prefer_ipv6`: Prefer IPv6, fallback to IPv4 if unavailable
+   - **Local address family awareness**: `prefer_ipv4`/`prefer_ipv6` also require the local host to have that family, based on the local host's last STUN result recorded via `DeviceRepository.UpdateStatus` in `PublishController`; unknown status keeps pure preference
    - **No port validation needed**: Since publish validates before storage, port should never be 0
    - Configures WireGuard peer with selected endpoint
 

--- a/internal/ctrl/endpoint_select.go
+++ b/internal/ctrl/endpoint_select.go
@@ -1,6 +1,10 @@
 package ctrl
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+)
 
 // SelectEndpoint applies the peer protocol preference to a decrypted
 // EndpointData record: "ipv4"/"ipv6" require that family and error when it
@@ -10,9 +14,24 @@ import "fmt"
 // actually pass "" here; mobile's config leaves the field optional, so its
 // controller can).
 //
+// local is the local host's own last STUN discovery result (see
+// entity.DeviceStatus), used only by "prefer_ipv4"/"prefer_ipv6" to skip a
+// family the local host has no address for. local == nil means the local
+// capability is unknown, in which case the result matches pure protocol
+// preference exactly as before this parameter existed.
+//
 // Shared by EstablishController.Execute and the mobile controller so the
 // two callers can never drift on this rule again.
-func SelectEndpoint(data EndpointData, protocol string) (string, error) {
+func SelectEndpoint(data EndpointData, protocol string, local *entity.DeviceStatus) (string, error) {
+	usable := func(candidate string, localHas func(entity.DeviceStatus) bool) bool {
+		if candidate == "" {
+			return false
+		}
+		return local == nil || localHas(*local)
+	}
+	hasIPv4 := func(s entity.DeviceStatus) bool { return s.IPv4 != "" }
+	hasIPv6 := func(s entity.DeviceStatus) bool { return s.IPv6 != "" }
+
 	switch protocol {
 	case "", "ipv4":
 		if data.IPv4 == "" {
@@ -25,21 +44,27 @@ func SelectEndpoint(data EndpointData, protocol string) (string, error) {
 		}
 		return data.IPv6, nil
 	case "prefer_ipv4":
-		if data.IPv4 != "" {
+		if data.IPv4 == "" && data.IPv6 == "" {
+			return "", fmt.Errorf("record has no endpoints")
+		}
+		if usable(data.IPv4, hasIPv4) {
 			return data.IPv4, nil
 		}
-		if data.IPv6 != "" {
+		if usable(data.IPv6, hasIPv6) {
 			return data.IPv6, nil
 		}
-		return "", fmt.Errorf("record has no endpoints")
+		return "", fmt.Errorf("no endpoint reachable from the local address families")
 	case "prefer_ipv6":
-		if data.IPv6 != "" {
+		if data.IPv4 == "" && data.IPv6 == "" {
+			return "", fmt.Errorf("record has no endpoints")
+		}
+		if usable(data.IPv6, hasIPv6) {
 			return data.IPv6, nil
 		}
-		if data.IPv4 != "" {
+		if usable(data.IPv4, hasIPv4) {
 			return data.IPv4, nil
 		}
-		return "", fmt.Errorf("record has no endpoints")
+		return "", fmt.Errorf("no endpoint reachable from the local address families")
 	default:
 		return "", fmt.Errorf("unknown peer protocol %q", protocol)
 	}

--- a/internal/ctrl/endpoint_select_test.go
+++ b/internal/ctrl/endpoint_select_test.go
@@ -1,0 +1,79 @@
+package ctrl_test
+
+import (
+	"testing"
+
+	"github.com/tjjh89017/stunmesh-go/internal/ctrl"
+	"github.com/tjjh89017/stunmesh-go/internal/entity"
+)
+
+func TestSelectEndpoint(t *testing.T) {
+	both := ctrl.EndpointData{IPv4: "1.2.3.4:51820", IPv6: "[2001:db8::1]:51820"}
+	ipv4Only := ctrl.EndpointData{IPv4: "1.2.3.4:51820"}
+	ipv6Only := ctrl.EndpointData{IPv6: "[2001:db8::1]:51820"}
+	empty := ctrl.EndpointData{}
+
+	localBoth := &entity.DeviceStatus{IPv4: "9.9.9.9:1", IPv6: "[fe80::1]:1"}
+	localIPv4Only := &entity.DeviceStatus{IPv4: "9.9.9.9:1"}
+	localIPv6Only := &entity.DeviceStatus{IPv6: "[fe80::1]:1"}
+	localNeither := &entity.DeviceStatus{}
+
+	tests := []struct {
+		name     string
+		data     ctrl.EndpointData
+		protocol string
+		local    *entity.DeviceStatus
+		want     string
+		wantErr  bool
+	}{
+		{"ipv4 selects ipv4 when both present", both, "ipv4", nil, "1.2.3.4:51820", false},
+		{"ipv4 errors when ipv4 absent", ipv6Only, "ipv4", nil, "", true},
+		{"empty protocol defaults to ipv4", both, "", nil, "1.2.3.4:51820", false},
+		{"ipv6 selects ipv6 when both present", both, "ipv6", nil, "[2001:db8::1]:51820", false},
+		{"ipv6 errors when ipv6 absent", ipv4Only, "ipv6", nil, "", true},
+
+		{"prefer_ipv4 selects ipv4 when both present, local nil", both, "prefer_ipv4", nil, "1.2.3.4:51820", false},
+		{"prefer_ipv4 falls back to ipv6, local nil", ipv6Only, "prefer_ipv4", nil, "[2001:db8::1]:51820", false},
+		{"prefer_ipv4 errors when both absent, local nil", empty, "prefer_ipv4", nil, "", true},
+
+		{"prefer_ipv6 selects ipv6 when both present, local nil", both, "prefer_ipv6", nil, "[2001:db8::1]:51820", false},
+		{"prefer_ipv6 falls back to ipv4, local nil", ipv4Only, "prefer_ipv6", nil, "1.2.3.4:51820", false},
+		{"prefer_ipv6 errors when both absent, local nil", empty, "prefer_ipv6", nil, "", true},
+
+		{"unknown protocol errors", both, "carrier-pigeon", nil, "", true},
+
+		// local-aware prefer_ipv6
+		{"prefer_ipv6, local has both, selects ipv6", both, "prefer_ipv6", localBoth, "[2001:db8::1]:51820", false},
+		{"prefer_ipv6, local lacks ipv6, falls back to ipv4", both, "prefer_ipv6", localIPv4Only, "1.2.3.4:51820", false},
+		{"prefer_ipv6, local lacks both, errors", both, "prefer_ipv6", localNeither, "", true},
+		{"prefer_ipv6, local has only ipv6, selects ipv6", both, "prefer_ipv6", localIPv6Only, "[2001:db8::1]:51820", false},
+
+		// local-aware prefer_ipv4 (mirror)
+		{"prefer_ipv4, local has both, selects ipv4", both, "prefer_ipv4", localBoth, "1.2.3.4:51820", false},
+		{"prefer_ipv4, local lacks ipv4, falls back to ipv6", both, "prefer_ipv4", localIPv6Only, "[2001:db8::1]:51820", false},
+		{"prefer_ipv4, local lacks both, errors", both, "prefer_ipv4", localNeither, "", true},
+		{"prefer_ipv4, local has only ipv4, selects ipv4", both, "prefer_ipv4", localIPv4Only, "1.2.3.4:51820", false},
+
+		// hard modes ignore local entirely
+		{"ipv4 ignores local lacking ipv4", both, "ipv4", localIPv6Only, "1.2.3.4:51820", false},
+		{"ipv6 ignores local lacking ipv6", both, "ipv6", localIPv4Only, "[2001:db8::1]:51820", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ctrl.SelectEndpoint(tt.data, tt.protocol, tt.local)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SelectEndpoint(%+v, %q, %+v) = %q, nil; want error", tt.data, tt.protocol, tt.local, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SelectEndpoint(%+v, %q, %+v) returned unexpected error: %v", tt.data, tt.protocol, tt.local, err)
+			}
+			if got != tt.want {
+				t.Errorf("SelectEndpoint(%+v, %q, %+v) = %q, want %q", tt.data, tt.protocol, tt.local, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ctrl/establish.go
+++ b/internal/ctrl/establish.go
@@ -92,14 +92,25 @@ func (c *EstablishController) Execute(ctx context.Context, peerId entity.PeerId)
 	// Log decrypted endpoint data for debugging
 	logger.Trace().Str("json", res.Content).Msg("decrypted endpoint data")
 
-	// Select endpoint based on peer protocol
+	// Select endpoint based on peer protocol, constrained by what the local
+	// host's own last STUN discovery showed it can reach.
+	status, statusKnown := c.devices.Status(ctx, device.Name())
+	var local *entity.DeviceStatus
+	if statusKnown {
+		local = &status
+	}
+
 	peerProtocol := peer.Protocol()
-	selectedEndpoint, err := SelectEndpoint(endpointData, peerProtocol)
+	selectedEndpoint, err := SelectEndpoint(endpointData, peerProtocol, local)
 	if err != nil {
 		logger.Error().Err(err).Str("protocol", peerProtocol).Msg("failed to select endpoint")
 		return
 	}
-	logger.Debug().Str("endpoint", selectedEndpoint).Str("protocol", peerProtocol).Msg("selected endpoint")
+	logger.Debug().
+		Str("endpoint", selectedEndpoint).
+		Str("protocol", peerProtocol).
+		Bool("local_status_known", statusKnown).
+		Msg("selected endpoint")
 
 	// Parse host:port
 	host, portStr, err := net.SplitHostPort(selectedEndpoint)

--- a/internal/ctrl/establish_test.go
+++ b/internal/ctrl/establish_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin"
 	"github.com/tjjh89017/stunmesh-go/internal/plugin/registry"
+	"github.com/tjjh89017/stunmesh-go/internal/wg"
 	"github.com/tjjh89017/stunmesh-go/pluginapi"
 	"go.uber.org/mock/gomock"
 )
@@ -365,6 +366,7 @@ func TestEstablishController_Execute_IPv4Selection(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -429,6 +431,7 @@ func TestEstablishController_Execute_IPv6Selection(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -493,6 +496,7 @@ func TestEstablishController_Execute_PreferIPv4_HasIPv4(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -557,6 +561,7 @@ func TestEstablishController_Execute_PreferIPv4_FallbackIPv6(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -621,6 +626,7 @@ func TestEstablishController_Execute_PreferIPv6_HasIPv6(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -685,6 +691,7 @@ func TestEstablishController_Execute_PreferIPv6_FallbackIPv4(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -749,6 +756,7 @@ func TestEstablishController_Execute_IPv4_NotAvailable(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -808,6 +816,7 @@ func TestEstablishController_Execute_WireGuardError(t *testing.T) {
 	// Setup expectations
 	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
 	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).Return(entity.DeviceStatus{}, false)
 	mockDecryptor.EXPECT().
 		Decrypt(ctx, gomock.Any()).
 		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
@@ -826,6 +835,78 @@ func TestEstablishController_Execute_WireGuardError(t *testing.T) {
 	)
 
 	// Should not panic
+	controller.Execute(ctx, peerId)
+}
+
+// Test Execute - prefer_ipv6 skips the record's IPv6 endpoint when the
+// local host's own last STUN discovery found no IPv6 address, falling
+// back to IPv4 instead of writing an endpoint the local host can't reach.
+func TestEstablishController_Execute_PreferIPv6_LocalHasNoIPv6_FallsBackIPv4(t *testing.T) {
+	registerTestPlugin()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockWgClient := mock.NewMockWireGuardClient(mockCtrl)
+	mockDevices := mock.NewMockDeviceRepository(mockCtrl)
+	mockPeers := mock.NewMockPeerRepository(mockCtrl)
+	mockDecryptor := mock.NewMockEndpointDecryptor(mockCtrl)
+	logger := zerolog.Nop()
+
+	ctx := context.Background()
+
+	device := createTestDevice("wg0", 51820, "dualstack")
+	peer := createTestPeer("wg0", "test_storage", "prefer_ipv6")
+	publicKey := peer.PublicKey()
+	devicePrivKey := device.PrivateKey()
+	peerId := entity.NewPeerId(devicePrivKey[:], publicKey[:])
+
+	// Setup plugin manager
+	pluginManager := plugin.NewManager()
+	_ = pluginManager.LoadPlugins(ctx, map[string]pluginapi.PluginDefinition{
+		"test_storage": {
+			Type:   "builtin",
+			Config: pluginapi.PluginConfig{"name": "test_storage"},
+		},
+	})
+
+	// Pre-populate store
+	_ = testStoreInstance.Set(ctx, peer.RemoteId(), "encrypted_data")
+
+	// Record has both endpoints, but the local host has no IPv6 of its own.
+	endpointData := ctrl.EndpointData{
+		IPv4: "1.2.3.4:51820",
+		IPv6: "[2001:db8::1]:51820",
+	}
+	jsonData, _ := json.Marshal(endpointData)
+
+	// Setup expectations
+	mockPeers.EXPECT().Find(ctx, gomock.Any()).Return(peer, nil)
+	mockDevices.EXPECT().Find(ctx, entity.DeviceId("wg0")).Return(device, nil)
+	mockDevices.EXPECT().Status(ctx, entity.DeviceId("wg0")).
+		Return(entity.DeviceStatus{IPv4: "9.9.9.9:51820"}, true)
+	mockDecryptor.EXPECT().
+		Decrypt(ctx, gomock.Any()).
+		Return(&ctrl.EndpointDecryptResponse{Content: string(jsonData)}, nil)
+	mockWgClient.EXPECT().
+		UpdatePeerEndpoint(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, update wg.PeerEndpointUpdate) error {
+			if update.Host != "1.2.3.4" || update.Port != 51820 {
+				t.Errorf("UpdatePeerEndpoint got host %q port %d, want the IPv4 endpoint 1.2.3.4:51820", update.Host, update.Port)
+			}
+			return nil
+		})
+
+	controller := ctrl.NewEstablishController(
+		mockWgClient,
+		mockDevices,
+		mockPeers,
+		pluginManager,
+		mockDecryptor,
+		nil, // deviceConfig
+		&logger,
+	)
+
 	controller.Execute(ctx, peerId)
 }
 

--- a/internal/ctrl/mock/mock_repository.go
+++ b/internal/ctrl/mock/mock_repository.go
@@ -83,6 +83,33 @@ func (mr *MockDeviceRepositoryMockRecorder) Save(ctx, device any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockDeviceRepository)(nil).Save), ctx, device)
 }
 
+// Status mocks base method.
+func (m *MockDeviceRepository) Status(ctx context.Context, name entity.DeviceId) (entity.DeviceStatus, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Status", ctx, name)
+	ret0, _ := ret[0].(entity.DeviceStatus)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// Status indicates an expected call of Status.
+func (mr *MockDeviceRepositoryMockRecorder) Status(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockDeviceRepository)(nil).Status), ctx, name)
+}
+
+// UpdateStatus mocks base method.
+func (m *MockDeviceRepository) UpdateStatus(ctx context.Context, name entity.DeviceId, s entity.DeviceStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateStatus", ctx, name, s)
+}
+
+// UpdateStatus indicates an expected call of UpdateStatus.
+func (mr *MockDeviceRepositoryMockRecorder) UpdateStatus(ctx, name, s any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockDeviceRepository)(nil).UpdateStatus), ctx, name, s)
+}
+
 // MockPeerRepository is a mock of PeerRepository interface.
 type MockPeerRepository struct {
 	ctrl     *gomock.Controller

--- a/internal/ctrl/publish.go
+++ b/internal/ctrl/publish.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/tjjh89017/stunmesh-go/internal/entity"
@@ -174,6 +175,12 @@ func (c *PublishController) Execute(ctx context.Context) {
 			Str("ipv4", ipv4Endpoint).
 			Str("ipv6", ipv6Endpoint).
 			Msg("discovered endpoints for device")
+
+		c.devices.UpdateStatus(ctx, device.Name(), entity.DeviceStatus{
+			IPv4:         ipv4Endpoint,
+			IPv6:         ipv6Endpoint,
+			DiscoveredAt: time.Now(),
+		})
 
 		peers, err := c.peers.ListByDevice(ctx, device.Name())
 		if err != nil {

--- a/internal/ctrl/publish_test.go
+++ b/internal/ctrl/publish_test.go
@@ -233,6 +233,7 @@ func TestPublishController_Execute_PeerListError(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockResolver.EXPECT().
 		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
 		Return("1.2.3.4", 51820, nil)
@@ -272,6 +273,7 @@ func TestPublishController_Execute_EncryptionError(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
 		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
@@ -315,6 +317,7 @@ func TestPublishController_Execute_SuccessfulEncryption(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
 		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv4", gomock.Any()).
@@ -376,6 +379,7 @@ func TestPublishController_Execute_IPv6(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 	mockResolver.EXPECT().
 		Resolve(gomock.Any(), "wg0", uint16(51820), "ipv6", gomock.Any()).
@@ -429,6 +433,7 @@ func TestPublishController_Execute_Dualstack(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 
 	// Expect both IPv4 and IPv6 resolution
@@ -537,6 +542,7 @@ func TestPublishController_Execute_Dualstack_PartialFail(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil)
 
 	// IPv4 resolves, IPv6 fails
@@ -610,6 +616,8 @@ func TestPublishController_Execute_MultipleDevices(t *testing.T) {
 
 	// Setup expectations
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device1, device2}, nil)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any())
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg1"), gomock.Any())
 
 	// Device 1 (wg0)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer1}, nil)
@@ -862,6 +870,7 @@ func TestPublishController_Execute_Dedup_ChangedEndpoint_Publishes(t *testing.T)
 	peer := createTestPeer("wg0", "test_plugin", "ipv4")
 
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any()).Times(2)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
 
 	// Two calls, two different resolved endpoints.
@@ -915,6 +924,7 @@ func TestPublishController_Execute_Dedup_UnchangedEndpoint_Skips(t *testing.T) {
 	peer := createTestPeer("wg0", "test_plugin", "ipv4")
 
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any()).Times(2)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
 
 	// Same endpoint resolved both times.
@@ -965,6 +975,7 @@ func TestPublishController_Execute_Dedup_OffByDefault_AlwaysPublishes(t *testing
 	peer := createTestPeer("wg0", "test_plugin", "ipv4")
 
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any()).Times(2)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
 
 	// Same endpoint resolved both times.
@@ -1129,6 +1140,7 @@ func TestPublishController_Execute_Dedup_FailedStore_DoesNotCacheAndRetries(t *t
 	peer := createTestPeer("wg0", "test_plugin", "ipv4")
 
 	mockDevices.EXPECT().List(ctx).Return([]*entity.Device{device}, nil).Times(2)
+	mockDevices.EXPECT().UpdateStatus(ctx, entity.DeviceId("wg0"), gomock.Any()).Times(2)
 	mockPeers.EXPECT().ListByDevice(ctx, entity.DeviceId("wg0")).Return([]*entity.Peer{peer}, nil).Times(2)
 
 	// Same endpoint resolved both times.

--- a/internal/ctrl/repository.go
+++ b/internal/ctrl/repository.go
@@ -12,6 +12,10 @@ type DeviceRepository interface {
 	List(ctx context.Context) ([]*entity.Device, error)
 	Find(ctx context.Context, name entity.DeviceId) (*entity.Device, error)
 	Save(ctx context.Context, device *entity.Device)
+	// UpdateStatus records the local host's latest STUN discovery result for a device.
+	UpdateStatus(ctx context.Context, name entity.DeviceId, s entity.DeviceStatus)
+	// Status returns the last recorded discovery result for a device, and whether one has been recorded yet.
+	Status(ctx context.Context, name entity.DeviceId) (entity.DeviceStatus, bool)
 }
 
 type PeerRepository interface {

--- a/internal/entity/device.go
+++ b/internal/entity/device.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"errors"
+	"time"
 )
 
 var (
@@ -68,4 +69,13 @@ func (d *Device) Protocol() string {
 
 func (d *Device) FirewallMark() int {
 	return d.firewallMark
+}
+
+// DeviceStatus records the local host's last STUN discovery result for a
+// device, so EstablishController can tell which endpoint address families
+// the local host itself can actually reach.
+type DeviceStatus struct {
+	IPv4         string
+	IPv6         string
+	DiscoveredAt time.Time
 }

--- a/internal/repo/devices.go
+++ b/internal/repo/devices.go
@@ -8,13 +8,15 @@ import (
 )
 
 type Devices struct {
-	mutex sync.RWMutex
-	items map[entity.DeviceId]*entity.Device
+	mutex  sync.RWMutex
+	items  map[entity.DeviceId]*entity.Device
+	status map[entity.DeviceId]entity.DeviceStatus
 }
 
 func NewDevices() *Devices {
 	return &Devices{
-		items: make(map[entity.DeviceId]*entity.Device),
+		items:  make(map[entity.DeviceId]*entity.Device),
+		status: make(map[entity.DeviceId]entity.DeviceStatus),
 	}
 }
 
@@ -47,4 +49,22 @@ func (r *Devices) Save(ctx context.Context, device *entity.Device) {
 	defer r.mutex.Unlock()
 
 	r.items[device.Name()] = device
+}
+
+// UpdateStatus records the local host's latest STUN discovery result for a device.
+func (r *Devices) UpdateStatus(ctx context.Context, name entity.DeviceId, s entity.DeviceStatus) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.status[name] = s
+}
+
+// Status returns the last recorded discovery result for a device, and
+// whether one has been recorded yet.
+func (r *Devices) Status(ctx context.Context, name entity.DeviceId) (entity.DeviceStatus, bool) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	s, ok := r.status[name]
+	return s, ok
 }

--- a/internal/repo/devices_test.go
+++ b/internal/repo/devices_test.go
@@ -96,6 +96,47 @@ func Test_DeviceList(t *testing.T) {
 	}
 }
 
+func Test_DeviceStatus_RoundTrip(t *testing.T) {
+	devices := repo.NewDevices()
+	name := entity.DeviceId("wg0")
+
+	status := entity.DeviceStatus{IPv4: "1.2.3.4:51820", IPv6: "[2001:db8::1]:51820"}
+	devices.UpdateStatus(context.TODO(), name, status)
+
+	got, ok := devices.Status(context.TODO(), name)
+	if !ok {
+		t.Fatal("Status() ok = false, want true after UpdateStatus")
+	}
+	if got != status {
+		t.Errorf("Status() = %+v, want %+v", got, status)
+	}
+}
+
+func Test_DeviceStatus_UnknownDevice(t *testing.T) {
+	devices := repo.NewDevices()
+
+	_, ok := devices.Status(context.TODO(), entity.DeviceId("wg0"))
+	if ok {
+		t.Error("Status() ok = true for a device that was never updated, want false")
+	}
+}
+
+func Test_DeviceStatus_OverwriteReplaces(t *testing.T) {
+	devices := repo.NewDevices()
+	name := entity.DeviceId("wg0")
+
+	devices.UpdateStatus(context.TODO(), name, entity.DeviceStatus{IPv4: "1.2.3.4:51820"})
+	devices.UpdateStatus(context.TODO(), name, entity.DeviceStatus{IPv6: "[2001:db8::1]:51820"})
+
+	got, ok := devices.Status(context.TODO(), name)
+	if !ok {
+		t.Fatal("Status() ok = false, want true")
+	}
+	if got.IPv4 != "" || got.IPv6 != "[2001:db8::1]:51820" {
+		t.Errorf("Status() = %+v, want overwrite to fully replace the prior status", got)
+	}
+}
+
 // Test_DeviceRepository_ConcurrentAccess spawns concurrent readers and
 // writers on a shared repo instance to exercise the sync.RWMutex under
 // `go test -race`. It intentionally mixes Save (write lock) with Find and

--- a/mobile/controller.go
+++ b/mobile/controller.go
@@ -150,12 +150,14 @@ func (c *controller) cycle(ctx context.Context) {
 	}
 
 	data, err := c.discover(ctx)
+	var local *entity.DeviceStatus
 	if err != nil {
 		listener.OnLog("warn", "endpoint discovery failed, skipping publish: "+err.Error())
 	} else {
 		c.publish(ctx, data)
+		local = &entity.DeviceStatus{IPv4: data.IPv4, IPv6: data.IPv6}
 	}
-	c.establish(ctx)
+	c.establish(ctx, local)
 }
 
 // discover resolves the reflexive addresses the interface protocol asks for,
@@ -279,7 +281,11 @@ func (c *controller) publish(ctx context.Context, data ctrl.EndpointData) {
 	}
 }
 
-func (c *controller) establish(ctx context.Context) {
+// establish decrypts and applies each peer's stored endpoint. local is the
+// local host's own last STUN discovery result (nil if unknown or the last
+// discovery cycle failed), passed through to ctrl.SelectEndpoint so a
+// family the local host cannot reach is not selected.
+func (c *controller) establish(ctx context.Context, local *entity.DeviceStatus) {
 	listener := c.node.listener
 	for _, peer := range c.cfg.Peers {
 		peerPub, err := keyToBytes(peer.PublicKey)
@@ -312,7 +318,7 @@ func (c *controller) establish(ctx context.Context) {
 			listener.OnLog("warn", "parse record for "+peer.Name+": "+err.Error())
 			continue
 		}
-		endpoint, err := ctrl.SelectEndpoint(data, peer.Protocol)
+		endpoint, err := ctrl.SelectEndpoint(data, peer.Protocol, local)
 		if err != nil {
 			listener.OnLog("warn", "select endpoint for "+peer.Name+": "+err.Error())
 			continue

--- a/mobile/controller_test.go
+++ b/mobile/controller_test.go
@@ -51,7 +51,7 @@ func TestSelectEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ctrl.SelectEndpoint(tt.data, tt.protocol)
+			got, err := ctrl.SelectEndpoint(tt.data, tt.protocol, nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("SelectEndpoint(%+v, %q) = %q, nil; want error", tt.data, tt.protocol, got)


### PR DESCRIPTION
## Problem

A host without IPv6 with a peer set to `prefer_ipv6` would write the
peer's IPv6 endpoint to storage on every publish cycle, because
`SelectEndpoint` only applied protocol preference and never checked
what the local host itself could reach. WireGuard's own roaming would
then move the active endpoint back to IPv4 once the IPv6 address
failed to answer, and the next refresh wrote IPv6 again — a repeating
flap.

## Mechanism

`PublishController` already runs STUN discovery per device every
cycle. It now also records that result as the local host's own
capability, per device, in `repo.Devices` (new `entity.DeviceStatus`,
`repo.Devices.UpdateStatus`/`Status`, under the same mutex as the
device map; added to `ctrl.DeviceRepository`). `EstablishController`
reads it before selecting an endpoint and passes it to
`SelectEndpoint`, which now treats a preferred family as unusable when
the local host has no address for it, falling back to the other
family. Hard `ipv4`/`ipv6` modes are unaffected. When no discovery
result has been recorded yet, behavior is unchanged (pure protocol
preference). The mobile controller carries its own discovery result
through the same call the same way.

## What changed

- `internal/entity/device.go`: new `DeviceStatus` type.
- `internal/repo/devices.go`: status map + `UpdateStatus`/`Status`.
- `internal/ctrl/repository.go`: `DeviceRepository` gains the two
  methods; mocks regenerated.
- `internal/ctrl/publish.go`: `Execute` records status after a
  successful discovery.
- `internal/ctrl/endpoint_select.go`: `SelectEndpoint` takes a `*entity.DeviceStatus`.
- `internal/ctrl/establish.go`: reads status before selecting.
- `mobile/controller.go`: passes its own discovery result through.
- `CLAUDE.md`: one bullet documenting the behavior.

## How tested

- `go build ./...`, `go test ./...`, `go vet ./...` all pass.
- New/updated tests: `internal/ctrl/endpoint_select_test.go` (full
  local-aware matrix), `internal/repo/devices_test.go` (status round
  trip, unknown device, overwrite), `internal/ctrl/establish_test.go`
  (new case asserting IPv4 fallback when local lacks IPv6),
  `internal/ctrl/publish_test.go` (`UpdateStatus` expectations).
- `make lint`/`make lint-mobile` could not be run in this environment:
  the sandboxed Go toolchain fails to typecheck the standard library
  here even on an unmodified checkout, unrelated to this change.